### PR TITLE
[PROXY-ISSUE] fix X-FORWARDED-FOR ip check ignored

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/HostsRule.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/HostsRule.java
@@ -91,10 +91,7 @@ public class HostsRule extends Rule {
 
     if (acceptXForwardedForHeader && xForwardedForHeader != null) {
       // Give it a try with the header
-      boolean attemptXFwdFor = matchesAddress(xForwardedForHeader, null);
-      if (attemptXFwdFor) {
-        return true;
-      }
+      return matchesAddress(xForwardedForHeader, null);
     }
     for (String allowedAddress : allowedAddresses) {
       if (allowedAddress.indexOf("/") > 0) {


### PR DESCRIPTION
* Test Environment
  * ElasticSearch : 2.4.3
  * ReadOnlyRest : 1.12.2
  * AWS ELB Proxy with X-Forwarded-For header.

We found a bug that HostsRule ignores ELB's X-Forwarded-For header.
When X-Forwarded-For header's IP does not match, HostsRule retry matching with ELB IP Address.

HostsRule must return the result of X-Forwarded-For header's IP match whether it returns true or false.

For example, we allow host 10.20.30.0/24 and ELB's IP exist in this subnet.
When we try to access other machine with 10.30.30.1, then X-Forwarded-For header's IP does not match. But, HostsRule ignore result and try to match ELB's IP and return success.