### PR TITLE
Password ending in ':' fails

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugin/readonlyrest/utils/BasicAuthUtils.java
+++ b/core/src/main/java/org/elasticsearch/plugin/readonlyrest/utils/BasicAuthUtils.java
@@ -35,6 +35,10 @@ public class BasicAuthUtils {
       .flatMap(BasicAuthUtils::getInterestingPartOfBasicAuthValue)
       .flatMap(BasicAuth::fromBase64Value);
   }
+  
+  public static Optional<BasicAuth> getBasicAuthFromString(String base64Value) {
+	  return BasicAuth.fromBase64Value(base64Value);
+  }
 
   private static Optional<String> getInterestingPartOfBasicAuthValue(String basicAuthValue) {
     if (basicAuthValue == null || basicAuthValue.trim().length() == 0 || !basicAuthValue.contains("Basic ")) {
@@ -59,20 +63,17 @@ public class BasicAuthUtils {
 
     private BasicAuth(String base64Value) {
       this.base64Value = base64Value;
-      String[] splitted = new String(Base64.getDecoder().decode(base64Value)).split(":");
-      if (splitted.length != 2) {
+      String decoded = new String(Base64.getDecoder().decode(base64Value));
+      int index = decoded.indexOf(":");
+      if (index == -1 || index == decoded.length() - 1) {
         throw new IllegalArgumentException("Cannot extract user name from base auth header");
       }
-      this.userName = splitted[0];
-      this.password = splitted[1];
+      this.userName = decoded.substring(0,index);
+      this.password = decoded.substring(index + 1);
     }
 
     public static Optional<BasicAuth> fromBase64Value(String base64Value) {
-      try {
         return Optional.of(new BasicAuth(base64Value));
-      } catch (IllegalArgumentException ex) {
-        return Optional.empty();
-      }
     }
 
     public String getBase64Value() {

--- a/core/src/test/java/org/elasticsearch/plugin/readonlyrest/utils/BasicAuthUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/plugin/readonlyrest/utils/BasicAuthUtilsTests.java
@@ -1,0 +1,36 @@
+package org.elasticsearch.plugin.readonlyrest.utils;
+
+import static org.junit.Assert.*;
+
+import java.util.Base64;
+import java.util.Optional;
+
+import org.elasticsearch.plugin.readonlyrest.utils.BasicAuthUtils;
+import org.elasticsearch.plugin.readonlyrest.utils.BasicAuthUtils.BasicAuth;
+import org.junit.Test;
+
+public class BasicAuthUtilsTests {
+
+	@Test
+	public void basicAuthValidTest() {
+		String user = "admin";
+		String passwd = "passwd:";
+		byte[] authToken = ((String) user + ":" + passwd).getBytes();
+		String base64Value = new String(Base64.getEncoder().encodeToString(authToken));
+		Optional<BasicAuth> basicAuth = BasicAuthUtils.getBasicAuthFromString(base64Value);
+		
+		assertTrue( user.equals(basicAuth.get().getUserName()));
+		assertTrue( passwd.equals(basicAuth.get().getPassword()));
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void basicAuthInvalidTest() {
+		String user = "admin";
+		String passwd = "";
+		byte[] authToken = ((String) user + ":" + passwd).getBytes();
+		String base64Value = new String(Base64.getEncoder().encodeToString(authToken));
+		Optional<BasicAuth> basicAuth = BasicAuthUtils.getBasicAuthFromString(base64Value);
+	}
+
+
+}


### PR DESCRIPTION
When user has a password ending with ":" authentication fails.