### PR TITLE
Correct plugin version for 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ List of other supported Elasticsearch versions: [releases](https://github.com/ss
 
 ```bash
 ES_VERSION=2.4.1
-bin/plugin install https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/releases/download/v1.10.0_es-v$ES_VERSION/elasticsearch-readonlyrest-v1.11.0_es-v$ES_VERSION.zip
+bin/plugin install https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/releases/download/v1.12.0-rc1_es-v$ES_VERSION/elasticsearch-readonlyrest-v1.12.0-rc1_es-v$ES_VERSION.zip
 ```
 
 ### 2. Configuration


### PR DESCRIPTION
For ES_VERSION=2.4.1, v1.12.0-rc1 should be used.
