### PR TITLE
Added basic authorization via HTTP Header to bypass all ACL checking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ readonlyrest:
     # HTTP response body in case of forbidden request.
     # If this is null or omitted, the name of the first violated access control rule is returned (useful for debugging!)
     response_if_req_forbidden: Sorry, your request is forbidden
+	
+	# Plain text authorisation key that allows client to bypass all ACL checking, enabling full access to elasticsearch 
+	# It is only optional and dont have to be used
+	# If key will match with the one in request, all ACL checking is skipped and request is permited to execute
+	auth_key: some-sort-of-secret-long-access-key
 
     # Default policy is to forbid everything, let's define a whitelist
     access_control_rules:
@@ -132,6 +137,19 @@ readonlyrest:
 
 ```
 
+### Authorisation header 
+In some cases, client may require full access to elastic search from public networks. This can be tricky/difficult or even impossible to configure using IP and/or URI patterns.
+For such cases, it is possible to bypass all ACL checking by providing special HTTP Header along with the request to Elastic Search. The header name is ```Auth``` and should be in following form:
+
+```
+
+Auth: BASE64-encoded-secred-key
+
+```
+
+This key is stored as ```auth_key``` in configuration file (see above). In case of troubles with using this mechanism, enable ```DEBUG``` log level and restart elasticsearch. Both auth key read from configuration file and value received in request will be displayed for manual comparison and bug tracking.
+
+Be advised that header name is case sensitive. 
 
 ### Some testing 
 

--- a/src/main/java/org/elasticsearch/rest/action/readonlyrest/ConfigurationHelper.java
+++ b/src/main/java/org/elasticsearch/rest/action/readonlyrest/ConfigurationHelper.java
@@ -1,5 +1,7 @@
 package org.elasticsearch.rest.action.readonlyrest;
 
+import org.elasticsearch.common.Base64;
+import org.elasticsearch.common.base.Charsets;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 
@@ -19,6 +21,8 @@ public class ConfigurationHelper {
   private final static String K_RESP_REQ_FORBIDDEN = "response_if_req_forbidden";
   final public boolean enabled;
   final public String forbiddenResponse;
+  final public String authKeyBase64;
+  private final static String K_AUTH_KEY = "auth_key";
 
   
   public ConfigurationHelper(Settings settings, ESLogger logger) {
@@ -43,6 +47,16 @@ public class ConfigurationHelper {
     else{
       this.forbiddenResponse = t;
     }
+    
+	String key = s.get(K_AUTH_KEY);
+	if (key != null) {
+		key = key.trim();
+	}
+	if (isNullOrEmpty(key)) {
+		this.authKeyBase64 = null;
+	} else {
+		this.authKeyBase64 = Base64.encodeBytes(key.getBytes(Charsets.UTF_8));
+	}
     
   }
   

--- a/src/main/java/org/elasticsearch/rest/action/readonlyrest/ReadonlyRestAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/readonlyrest/ReadonlyRestAction.java
@@ -58,6 +58,7 @@ public class ReadonlyRestAction extends BaseRestHandler {
 
       @Override
       public void process(RestRequest request, RestChannel channel, RestFilterChain filterChain) {
+
 		if (isAuthorisedToBypassACL(request, conf)) {
 			logger.debug("Auth ok, will bypass filters");
 			ok(request, filterChain, channel);
@@ -87,12 +88,14 @@ public class ReadonlyRestAction extends BaseRestHandler {
 	if (conf.authKeyBase64 == null) {
 		return false;
 	}
-	String authVal = request.header("Authorization");
+	logger.debug("Headers: {}", request.getHeaders());
+	logger.debug("Request headers (lowercase): {}", request.headers());
+	String authVal = request.header("Auth");
 	logger.debug("Auth header: {}", authVal);
 	if (authVal == null) {
 		return false;
 	}
-	String val = authVal.replace("Basic ", "").trim();
+	String val = authVal.trim();
 	return val.equals(conf.authKeyBase64);
   }
 	

--- a/src/main/java/org/elasticsearch/rest/action/readonlyrest/ReadonlyRestAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/readonlyrest/ReadonlyRestAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.rest.action.readonlyrest.acl.RuleConfigurationError;
  * <pre>
  * readonlyrest: 
  *  enable: true 
+ *  auth_key: secretAuthKey // this can bypasses all other rules and allows for operation if matched
  *  allow_localhost: true 
  *  whitelist: [192.168.1.144]
  *  forbidden_uri_re: .*bar_me_pls.* 
@@ -57,6 +58,13 @@ public class ReadonlyRestAction extends BaseRestHandler {
 
       @Override
       public void process(RestRequest request, RestChannel channel, RestFilterChain filterChain) {
+		if (isAuthorisedToBypassACL(request, conf)) {
+			logger.debug("Auth ok, will bypass filters");
+			ok(request, filterChain, channel);
+			return;
+		} else {
+			logger.debug("Cannot bypass filters via Authorization");
+		}
         ACLRequest aclReq = new ACLRequest(request, channel);
         String reason = acl.check(aclReq);
         if(reason == null){
@@ -73,6 +81,21 @@ public class ReadonlyRestAction extends BaseRestHandler {
       }
     });
   }
+  
+  protected boolean isAuthorisedToBypassACL(RestRequest request, ConfigurationHelper conf) {
+	logger.debug("Auth key: {}", conf.authKeyBase64);
+	if (conf.authKeyBase64 == null) {
+		return false;
+	}
+	String authVal = request.header("Authorization");
+	logger.debug("Auth header: {}", authVal);
+	if (authVal == null) {
+		return false;
+	}
+	String val = authVal.replace("Basic ", "").trim();
+	return val.equals(conf.authKeyBase64);
+  }
+	
   public void ok(RestRequest request, RestFilterChain filterChain, RestChannel channel ){
     filterChain.continueProcessing(request, channel);
   }


### PR DESCRIPTION
This can come in handy when some parts of system needs to have full access to elastic search without exposing existance of some exceptions from RO rule.