### PR TITLE
Order sync rules: auth, inspect, mutate

### DIFF
--- a/src/test/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/BlockTest.java
+++ b/src/test/java/org/elasticsearch/plugin/readonlyrest/acl/blocks/BlockTest.java
@@ -1,0 +1,55 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package org.elasticsearch.plugin.readonlyrest.acl.blocks;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.readonlyrest.acl.blocks.rules.SyncRule;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import junit.framework.TestCase;
+
+public class BlockTest extends TestCase {
+
+	public void testRulesShallFollowAuthInspectMutateOrder() {
+		Settings settings = Settings.builder()
+		                        .put("name", "Dummy block")
+		                        .put("type", "allow")
+		                        .put("proxy_auth", "*")
+		                        .putArray("indices_rewrite", "needle", "replacement")
+		                        .putArray("indices", "allowed-index")
+		                        .build();
+		Block block = new Block(settings, Lists.newArrayList(), Lists.newArrayList(),
+		                        null, null, null);
+
+		Set<SyncRule> syncRules = block.getSyncRules();
+		Iterator<SyncRule> it = syncRules.iterator();
+		SyncRule auth = it.next();
+		SyncRule inspect = it.next();
+		SyncRule mutate = it.next();
+
+		Assert.assertEquals("proxy_auth", auth.getKey());
+		Assert.assertEquals("indices", inspect.getKey());
+		Assert.assertEquals("indices_rewrite", mutate.getKey());
+	}
+
+}


### PR DESCRIPTION
This PR implements the order suggested in the forum thread.

1. Auth related rules - those that implement UserRule interface
2. Rules that inspect the request - all the remaining ones
3. Rewrite rules - currently, only IndicesRewrite

I hope all the rules are in the appropiate set 😄 

The first commit also implements a test case to ensure the established order is observed.

Unfortunately, due to the previous implementation using a hashmap,  there's a slight chance the test case would pass even if implementation under test doesn't guarantee the required order.