### PR TITLE
(LDAP) Allow for fetching groups from a multi-value attribute on the user

### DIFF
--- a/core/src/main/java/tech/beshu/ror/acl/definitions/DefinitionsFactory.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/DefinitionsFactory.java
@@ -106,7 +106,9 @@ public class DefinitionsFactory implements LdapClientFactory,
               settings.getSearchGroupBaseDn(),
               settings.getUniqueMemberAttribute(),
               settings.getGroupSearchFilter(),
-              settings.getGroupNameAttribute()
+              settings.getGroupNameAttribute(),
+              settings.isGroupsFromUser(),
+              settings.getGroupsFromUserAttribute()
             ),
             settings.getSearchingUserSettings().map(s ->
                                                       new SearchingUserConfig(s.getDn(), s.getPassword())

--- a/core/src/main/java/tech/beshu/ror/acl/definitions/ldaps/unboundid/UnboundidGroupsProviderLdapClient.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/ldaps/unboundid/UnboundidGroupsProviderLdapClient.java
@@ -18,6 +18,8 @@ package tech.beshu.ror.acl.definitions.ldaps.unboundid;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.DN;
 import com.unboundid.ldap.sdk.Filter;
 import com.unboundid.ldap.sdk.LDAPException;
 import com.unboundid.ldap.sdk.SearchRequest;
@@ -35,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class UnboundidGroupsProviderLdapClient extends UnboundidAuthenticationLdapClient implements GroupsProviderLdapClient {
 
@@ -67,48 +70,103 @@ public class UnboundidGroupsProviderLdapClient extends UnboundidAuthenticationLd
   @Override
   public CompletableFuture<Set<LdapGroup>> userGroups(LdapUser user) {
     try {
-
-      // Compose the search string
-      String searchString = String.format(
-        "(&%s(%s=%s))",
-        userGroupsSearchFilterConfig.getGroupSearchFilter(),
-        userGroupsSearchFilterConfig.getUniqueMemberAttribute(),
-        Filter.encodeValue(user.getDN())
-      );
-      logger.debug("LDAP search string: " + searchString + "  |  groupNameAttr: " + userGroupsSearchFilterConfig.getGroupNameAttribute());
-
-      // Request formulation
-      CompletableFuture<List<SearchResultEntry>> searchGroups = new CompletableFuture<>();
-      connection.getConnectionPool().processRequestsAsync(
-        Lists.newArrayList(
-          new SearchRequest(
-            new UnboundidSearchResultListener(searchGroups),
-            userGroupsSearchFilterConfig.getSearchGroupBaseDN(),
-            SearchScope.SUB,
-            searchString,
-            userGroupsSearchFilterConfig.getGroupNameAttribute()
-          )),
-        requestTimeout.toMillis()
-      );
-
-      // Response adaptation
-      return searchGroups
-        .thenApply(groupSearchResult -> groupSearchResult.stream()
-          .map(it -> Optional.ofNullable(it.getAttributeValue(userGroupsSearchFilterConfig.getGroupNameAttribute())))
-          .filter(Optional::isPresent)
-          .map(Optional::get)
-          .map(LdapGroup::new)
-          .collect(Collectors.toSet()))
-        .exceptionally(t -> {
-          if (t instanceof LdapSearchError) {
-            LdapSearchError error = (LdapSearchError) t;
-            logger.debug(String.format("LDAP getting user groups returned error [%s]", error.getResultString()));
-          }
-          return Sets.newHashSet();
-        });
+      return userGroupsSearchFilterConfig.isGroupsFromUser() ? getGroupsFromUser(user) : getGroups(user);
     } catch (LDAPException e) {
       logger.error("LDAP getting user groups operation failed", e);
       return CompletableFuture.completedFuture(Sets.newHashSet());
     }
   }
+
+  private CompletableFuture<Set<LdapGroup>> getGroups(LdapUser user) throws LDAPException {
+    // Compose the search string
+    String searchString = String.format(
+        "(&%s(%s=%s))",
+        userGroupsSearchFilterConfig.getGroupSearchFilter(),
+        userGroupsSearchFilterConfig.getUniqueMemberAttribute(),
+        Filter.encodeValue(user.getDN())
+    );
+    logger.debug("LDAP search string: " + searchString + "  |  groupNameAttr: " + userGroupsSearchFilterConfig.getGroupNameAttribute());
+
+    // Request formulation
+    CompletableFuture<List<SearchResultEntry>> searchGroups = new CompletableFuture<>();
+    connection.getConnectionPool().processRequestsAsync(
+      Lists.newArrayList(
+        new SearchRequest(
+          new UnboundidSearchResultListener(searchGroups),
+          userGroupsSearchFilterConfig.getSearchGroupBaseDN(),
+          SearchScope.SUB,
+          searchString,
+          userGroupsSearchFilterConfig.getGroupNameAttribute()
+        )),
+      requestTimeout.toMillis()
+    );
+
+    // Response adaptation
+    return searchGroups
+      .thenApply(groupSearchResult -> groupSearchResult.stream()
+        .map(it -> Optional.ofNullable(it.getAttributeValue(userGroupsSearchFilterConfig.getGroupNameAttribute())))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(LdapGroup::new)
+        .collect(Collectors.toSet()))
+      .exceptionally(t -> {
+        if (t instanceof LdapSearchError) {
+          LdapSearchError error = (LdapSearchError) t;
+          logger.debug(String.format("LDAP getting user groups returned error [%s]", error.getResultString()));
+        }
+        return Sets.newHashSet();
+      });
+  }
+
+  private CompletableFuture<Set<LdapGroup>> getGroupsFromUser(LdapUser user) throws LDAPException {
+    logger.debug("LDAP search string: " + user.getDN() + "  |  groupsFromUserAttribute: " + userGroupsSearchFilterConfig.getGroupsFromUserAttribute());
+
+    // Request formulation
+    CompletableFuture<List<SearchResultEntry>> searchGroups = new CompletableFuture<>();
+    connection.getConnectionPool().processRequestsAsync(
+        Lists.newArrayList(
+            new SearchRequest(
+                new UnboundidSearchResultListener(searchGroups),
+                user.getDN(),
+                SearchScope.BASE,
+                "(objectClass=*)",
+                userGroupsSearchFilterConfig.getGroupsFromUserAttribute()
+            )),
+        requestTimeout.toMillis()
+    );
+
+    // Response adaptation
+    return searchGroups
+      .thenApply(groupSearchResult -> groupSearchResult.stream()
+        .map(it -> Stream.of(it.getAttributeValues(userGroupsSearchFilterConfig.getGroupsFromUserAttribute())))
+        .reduce(Stream.empty(), Stream::concat)
+        .map(this::getGroupNameFromDN)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(LdapGroup::new)
+        .collect(Collectors.toSet()))
+      .exceptionally(t -> {
+        if (t instanceof LdapSearchError) {
+          LdapSearchError error = (LdapSearchError) t;
+          logger.debug(String.format("LDAP getting user groups returned error [%s]", error.getResultString()));
+        }
+        return Sets.newHashSet();
+      });
+  }
+
+  private Optional<String> getGroupNameFromDN(String stringDn) {
+    try {
+      DN dn = new DN(stringDn);
+      if (dn.isDescendantOf(userGroupsSearchFilterConfig.getSearchGroupBaseDN(), false)) {
+        return Stream.of(dn.getRDN().getAttributes())
+            .filter(attribute -> userGroupsSearchFilterConfig.getGroupNameAttribute().equals(attribute.getBaseName()))
+            .map(Attribute::getValue)
+            .findFirst();
+      }
+    } catch (Exception e) {
+      /* ignore */
+    }
+    return Optional.empty();
+  }
+
 }

--- a/core/src/main/java/tech/beshu/ror/acl/definitions/ldaps/unboundid/UserGroupsSearchFilterConfig.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/ldaps/unboundid/UserGroupsSearchFilterConfig.java
@@ -24,13 +24,18 @@ public class UserGroupsSearchFilterConfig {
   private final String uniqueMemberAttribute;
   private final String groupSearchFilter;
   private final String groupNameAttribute;
+  private final boolean isGroupsFromUser;
+  private final String groupsFromUserAttribute;
 
   public UserGroupsSearchFilterConfig(String searchGroupBaseDN, String uniqueMemberAttribute,
-                                      String groupSearchFilter, String groupNameAttribute) {
+                                      String groupSearchFilter, String groupNameAttribute,
+                                      boolean isGroupsFromUser, String groupsFromUserAttribute) {
     this.searchGroupBaseDN = searchGroupBaseDN;
     this.uniqueMemberAttribute = uniqueMemberAttribute;
     this.groupSearchFilter = groupSearchFilter;
     this.groupNameAttribute = groupNameAttribute;
+    this.isGroupsFromUser = isGroupsFromUser;
+    this.groupsFromUserAttribute = groupsFromUserAttribute;
   }
 
   public String getGroupNameAttribute() {
@@ -49,12 +54,22 @@ public class UserGroupsSearchFilterConfig {
     return uniqueMemberAttribute;
   }
 
+  public boolean isGroupsFromUser () {
+    return isGroupsFromUser;
+  }
+
+  public String getGroupsFromUserAttribute() {
+    return groupsFromUserAttribute;
+  }
+
   public static class Builder {
 
     private final String searchGroupBaseDN;
     private String uniqueMemberAttribute = GroupsProviderLdapSettings.UNIQUE_MEMBER_DEFAULT;
     private String groupSearchFilter = GroupsProviderLdapSettings.GROUP_SEARCH_FILTER_DEFAULT;
     private String groupNameAttribute = GroupsProviderLdapSettings.GROUP_NAME_ATTRIBUTE_DEFAULT;
+    private boolean isGroupsFromUser = GroupsProviderLdapSettings.GROUPS_FROM_USER_DEFAULT;
+    private String groupsFromUserAttribute = GroupsProviderLdapSettings.GROUPS_FROM_USER_ATTRIBUTE_DEFAULT;
 
     public Builder(String searchGroupBaseDN) {
       this.searchGroupBaseDN = searchGroupBaseDN;
@@ -75,8 +90,18 @@ public class UserGroupsSearchFilterConfig {
       return this;
     }
 
+    public Builder setIsGroupsFromUser(boolean isGroupsFromUser) {
+      this.isGroupsFromUser = isGroupsFromUser;
+      return this;
+    }
+
+    public Builder setGroupsFromUserAttribute(String groupsFromUserAttribute) {
+      this.groupsFromUserAttribute = groupsFromUserAttribute;
+      return this;
+    }
+
     public UserGroupsSearchFilterConfig build() {
-      return new UserGroupsSearchFilterConfig(searchGroupBaseDN, uniqueMemberAttribute, groupSearchFilter, groupNameAttribute);
+      return new UserGroupsSearchFilterConfig(searchGroupBaseDN, uniqueMemberAttribute, groupSearchFilter, groupNameAttribute, isGroupsFromUser, groupsFromUserAttribute);
     }
   }
 }

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/GroupsProviderLdapSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/GroupsProviderLdapSettings.java
@@ -27,10 +27,16 @@ public class GroupsProviderLdapSettings extends AuthenticationLdapSettings {
   private static final String UNIQUE_MEMBER = "unique_member_attribute";
   private static final String GROUP_SEARCH_FILTER = "group_search_filter";
   private static final String GROUP_NAME_ATTRIBUTE = "group_name_attribute";
+  private static final String GROUPS_FROM_USER = "groups_from_user";
+  public static final boolean GROUPS_FROM_USER_DEFAULT = false;
+  private static final String GROUPS_FROM_USER_ATTRIBUTE = "groups_from_user_attribute";
+  public static final String GROUPS_FROM_USER_ATTRIBUTE_DEFAULT = "memberOf";
   private final String searchGroupBaseDn;
   private final String uniqueMemberAttribute;
   private final String groupSearchFilter;
   private final String groupNameAttribute;
+  private final boolean groupsFromUser;
+  private final String groupsFromUserAttribute;
 
   public GroupsProviderLdapSettings(RawSettings settings) {
     super(settings);
@@ -38,6 +44,8 @@ public class GroupsProviderLdapSettings extends AuthenticationLdapSettings {
     this.uniqueMemberAttribute = settings.stringOpt(UNIQUE_MEMBER).orElse(UNIQUE_MEMBER_DEFAULT);
     this.groupSearchFilter = settings.stringOpt(GROUP_SEARCH_FILTER).orElse(GROUP_SEARCH_FILTER_DEFAULT);
     this.groupNameAttribute = settings.stringOpt(GROUP_NAME_ATTRIBUTE).orElse(GROUP_NAME_ATTRIBUTE_DEFAULT);
+    this.groupsFromUser = settings.booleanOpt(GROUPS_FROM_USER).orElse(GROUPS_FROM_USER_DEFAULT);
+    this.groupsFromUserAttribute = settings.stringOpt(GROUPS_FROM_USER_ATTRIBUTE).orElse(GROUPS_FROM_USER_ATTRIBUTE_DEFAULT);
   }
 
   public static boolean canBeCreated(RawSettings settings) {
@@ -58,5 +66,13 @@ public class GroupsProviderLdapSettings extends AuthenticationLdapSettings {
 
   public String getGroupSearchFilter() {
     return groupSearchFilter;
+  }
+
+  public boolean isGroupsFromUser() {
+    return groupsFromUser;
+  }
+
+  public String getGroupsFromUserAttribute() {
+    return groupsFromUserAttribute;
   }
 }

--- a/core/src/test/resources/test_example.ldif
+++ b/core/src/test/resources/test_example.ldif
@@ -14,6 +14,8 @@ cn: Morgan Freeman
 sn: Freeman
 uid: morgan
 userPassword:: e1NNRDV9cTg2ZHlvbGRRRk5pZ04waVprMDgzYnZrVEY3bFdacFk=
+memberOf: cn=group2,ou=Groups,dc=example,dc=com
+memberOf: cn=group3,ou=Groups,dc=example,dc=com
 
 dn: cn=Eric Cartman,ou=People,dc=example,dc=com
 objectClass: top
@@ -24,6 +26,8 @@ cn: Eric Cartman
 sn: Cartman
 uid: cartman
 userPassword:: e1NNRDV9czdnM0NVekVCMGQxMm5CM0N3VGFrQmp3K0VGMTE3cFg=
+memberOf: cn=group1,ou=Groups,dc=example,dc=com
+memberOf: cn=group3,ou=Groups,dc=example,dc=com
 
 dn: cn=Chanandler Bong,ou=People,dc=example,dc=com
 objectClass: top
@@ -34,6 +38,8 @@ cn: Chanandler Bong
 sn: Bong
 uid: bong
 userPassword:: e1NIQX1zOXFuZTB3RXFWVWJoNEhRTVpIK0NZOHlYbWM9
+memberOf: cn=group1,ou=Groups,dc=example,dc=com
+memberOf: cn=group3,ou=Groups,dc=example,dc=com
 
 dn: cn=Viktor Navorski (Tom Hanks),ou=People,dc=example,dc=com
 objectClass: top
@@ -43,6 +49,17 @@ objectClass: inetOrgPerson
 cn: Viktor Navorski (Tom Hanks)
 sn: Navorski
 uid: viktor
+userPassword:: e1NNRDV9czdnM0NVekVCMGQxMm5CM0N3VGFrQmp3K0VGMTE3cFg=
+memberOf: cn=group3,ou=Groups,dc=example,dc=com
+
+dn: cn=Groupless User,ou=People,dc=example,dc=com
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: Groupless User
+sn: User
+uid: guser
 userPassword:: e1NNRDV9czdnM0NVekVCMGQxMm5CM0N3VGFrQmp3K0VGMTE3cFg=
 
 dn: ou=Groups,dc=example,dc=com


### PR DESCRIPTION
This allows the LDAP authorization connector to fetch groups from the memberOf or other multi-value attribute from the user rather than doing the lookup on a group. This is especially helpful when using recursive groups.

Two new configuration options have been added:

`groups_from_user` a boolean used to toggle between fetching from the group or from an attribute on the user. Default: `false` (fetch from group, current functionality)

`groups_from_user_attribute` a string used to indicate which property to check on the user. Default: `memberOf`

The `UnboundidGroupsProviderLdapClientTests` class has been largely refactored to include the new functionality and ensure parity. Additionally a check for empty results has been added.