### PR TITLE
(JWT) Allow validating RSA, DSA, and other KeyFactory supported algor…

### DIFF
--- a/core/src/main/java/tech/beshu/ror/settings/rules/JwtAuthRuleSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/rules/JwtAuthRuleSettings.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 public class JwtAuthRuleSettings implements RuleSettings, AuthKeyProviderSettings {
 
   public static final String ATTRIBUTE_NAME = "jwt_auth";
+  public static final String SIGNATURE_ALGO = "signature_algo";
   public static final String SIGNATURE_KEY = "signature_key";
   public static final String USER_CLAIM = "user_claim";
   public static final String HEADER_NAME = "header_name";
@@ -34,13 +35,15 @@ public class JwtAuthRuleSettings implements RuleSettings, AuthKeyProviderSetting
 
   private final byte[] key;
   private final Optional<String> userClaim;
+  private final Optional<String> algo;
   private final String headerName;
 
-  private JwtAuthRuleSettings(String key, Optional<String> userClaim, Optional<String> headerName) {
+  private JwtAuthRuleSettings(String key,  Optional<String> algo, Optional<String> userClaim, Optional<String> headerName) {
     if (Strings.isNullOrEmpty(key))
       throw new SettingsMalformedException(
         "Attribute '" + SIGNATURE_KEY + "' shall not evaluate to an empty string");
     this.key = key.getBytes();
+    this.algo = algo;
     this.userClaim = userClaim;
     this.headerName = headerName.orElse(DEFAULT_HEADER_NAME);
   }
@@ -48,6 +51,7 @@ public class JwtAuthRuleSettings implements RuleSettings, AuthKeyProviderSetting
   public static JwtAuthRuleSettings from(RawSettings settings) {
     return new JwtAuthRuleSettings(
       evalPrefixedSignatureKey(ensureString(settings, SIGNATURE_KEY)),
+      settings.stringOpt(SIGNATURE_ALGO),
       settings.stringOpt(USER_CLAIM),
       settings.stringOpt(HEADER_NAME)
     );
@@ -70,6 +74,10 @@ public class JwtAuthRuleSettings implements RuleSettings, AuthKeyProviderSetting
 
   public byte[] getKey() {
     return key;
+  }
+
+  public Optional<String> getAlgo() {
+   return algo;
   }
 
   public Optional<String> getUserClaim() {


### PR DESCRIPTION
The current JWT validator only support HMAC signatures. Extend to allow RSA, DSA, and other algorithms supported by the Java KeyFactory via the new `signature_algo` configuration option.

RSA Example:
```
      access_control_rules:
      - name: "jwt-rsa"
        jwt_auth:
          signature_key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAswRJV9YwPCPCu0173Slfp5L7vv6iTmm+dGrE6Q0/1pUVbC/sGS4ItfkereULuLYViN0pqhGNxNAPZabjOL5SAlIqq5j05vlGONaEBTM+F8KD+HEIfxP4OZwcpC92D6pM2FKCYUZJx/pZ2sMxFGn7qR9DdCnPHq7hvvaTNAZCw8HlBax8182NwuNty0EpuZmHoJTGCZRXJifb6DJwlJgz2OKkzZRcvFOJLARQQNfqv6aRannjmrAJR4e5ZywLUe/CP6xi4VQwagIDtFtrDjAzCz+fOJZdM68mK7pQOzhLEBmKkHqUplEvaZtNuN3ZdIMLLhmG3NJuSz9uARf0S0NqSQIDAQAB"
          signature_algo: RSA
          user_claim: preferred_username
```