### PR TITLE
changed: ldap user id and user refernce attributes from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ readonlyrest:
 ```
 
 LDAP configuration requirements:
-- user from `search_user_base_DN` should have `uid` attribute
-- groups from `search_groups_base_DN` should have `uniqueMember` attribute
+- user from `search_user_base_DN` should have `uid` attribute (can be overwritten using `user_id_attribute`)
+- groups from `search_groups_base_DN` should have `uniqueMember` attribute (can be overwritten using `unique_member_attribute`)
 
 (example LDAP config can be found in test /resources/test_example.ldif)
 

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/LdapConfig.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/LdapConfig.java
@@ -97,11 +97,11 @@ public class LdapConfig {
   }
 
   private static boolean sslEnabledFrom(Settings settings) {
-    return settings.getAsBoolean(ATTRIBUTE_SSL_ENABLED, UnboundidLdapClient.DEFAULT_LDAP_SSL_ENABLED);
+    return settings.getAsBoolean(ATTRIBUTE_SSL_ENABLED, UnboundidLdapClient.Builder.DEFAULT_LDAP_SSL_ENABLED);
   }
 
   private static boolean trustAllCertsFrom(Settings settings) {
-    return settings.getAsBoolean(ATTRIBUTE_SSL_TRUST_ALL_CERTS, UnboundidLdapClient.DEFAULT_LDAP_SSL_TRUST_ALL_CERTS);
+    return settings.getAsBoolean(ATTRIBUTE_SSL_TRUST_ALL_CERTS, UnboundidLdapClient.Builder.DEFAULT_LDAP_SSL_TRUST_ALL_CERTS);
   }
 
   private static Optional<UnboundidLdapClient.BindDnPassword> bindDNPasswordFrom(Settings settings) {
@@ -141,42 +141,42 @@ public class LdapConfig {
   }
 
   private static String uidAttribute(Settings settings) {
-    return settings.get(ATTRIBUTE_UID_ATTRIBUTE, UnboundidLdapClient.DEFAULT_UID_ATTRIBUTE);
+    return settings.get(ATTRIBUTE_UID_ATTRIBUTE, UnboundidLdapClient.Builder.DEFAULT_UID_ATTRIBUTE);
   }
 
   private static String uniqueMemberAttribute(Settings settings) {
-    return settings.get(ATTRIBUTE_UNIQUE_MEMEBER_ATTRIBUTE, UnboundidLdapClient.DEFAULT_UNIQUE_MEMBER_ATTRIBUTE);
+    return settings.get(ATTRIBUTE_UNIQUE_MEMEBER_ATTRIBUTE, UnboundidLdapClient.Builder.DEFAULT_UNIQUE_MEMBER_ATTRIBUTE);
   }
 
   private static int portFrom(Settings settings) {
-    return settings.getAsInt(ATTRIBUTE_PORT, UnboundidLdapClient.DEFAULT_LDAP_PORT);
+    return settings.getAsInt(ATTRIBUTE_PORT, UnboundidLdapClient.Builder.DEFAULT_LDAP_PORT);
   }
 
   private static int poolSizeFrom(Settings settings) {
     return settings.getAsInt(
       ATTRIBUTE_CONNECTION_POOL_SIZE,
-      UnboundidLdapClient.DEFAULT_LDAP_CONNECTION_POOL_SIZE
+      UnboundidLdapClient.Builder.DEFAULT_LDAP_CONNECTION_POOL_SIZE
     );
   }
 
   private static Duration connectionTimeoutFrom(Settings settings) {
     return Duration.ofSeconds(settings.getAsLong(
       ATTRIBUTE_CONNECTION_TIMEOUT,
-      UnboundidLdapClient.DEFAULT_LDAP_CONNECTION_TIMEOUT.getSeconds()
+      UnboundidLdapClient.Builder.DEFAULT_LDAP_CONNECTION_TIMEOUT.getSeconds()
     ));
   }
 
   private static Duration requestTimeoutFrom(Settings settings) {
     return Duration.ofSeconds(settings.getAsLong(
       ATTRIBUTE_REQUEST_TIMEOUT,
-      UnboundidLdapClient.DEFAULT_LDAP_REQUEST_TIMEOUT.getSeconds()
+      UnboundidLdapClient.Builder.DEFAULT_LDAP_REQUEST_TIMEOUT.getSeconds()
     ));
   }
 
   private static Duration cacheTtlFrom(Settings settings) {
     return Duration.ofSeconds(settings.getAsLong(
       ATTRIBUTE_CACHE_TTL,
-      UnboundidLdapClient.DEFAULT_LDAP_CACHE_TTL.getSeconds()
+      UnboundidLdapClient.Builder.DEFAULT_LDAP_CACHE_TTL.getSeconds()
     ));
   }
 

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/LdapConfig.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/rules/impl/LdapConfig.java
@@ -35,6 +35,8 @@ public class LdapConfig {
   private static String ATTRIBUTE_BIND_PASSWORD = "bind_password";
   private static String ATTRIBUTE_SEARCH_USER_BASE_DN = "search_user_base_DN";
   private static String ATTRIBUTE_SEARCH_GROUPS_BASE_DN = "search_groups_base_DN";
+  private static String ATTRIBUTE_UID_ATTRIBUTE = "user_id_attribute";
+  private static String ATTRIBUTE_UNIQUE_MEMEBER_ATTRIBUTE = "unique_member_attribute";
   private static String ATTRIBUTE_CONNECTION_POOL_SIZE = "connection_pool_size";
   private static String ATTRIBUTE_CONNECTION_TIMEOUT = "connection_timeout_in_sec";
   private static String ATTRIBUTE_REQUEST_TIMEOUT = "request_timeout_in_sec";
@@ -63,7 +65,9 @@ public class LdapConfig {
         .setTrustAllCerts(trustAllCertsFrom(settings))
         .setPoolSize(poolSizeFrom(settings))
         .setConnectionTimeout(connectionTimeoutFrom(settings))
-        .setRequestTimeout(requestTimeoutFrom(settings));
+        .setRequestTimeout(requestTimeoutFrom(settings))
+        .setUidAttribute(uidAttribute(settings))
+        .setUniqueMemberAttribute(uniqueMemberAttribute(settings));
 
     Optional<UnboundidLdapClient.BindDnPassword> bindDnPassword = bindDNPasswordFrom(settings);
     Duration cacheTtl = cacheTtlFrom(settings);
@@ -134,6 +138,14 @@ public class LdapConfig {
                                            "] attribute defined for LDAP [" + name + "]");
     }
     return searchGroupsBaseDn;
+  }
+
+  private static String uidAttribute(Settings settings) {
+    return settings.get(ATTRIBUTE_UID_ATTRIBUTE, UnboundidLdapClient.DEFAULT_UID_ATTRIBUTE);
+  }
+
+  private static String uniqueMemberAttribute(Settings settings) {
+    return settings.get(ATTRIBUTE_UNIQUE_MEMEBER_ATTRIBUTE, UnboundidLdapClient.DEFAULT_UNIQUE_MEMBER_ATTRIBUTE);
   }
 
   private static int portFrom(Settings settings) {

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/ldap/UnboundidLdapClient.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/ldap/UnboundidLdapClient.java
@@ -51,16 +51,6 @@ import java.util.stream.Collectors;
 public class UnboundidLdapClient implements LdapClient {
   private static final Logger logger = Loggers.getLogger(UnboundidLdapClient.class);
 
-  public static int DEFAULT_LDAP_PORT = 389;
-  public static int DEFAULT_LDAP_CONNECTION_POOL_SIZE = 30;
-  public static Duration DEFAULT_LDAP_REQUEST_TIMEOUT = Duration.ofSeconds(1);
-  public static Duration DEFAULT_LDAP_CONNECTION_TIMEOUT = Duration.ofSeconds(1);
-  public static Duration DEFAULT_LDAP_CACHE_TTL = Duration.ZERO;
-  public static boolean DEFAULT_LDAP_SSL_ENABLED = true;
-  public static boolean DEFAULT_LDAP_SSL_TRUST_ALL_CERTS = false;
-  public static String DEFAULT_UID_ATTRIBUTE = "uid";
-  public static String DEFAULT_UNIQUE_MEMBER_ATTRIBUTE = "uniqueMember";
-
   private final String searchUserBaseDN;
   private final String searchGroupBaseDN;
   private final String uidAttribute;
@@ -306,18 +296,29 @@ public class UnboundidLdapClient implements LdapClient {
   }
 
   public static class Builder {
+
+    public static int DEFAULT_LDAP_PORT = 389;
+    public static int DEFAULT_LDAP_CONNECTION_POOL_SIZE = 30;
+    public static Duration DEFAULT_LDAP_REQUEST_TIMEOUT = Duration.ofSeconds(1);
+    public static Duration DEFAULT_LDAP_CONNECTION_TIMEOUT = Duration.ofSeconds(1);
+    public static boolean DEFAULT_LDAP_SSL_ENABLED = true;
+    public static boolean DEFAULT_LDAP_SSL_TRUST_ALL_CERTS = false;
+    public static String DEFAULT_UID_ATTRIBUTE = "uid";
+    public static String DEFAULT_UNIQUE_MEMBER_ATTRIBUTE = "uniqueMember";
+    public static Duration DEFAULT_LDAP_CACHE_TTL = Duration.ZERO;
+
     private final String host;
     private final String searchUserBaseDN;
     private final String searchGroupBaseDN;
-    private String uidAttribute;
-    private String uniqueMemberAttribute;
-    private int port;
+    private int port = DEFAULT_LDAP_PORT;
     private Optional<BindDnPassword> bindDnPassword = Optional.empty();
-    private int poolSize;
-    private Duration connectionTimeout;
-    private Duration requestTimeout;
-    private boolean sslEnabled;
-    private boolean trustAllCerts;
+    private int poolSize = DEFAULT_LDAP_CONNECTION_POOL_SIZE;
+    private Duration requestTimeout = DEFAULT_LDAP_REQUEST_TIMEOUT;
+    private Duration connectionTimeout = DEFAULT_LDAP_CONNECTION_TIMEOUT;
+    private boolean sslEnabled = DEFAULT_LDAP_SSL_ENABLED;
+    private boolean trustAllCerts = DEFAULT_LDAP_SSL_TRUST_ALL_CERTS;
+    private String uidAttribute = DEFAULT_UID_ATTRIBUTE;
+    private String uniqueMemberAttribute = DEFAULT_UNIQUE_MEMBER_ATTRIBUTE;
 
     public Builder(String host, String searchUserBaseDN, String searchGroupBaseDN) {
       this.host = host;

--- a/src/main/java/org/elasticsearch/plugin/readonlyrest/ldap/UnboundidLdapClient.java
+++ b/src/main/java/org/elasticsearch/plugin/readonlyrest/ldap/UnboundidLdapClient.java
@@ -58,9 +58,13 @@ public class UnboundidLdapClient implements LdapClient {
   public static Duration DEFAULT_LDAP_CACHE_TTL = Duration.ZERO;
   public static boolean DEFAULT_LDAP_SSL_ENABLED = true;
   public static boolean DEFAULT_LDAP_SSL_TRUST_ALL_CERTS = false;
+  public static String DEFAULT_UID_ATTRIBUTE = "uid";
+  public static String DEFAULT_UNIQUE_MEMBER_ATTRIBUTE = "uniqueMember";
 
   private final String searchUserBaseDN;
   private final String searchGroupBaseDN;
+  private final String uidAttribute;
+  private final String uniqueMemberAttribute;
   private final Long timeout;
   private LDAPConnectionPool connectionPool;
 
@@ -69,6 +73,8 @@ public class UnboundidLdapClient implements LdapClient {
                               Optional<BindDnPassword> bindDnPassword,
                               String searchUserBaseDN,
                               String searchGroupBaseDN,
+                              String uidAttribute,
+                              String uniqueMemberAttribute,
                               int poolSize,
                               Duration connectionTimeout,
                               Duration requestTimeout,
@@ -76,6 +82,8 @@ public class UnboundidLdapClient implements LdapClient {
                               boolean trustAllCerts) {
     this.searchUserBaseDN = searchUserBaseDN;
     this.searchGroupBaseDN = searchGroupBaseDN;
+    this.uidAttribute = uidAttribute;
+    this.uniqueMemberAttribute = uniqueMemberAttribute;
     this.timeout = requestTimeout.toMillis();
 
     AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
@@ -143,7 +151,7 @@ public class UnboundidLdapClient implements LdapClient {
             new UnboundidSearchResultListener(searchUser),
             searchUserBaseDN,
             SearchScope.SUB,
-            String.format("(uid=%s)", uid)
+            String.format("(%s=%s)", uidAttribute, uid)
           )),
         timeout
       );
@@ -180,7 +188,7 @@ public class UnboundidLdapClient implements LdapClient {
             new UnboundidSearchResultListener(searchGroups),
             searchGroupBaseDN,
             SearchScope.SUB,
-            String.format("(&(cn=*)(uniqueMember=%s))", user.getDN())
+            String.format("(&(cn=*)(%s=%s))", uniqueMemberAttribute, user.getDN())
           )),
         timeout
       );
@@ -301,6 +309,8 @@ public class UnboundidLdapClient implements LdapClient {
     private final String host;
     private final String searchUserBaseDN;
     private final String searchGroupBaseDN;
+    private String uidAttribute;
+    private String uniqueMemberAttribute;
     private int port;
     private Optional<BindDnPassword> bindDnPassword = Optional.empty();
     private int poolSize;
@@ -313,6 +323,16 @@ public class UnboundidLdapClient implements LdapClient {
       this.host = host;
       this.searchUserBaseDN = searchUserBaseDN;
       this.searchGroupBaseDN = searchGroupBaseDN;
+    }
+
+    public Builder setUidAttribute(String attribute) {
+      this.uidAttribute = attribute;
+      return this;
+    }
+
+    public Builder setUniqueMemberAttribute(String attribute) {
+      this.uniqueMemberAttribute = attribute;
+      return this;
     }
 
     public Builder setPort(int port) {
@@ -352,7 +372,8 @@ public class UnboundidLdapClient implements LdapClient {
 
     public UnboundidLdapClient build() {
       return new UnboundidLdapClient(host, port, bindDnPassword, searchUserBaseDN, searchGroupBaseDN,
-                                     poolSize, connectionTimeout, requestTimeout, sslEnabled, trustAllCerts
+                                     uidAttribute, uniqueMemberAttribute, poolSize, connectionTimeout,
+                                     requestTimeout, sslEnabled, trustAllCerts
       );
     }
   }

--- a/src/test/resources/test_elasticsearch.yml
+++ b/src/test/resources/test_elasticsearch.yml
@@ -139,6 +139,8 @@ readonlyrest:
       bind_password: "password"                                 # skip for anonymous bind
       search_user_base_DN: "ou=People,dc=example,dc=com"
       search_groups_base_DN: "ou=Groups,dc=example,dc=com"
+      user_id_attribute: "uid"                                  # default "uid"
+      unique_member_attribute: "uniqueMember"                   # default "uniqueMember"
       connection_pool_size: 10                                  # default 30
       connection_timeout_in_sec: 10                             # default 1
       request_timeout_in_sec: 10                                # default 1


### PR DESCRIPTION
Now you can override `uid` and `uniqueMember` attributes.
Example config:
```
    ldaps:
    - name: ldap1
      host: {LDAP1}
      port: 389                                                 # default 389
      ssl_enabled: false                                        # default true
      ssl_trust_all_certs: true                                 # default false
      bind_dn: "cn=admin,dc=example,dc=com"                     # skip for anonymous bind
      bind_password: "password"                                 # skip for anonymous bind
      search_user_base_DN: "ou=People,dc=example,dc=com"
      search_groups_base_DN: "ou=Groups,dc=example,dc=com"
      user_id_attribute: "uid"                                  # default "uid"
      unique_member_attribute: "uniqueMember"                   # default "uniqueMember"
      connection_pool_size: 10                                  # default 30
      connection_timeout_in_sec: 10                             # default 1
      request_timeout_in_sec: 10                                # default 1
      cache_ttl_in_sec: 60                                      # default 0 - cache disabled
```