### PR TITLE
More ACL rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ No need to spin up a new HTTP proxy (Varnish, NGNix, HAProxy) between ES and cli
 
 #### Flexible ACLs
 Explicitly allow/forbid requests by access control rule parameters:
-* ```hosts``` a list of origin IP addresses
+* ```hosts``` a list of origin IP addresses or subnets
+* ```api_keys``` a list of api keys passed in via header X-Api-Key
 * ```methods``` a list of HTTP methods
 * ```uri_re``` a regular expression to match the request URI (useful to restrict certain indexes)
 * ```maxBodyLength``` limit HTTP request body length.
@@ -108,10 +109,15 @@ readonlyrest:
     # Default policy is to forbid everything, let's define a whitelist
     access_control_rules:
     
-    # from these IP addresses, accept any method, any URI, any HTTP body
+    # From these IP addresses, accept any method, any URI, any HTTP body
     - name: full access to internal servers
       type: allow
-      hosts: [127.0.0.1, 10.0.0.20, 10.0.2.112]
+      hosts: [127.0.0.1, 10.0.0.20, 10.0.2.112, 10.0.1.0/24]
+
+    # From these API Keys, accept any method, any URI, any HTTP body
+    - name: full access to remote authorized clients
+      type: allow
+      api_keys: [abcdefghijklmnopqrstuvwxyz, a1b2c3d4e5f6]
 
     # From any other hosts, check first they are not accessing private indexes
     - name: forbid access to private index from external hosts

--- a/src/main/java/org/elasticsearch/rest/action/readonlyrest/IPMask.java
+++ b/src/main/java/org/elasticsearch/rest/action/readonlyrest/IPMask.java
@@ -1,0 +1,112 @@
+package org.elasticsearch.rest.action.readonlyrest;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Represents an IP range based on an address/mask.
+ * @author Scott Plante, using code snippets by John Kugelman.
+ */
+public class IPMask
+{
+  private Inet4Address i4addr;
+  private byte maskCtr;
+
+  private int addrInt;
+  private int maskInt;
+
+  public IPMask(Inet4Address i4addr, byte mask)
+  {
+    this.i4addr = i4addr;
+    this.maskCtr = mask;
+
+    this.addrInt = addrToInt(i4addr);
+    this.maskInt = ~((1 << (32 - maskCtr)) - 1);
+  }
+
+  /** IPMask factory method.
+   *
+   * @param addrSlashMask IP/Mask String in format "nnn.nnn.nnn.nnn/mask". If
+   *    the "/mask" is omitted, "/32" (just the single address) is assumed.
+   * @return a new IPMask
+   * @throws UnknownHostException if address part cannot be parsed by
+   *    InetAddress
+   */
+  public static IPMask getIPMask(String addrSlashMask)
+      throws UnknownHostException
+  {
+    int pos = addrSlashMask.indexOf('/');
+    String addr;
+    byte maskCtr;
+    if (pos==-1)
+    {
+      addr = addrSlashMask;
+      maskCtr = 32;
+    }
+    else
+    {
+      addr = addrSlashMask.substring(0, pos);
+      maskCtr = Byte.parseByte(addrSlashMask.substring(pos + 1));
+    }
+    return new IPMask((Inet4Address) InetAddress.getByName(addr), maskCtr);
+  }
+
+ /** Test given IPv4 address against this IPMask object.
+   *
+   * @param testAddr address to check.
+   * @return true if address is in the IP Mask range, false if not.
+   */
+  public boolean matches(Inet4Address testAddr)
+  {
+    int testAddrInt = addrToInt(testAddr);
+    return ((addrInt & maskInt) == (testAddrInt & maskInt));
+  }
+
+/** Convenience method that converts String host to IPv4 address.
+   *
+   * @param addr IP address to match in nnn.nnn.nnn.nnn format or hostname.
+   * @return true if address is in the IP Mask range, false if not.
+   * @throws UnknownHostException if the string cannot be decoded.
+   */
+  public boolean matches(String addr)
+      throws UnknownHostException
+  {
+    return matches((Inet4Address)InetAddress.getByName(addr));
+  }
+
+/** Converts IPv4 address to integer representation.
+   */
+  private static int addrToInt(Inet4Address i4addr)
+  {
+    byte[] ba = i4addr.getAddress();
+    return (ba[0]       << 24)
+        | ((ba[1]&0xFF) << 16)
+        | ((ba[2]&0xFF) << 8)
+        |  (ba[3]&0xFF);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "IPMask(" + i4addr.getHostAddress() + "/" + maskCtr + ")";
+  }
+
+  @Override
+  public boolean equals(Object obj)
+  {
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    final IPMask that = (IPMask) obj;
+    return (this.addrInt == that.addrInt && this.maskInt == that.maskInt);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return this.maskInt + this.addrInt;
+  }
+
+}

--- a/src/main/java/org/elasticsearch/rest/action/readonlyrest/acl/ACL.java
+++ b/src/main/java/org/elasticsearch/rest/action/readonlyrest/acl/ACL.java
@@ -48,6 +48,7 @@ public class ACL {
       // The logic will exit at the first rule that matches the request
       boolean match = true;
       match &= rule.matchesAddress(req.getAddress());
+      match &= rule.matchesApiKey(req.getApiKey());
       match &= rule.matchesMaxBodyLength(req.getBodyLength());
       match &= rule.matchesUriRe(req.getUri());
       match &= rule.mathesMethods(req.getMethod());
@@ -57,7 +58,7 @@ public class ACL {
         return rule.type.equals(Type.FORBID) ? rule.name : null;
       }
     }
-    return "request matches no rules, forbidden by default: req: " + req.getUri() + " - method: " + req.getMethod() + " - origin addr: " + req.getAddress();
+    return "request matches no rules, forbidden by default: req: " + req.getUri() + " - method: " + req.getMethod() + " - origin addr: " + req.getAddress() + " - api key: " + req.getApiKey();
   }
 
 }

--- a/src/test/java/org/elasticsearch/rest/action/readonlyrest/acl/test/ACLTest.java
+++ b/src/test/java/org/elasticsearch/rest/action/readonlyrest/acl/test/ACLTest.java
@@ -45,37 +45,37 @@ public class ACLTest {
 
   @Test
   public final void testExternalGet() {
-    ACLRequest ar = new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "1.1.1.1", 0, Method.GET);
+    ACLRequest ar = new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "1.1.1.1", "", 0, Method.GET);
     Assert.assertNull(acl.check(ar));
   }
 
   @Test
   public final void testExternalPost() {
-    Assert.assertNotNull(acl.check(new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "1.1.1.1", 0, Method.POST)));
+    Assert.assertNotNull(acl.check(new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "1.1.1.1", "", 0, Method.POST)));
   }
   @Test 
   public final void testExternalURIRE(){
-    Assert.assertNotNull(acl.check( new ACLRequest("http://localhost:9200/reservedIdx/_search?q=item.name:fishingpole&size=200", "1.1.1.1", 0, Method.GET)));
+    Assert.assertNotNull(acl.check( new ACLRequest("http://localhost:9200/reservedIdx/_search?q=item.name:fishingpole&size=200", "1.1.1.1", "", 0, Method.GET)));
   }
 
   @Test 
   public final void testExternalMatchAddress(){
-    Assert.assertNull(acl.check( new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "127.0.0.1", 0, Method.GET)));
+    Assert.assertNull(acl.check( new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "127.0.0.1", "", 0, Method.GET)));
   }
   
   @Test 
   public final void testExternalWithBody(){
-    Assert.assertNotNull(acl.check( new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "1.1.1.1", 20, Method.GET)));
+    Assert.assertNotNull(acl.check( new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "1.1.1.1", "", 20, Method.GET)));
   }
 
   @Test 
   public final void testExternalMethods(){
-    Assert.assertNull(acl.check( new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "1.1.1.1", 0, Method.OPTIONS)));
+    Assert.assertNull(acl.check( new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "1.1.1.1", "", 0, Method.OPTIONS)));
   }
   
   @Test 
   public final void testInternalMethods(){
-    Assert.assertNull(acl.check( new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "127.0.0.1", 0, Method.HEAD)));
+    Assert.assertNull(acl.check( new ACLRequest("http://es/index1/_search?q=item.name:fishingpole&size=200", "127.0.0.1", "", 0, Method.HEAD)));
   }
 
 }

--- a/src/test/java/org/elasticsearch/rest/action/readonlyrest/acl/test/MarvelPassthroughACL.java
+++ b/src/test/java/org/elasticsearch/rest/action/readonlyrest/acl/test/MarvelPassthroughACL.java
@@ -41,7 +41,7 @@ public class MarvelPassthroughACL {
 
     @Test
     public final void testInternalMethods(){
-        Assert.assertNull(acl.check( new ACLRequest(".marvel-2015.11.10/_search", "127.0.0.1", 0, Method.POST)));
+        Assert.assertNull(acl.check( new ACLRequest(".marvel-2015.11.10/_search", "127.0.0.1", "", 0, Method.POST)));
     }
 
 }


### PR DESCRIPTION
These changes were specifically made to allow AWS Lambda to be able to send requests to an ES cluster without having to open the entire cluster to the outside world.  

Currently, requests to an ES cluster (not an AWS managed ES cluster) from AWS Lambda may come from a large unknown pool of IP addresses.  By allowing access via an API Key that is made available to an AWS Lambda, you can allow access to just that Lambda.  Until AWS Lambdas can be run inside a VPC, this is a sufficient workaround.

Also, if your ES cluster is behind an AWS ELB, the addition of support for creating a rule using a subnet and retrieval of the remote address from the X-Forwarded-For header allows the host based rule parameter to still work since ELB attaches the X-Forwarded-For header to requests and also lives inside a known subnet (assuming your ELB is inside a VPC).