### PR TITLE
Problem with Indices Rule

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/IndicesRule.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/IndicesRule.java
@@ -12,7 +12,8 @@ import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.Rule;
 import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.RuleExitResult;
 import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.RuleNotConfiguredException;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
@@ -50,14 +51,11 @@ public class IndicesRule extends Rule {
           public Void run() {
             String[] indices;
             try {
-              Field f = ar.getClass().getDeclaredField("indices");
-              f.setAccessible(true);
-              indices = (String[]) f.get(ar);
-            } catch ( SecurityException | IllegalArgumentException | IllegalAccessException e) {
-              throw new SecurityPermissionException("Insufficient permissions to extract the indices. Abort! Cause: " + e.getMessage(), e);
-            }
-            catch (NoSuchFieldException nfe) {
-              return null;
+              Method m = ar.getClass().getMethod("indices");
+              m.setAccessible(true);
+              indices = (String[]) m.invoke(ar);
+            } catch ( SecurityException | IllegalArgumentException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+                throw new SecurityPermissionException("Insufficient permissions to extract the indices. Abort! Cause: " + e.getMessage(), e);
             }
             out[0] = indices;
             return null;

--- a/src/test/java/org/elasticsearch/rest/action/readonlyrest/acl/test/ACLTest.java
+++ b/src/test/java/org/elasticsearch/rest/action/readonlyrest/acl/test/ACLTest.java
@@ -61,6 +61,7 @@ public class ACLTest {
       public ActionRequestValidationException validate() {
         return null;
       }
+      public String[] indices() { return indices; }
     });
   }
 


### PR DESCRIPTION
Hi Simone,
thank you for sharing the plugin! It is turning out to be useful for some of our projects. I just had a small issue when trying to restrict indexes access. I tested this only with Elasticsearch v.2.2.0 but I've looked over the older APIs and I would expect that to be ok for previous versions as well.

I am sharing back to seek for validation as well.

So this is what I have done:

Changed reflection call from Field 'indices' to method 'indices' as the method 'getDeclaredField' gets the fields, regardless of their accessibility but only for the current class, not any base classes that the current class might be inheriting from. And the field 'indices' is private and inherited. Changed it to access the public method instead. By doing that I can now use 'getMethod' and get to the public methods of the superclasses.