### PR TITLE
feature: add group access rule and dedicated user list

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,46 @@ This is secure because the users connecting from their browsers will be asked to
 
 **Now activate authenticatoin in Logstash**: [(follow the docs, it's very similar to Kibana!)](https://www.elastic.co/guide/en/shield/current/logstash.html#ls-http-auth-basic)
 
-### 4. restart elastic search
+### USE CASE 3: Group-based access control
+```yml
+readonlyrest:
+    enable: true
+    response_if_req_forbidden: Forbidden by ReadonlyREST ES plugin
+    
+    access_control_rules:
+
+    - name: Accept requests from users in group team1 on index1
+      type: allow
+      groups: ["team1"]
+      uri_re: ^/index1/.*
+
+    - name: Accept requests from users in group team2 on index2
+      type: allow
+      groups: ["team2"]
+      uri_re: ^/index2/.*
+
+    - name: Accept requests from users in groups team1 or team2 on index3
+      type: allow
+      groups: ["team1", "team2"]
+      uri_re: ^/index3/.*
+    
+    users:
+    
+    - username: alice
+      auth_key: alice:p455phrase
+      groups: ["team1"]
+      
+    - username: bob
+      auth_key: bob:s3cr37
+      groups: ["team2", "team4"]
+      
+    - username: claire
+      auth_key_sha1: 2bc37a406bd743e2b7a4cb33efc0c52bc2cb03f0 #claire:p455key
+      groups: ["team1", "team5"]
+
+```
+
+### 3. Restart Elasticsearch
 
 **For other use cases and finer access control** have a look at [the full list of supported rules](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/wiki/Supported-Rules)
 

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/ACL.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/ACL.java
@@ -21,18 +21,20 @@ public class ACL {
   private final static ESLogger logger = Loggers.getLogger(ACL.class);
   // Array list because it preserves the insertion order
   private ArrayList<Block> blocks = new ArrayList<>();
-  private final static String PREFIX = "readonlyrest.access_control_rules";
+  private final static String RULES_PREFIX = "readonlyrest.access_control_rules";
+  private final static String USERS_PREFIX = "readonlyrest.users";
   private boolean basicAuthConfigured = false;
 
   @Inject
   public ACL(Settings s) {
-    Map<String, Settings> g = s.getGroups(PREFIX);
+    Map<String, Settings> g = s.getGroups(RULES_PREFIX);
     // Maintaining the order is not guaranteed, moving everything to tree map!
     TreeMap<String, Settings> tmp = new TreeMap<>();
     tmp.putAll(g);
     g = tmp;
+    Map<String, Settings> users = s.getGroups(USERS_PREFIX);
     for (String k : g.keySet()) {
-      Block block = new Block(g.get(k), logger);
+      Block block = new Block(g.get(k), new ArrayList<>(users.values()), logger);
       blocks.add(block);
       if (block.isAuthHeaderAccepted()) {
         basicAuthConfigured = true;

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/Block.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/Block.java
@@ -1,6 +1,7 @@
 package org.elasticsearch.plugin.readonlyrest.acl.blocks;
 
 import com.google.common.collect.Sets;
+import java.util.List;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugin.readonlyrest.acl.RequestContext;
@@ -23,7 +24,7 @@ public class Block {
   private boolean authHeaderAccepted = false;
   private Set<Rule> conditionsToCheck = Sets.newHashSet();
 
-  public Block(Settings s, ESLogger logger) {
+  public Block(Settings s, List<Settings> userList, ESLogger logger) {
     this.name = s.get("name");
     String sPolicy = s.get("type");
     this.logger = logger;
@@ -75,6 +76,10 @@ public class Block {
     try {
       conditionsToCheck.add(new AuthKeySha1Rule(s));
       authHeaderAccepted = true;
+    } catch (RuleNotConfiguredException e) {
+    }
+    try {
+      conditionsToCheck.add(new GroupsRule(s, userList));
     } catch (RuleNotConfiguredException e) {
     }
   }

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/User.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/User.java
@@ -1,0 +1,49 @@
+package org.elasticsearch.plugin.readonlyrest.acl.blocks.rules;
+
+import java.util.Arrays;
+import java.util.List;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.impl.AuthKeyRule;
+import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.impl.AuthKeySha1Rule;
+
+/**
+ * @author Christian Henke <maitai@users.noreply.github.com>
+ */
+public class User {
+
+  private final String username;
+  private AuthKeyRule authKeyRule;
+  private final List<String> groups;
+
+  public User(Settings userProperties) throws UserNotConfiguredException {
+    this.username = userProperties.get("username");
+    try {
+      this.authKeyRule = new AuthKeyRule(userProperties);
+    } catch (RuleNotConfiguredException e) {
+      try {
+        this.authKeyRule = new AuthKeySha1Rule(userProperties);
+      } catch (RuleNotConfiguredException e2) {
+        throw new UserNotConfiguredException();
+      }
+    }
+    String[] pGroups = userProperties.getAsArray("groups");
+    if (pGroups != null && pGroups.length > 0) {
+      this.groups = Arrays.asList(pGroups);
+    } else {
+      throw new UserNotConfiguredException();
+    }
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public AuthKeyRule getAuthKeyRule() {
+    return authKeyRule;
+  }
+
+  public List<String> getGroups() {
+    return groups;
+  }
+
+}

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/UserNotConfiguredException.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/UserNotConfiguredException.java
@@ -1,0 +1,8 @@
+package org.elasticsearch.plugin.readonlyrest.acl.blocks.rules;
+
+/**
+ * @author Christian Henke <maitai@users.noreply.github.com>
+ */
+public class UserNotConfiguredException extends Exception {
+
+}

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/GroupsRule.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/GroupsRule.java
@@ -1,0 +1,59 @@
+package org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.readonlyrest.acl.RequestContext;
+import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.Rule;
+import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.RuleExitResult;
+import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.RuleNotConfiguredException;
+import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.User;
+import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.UserNotConfiguredException;
+
+/**
+ * A GroupsRule checks if a request containing Basic Authentication credentials 
+ * matches a user in one of the specified groups.
+ * 
+ * @author Christian Henke <maitai@users.noreply.github.com>
+ */
+public class GroupsRule extends Rule {
+
+  private final List<User> users = new ArrayList<>();
+  private final List<String> groups;
+
+  public GroupsRule(Settings s, List<Settings> userList) throws RuleNotConfiguredException {
+    super(s);
+
+    String[] pGroups = s.getAsArray(this.KEY);
+    if (pGroups != null && pGroups.length > 0) {
+      this.groups = Arrays.asList(pGroups);
+    } else {
+      throw new RuleNotConfiguredException();
+    }
+    for (Settings userProperties : userList) {
+      try {
+        this.users.add(new User(userProperties));
+      } catch (UserNotConfiguredException e) {
+      }
+    }
+    if (this.users.isEmpty()) {
+      throw new RuleNotConfiguredException();
+    }
+  }
+
+  @Override
+  public RuleExitResult match(RequestContext rc) {
+    for (User user : this.users) {
+      if (user.getAuthKeyRule().match(rc).isMatch()) {
+        List<String> commonGroups = new ArrayList<>(user.getGroups());
+        commonGroups.retainAll(this.groups);
+        if (!commonGroups.isEmpty()) {
+          return MATCH;
+        }
+      }
+    }
+    return NO_MATCH;
+  }
+
+}

--- a/src/test/java/org/elasticsearch/rest/action/readonlyrest/acl/test/ACLTest.java
+++ b/src/test/java/org/elasticsearch/rest/action/readonlyrest/acl/test/ACLTest.java
@@ -285,5 +285,42 @@ public class ACLTest {
     BlockExitResult res = acl.check(rc);
     assertFalse(res.isMatch());
   }
-
+  
+  // Groups
+  @Test
+  public final void testAllowGroupAuth() throws Throwable {
+    String secret64 = Base64.encodeBytes("alice:p455phrase".getBytes(Charsets.UTF_8));
+    RequestContext rc = mockReq("/groupindex1/_search?q=item.getName():fishingpole&size=200", "1.1.1.1", "", "Basic " + secret64, 0, Method.DELETE, null, null, null);
+    BlockExitResult res = acl.check(rc);
+    assertTrue(res.isMatch());
+    assertTrue(res.getBlock().getPolicy() == Block.Policy.ALLOW);
+    assertEquals("16", res.getBlock().getName());
+  }
+  
+  @Test
+  public final void testAllowGroupAuthSha1() throws Throwable {
+    String secret64 = Base64.encodeBytes("claire:p455key".getBytes(Charsets.UTF_8));
+    RequestContext rc = mockReq("/groupindex1/_search?q=item.getName():fishingpole&size=200", "1.1.1.1", "", "Basic " + secret64, 0, Method.DELETE, null, null, null);
+    BlockExitResult res = acl.check(rc);
+    assertTrue(res.isMatch());
+    assertTrue(res.getBlock().getPolicy() == Block.Policy.ALLOW);
+    assertEquals("16", res.getBlock().getName());
+  }
+  
+  @Test
+  public final void testForbidGroupAuthWrongCreds() throws Throwable {
+    String secret64 = Base64.encodeBytes("alice:wr0ngp455".getBytes(Charsets.UTF_8));
+    RequestContext rc = mockReq("/groupindex1/_search?q=item.getName():fishingpole&size=200", "1.1.1.1", "", "Basic " + secret64, 0, Method.DELETE, null, null, null);
+    BlockExitResult res = acl.check(rc);
+    assertFalse(res.isMatch());
+  }
+  
+  @Test
+  public final void testForbidGroupAuthWrongGroup() throws Throwable {
+    String secret64 = Base64.encodeBytes("bob:s3cr37".getBytes(Charsets.UTF_8));
+    RequestContext rc = mockReq("/groupindex1/_search?q=item.getName():fishingpole&size=200", "1.1.1.1", "", "Basic " + secret64, 0, Method.DELETE, null, null, null);
+    BlockExitResult res = acl.check(rc);
+    assertFalse(res.isMatch());
+  }
+  
 }

--- a/src/test/test_rules.yml
+++ b/src/test/test_rules.yml
@@ -102,3 +102,23 @@ readonlyrest:
     - name: 15
       type: allow
       auth_key_sha1: a5aa590854b3806350b345ea154a52e3391aed32 #sha1configured:p455wd
+      
+    - name: 16
+      type: allow
+      groups: ["b"]
+      
+      
+    users:
+    
+    - username: alice
+      auth_key: alice:p455phrase
+      groups: ["b", "c"]
+      
+    - username: bob
+      auth_key: bob:s3cr37
+      groups: ["c"]
+      
+    - username: claire
+      auth_key_sha1: 2bc37a406bd743e2b7a4cb33efc0c52bc2cb03f0
+      groups: ["b"]
+


### PR DESCRIPTION
Hi Simone,
thank you for creating this plugin! :)

This change introduces a rule where one may specify user groups inside
access control blocks as well as define a dedicated list of users that are
members of these groups. A typical user entry consists of a username,
an auth key and a number of group memberships. A matching auth key in
combination with the correct group membership grants access under this rule.
