### PR TITLE
General Code Improvement 1

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/ACL.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/ACL.java
@@ -20,10 +20,6 @@ public class ACL {
   private final static String PREFIX = "readonlyrest.access_control_rules";
   private boolean basicAuthConfigured = false;
 
-  public boolean isBasicAuthConfigured() {
-    return basicAuthConfigured;
-  }
-
   public ACL(Settings s) {
     Map<String, Settings> g = s.getGroups(PREFIX);
     // Maintaining the order is not guaranteed, moving everything to tree map!
@@ -38,6 +34,10 @@ public class ACL {
       }
       logger.info("ADDING " + block.toString());
     }
+  }
+
+  public boolean isBasicAuthConfigured() {
+    return basicAuthConfigured;
   }
 
   public BlockExitResult check(RequestContext rc) {

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/Block.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/Block.java
@@ -23,18 +23,6 @@ public class Block {
   private boolean authHeaderAccepted = false;
   private Set<Rule> conditionsToCheck = Sets.newHashSet();
 
-  public String getName() {
-    return name;
-  }
-
-  public Policy getPolicy() {
-    return policy;
-  }
-
-  public boolean isAuthHeaderAccepted() {
-    return authHeaderAccepted;
-  }
-
   public Block(Settings s, ESLogger logger) {
     this.name = s.get("name");
     String sPolicy = s.get("type");
@@ -76,6 +64,18 @@ public class Block {
       conditionsToCheck.add(new IndicesRule(s));
     } catch (RuleNotConfiguredException e) {
     }
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Policy getPolicy() {
+    return policy;
+  }
+
+  public boolean isAuthHeaderAccepted() {
+    return authHeaderAccepted;
   }
 
   public enum Policy {

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/IPMask.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/IPMask.java
@@ -60,7 +60,7 @@ public class IPMask
   public boolean matches(Inet4Address testAddr)
   {
     int testAddrInt = addrToInt(testAddr);
-    return ((addrInt & maskInt) == (testAddrInt & maskInt));
+    return (addrInt & maskInt) == (testAddrInt & maskInt);
   }
 
 /** Convenience method that converts String host to IPv4 address.
@@ -100,7 +100,7 @@ public class IPMask
     if (getClass() != obj.getClass())
       return false;
     final IPMask that = (IPMask) obj;
-    return (this.addrInt == that.addrInt && this.maskInt == that.maskInt);
+    return this.addrInt == that.addrInt && this.maskInt == that.maskInt;
   }
 
   @Override

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/AuthKeyRule.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/AuthKeyRule.java
@@ -33,7 +33,9 @@ public class AuthKeyRule extends Rule {
     if (authorizationHeader == null || authorizationHeader.trim().length() == 0 || !authorizationHeader.contains("Basic "))
       return null;
     String interestingPart = authorizationHeader.split("Basic")[1].trim();
-    if (interestingPart.length() == 0) return null;
+    if (interestingPart.length() == 0) {
+        return null;
+    }
     return interestingPart;
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1213  The members of an interface declaration or class should appear in a pre-defined order
squid:UselessParenthesesCheck  Useless parentheses around expressions should be removed to prevent any misunderstanding
squid:S00122  Statements should be on separate lines

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck 
https://dev.eclipse.org/sonar/rules/show/squid:S00122 

Please let me know if you have any questions.

Zeeshan Asghar