### PR TITLE
jwt_auth: role-based access controls

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-echo ">>> ($0) RUNNINIG CONTINUOUS INTEGRATION"
+echo ">>> ($0) RUNNING CONTINUOUS INTEGRATION"
 
 # Log file friendly Gradle output
 export TERM=dumb

--- a/commons/src/main/java/tech/beshu/ror/commons/settings/RawSettings.java
+++ b/commons/src/main/java/tech/beshu/ror/commons/settings/RawSettings.java
@@ -135,7 +135,21 @@ public class RawSettings {
   }
 
   public Optional<Set<?>> notEmptySetOpt(String attr) {
-    return opt(attr).flatMap(obj -> ((Set<?>) obj).isEmpty() ? Optional.empty() : Optional.of((Set<?>) obj));
+    return opt(attr).flatMap(value -> {
+      HashSet<Object> set = new HashSet<>();
+      if (value instanceof List<?>) {
+        List<?> l = (List<?>) value;
+        set.addAll(l);
+        if (set.size() < l.size()) {
+          throw new SettingsMalformedException("Set value of '" + attr + "' attribute cannot contain duplicates");
+        }
+      }
+      else if (value instanceof String) {
+        set.add(value);
+      }
+      if (set.isEmpty()) return Optional.empty();
+      return Optional.of(set);
+    });
   }
 
   public Set<?> notEmptySetReq(String attr) {

--- a/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthSyncRule.java
+++ b/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthSyncRule.java
@@ -16,7 +16,23 @@
  */
 package tech.beshu.ror.acl.blocks.rules.impl;
 
+import java.security.AccessController;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.PrivilegedAction;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
@@ -33,14 +49,6 @@ import tech.beshu.ror.commons.shims.es.ESContext;
 import tech.beshu.ror.commons.shims.es.LoggerShim;
 import tech.beshu.ror.requestcontext.RequestContext;
 import tech.beshu.ror.settings.rules.JwtAuthRuleSettings;
-
-import java.security.AccessController;
-import java.security.Key;
-import java.security.KeyFactory;
-import java.security.PrivilegedAction;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
-import java.util.Optional;
 
 public class JwtAuthSyncRule extends UserRule implements Authentication {
 
@@ -61,7 +69,6 @@ public class JwtAuthSyncRule extends UserRule implements Authentication {
     }
 
     return Optional.ofNullable(Strings.emptyToNull(authHeader));
-
   }
 
   private Optional<Key> getSigningKeyForAlgo() {
@@ -80,9 +87,8 @@ public class JwtAuthSyncRule extends UserRule implements Authentication {
 
   @Override
   public RuleExitResult match(RequestContext rc) {
-    Optional<String> token = Optional.of(rc.getHeaders())
-      .map(m -> m.get(settings.getHeaderName()))
-      .flatMap(JwtAuthSyncRule::extractToken);
+    Optional<String> token = Optional.of(rc.getHeaders()).map(m -> m.get(settings.getHeaderName()))
+        .flatMap(JwtAuthSyncRule::extractToken);
 
     if (!token.isPresent()) {
       logger.debug("Authorization header is missing or does not contain a bearer token");
@@ -90,22 +96,35 @@ public class JwtAuthSyncRule extends UserRule implements Authentication {
     }
 
     try {
-      Jws<Claims> jws = AccessController.doPrivileged(
-        (PrivilegedAction<Jws<Claims>>) () -> {
-          JwtParser parser = Jwts.parser();
-          if (signingKeyForAlgo.isPresent()) {
-            parser.setSigningKey(signingKeyForAlgo.get());
-          } else {
-            parser.setSigningKey(settings.getKey());
-          }
-          return parser.parseClaimsJws(token.get());
+      Jws<Claims> jws = AccessController.doPrivileged((PrivilegedAction<Jws<Claims>>) () -> {
+        JwtParser parser = Jwts.parser();
+        if (signingKeyForAlgo.isPresent()) {
+          parser.setSigningKey(signingKeyForAlgo.get());
+        } else {
+          parser.setSigningKey(settings.getKey());
         }
-      );
+        return parser.parseClaimsJws(token.get());
+      });
 
       Optional<String> user = settings.getUserClaim().map(claim -> jws.getBody().get(claim, String.class));
       if (settings.getUserClaim().isPresent())
-        if (!user.isPresent()) return NO_MATCH;
-        else rc.setLoggedInUser(new LoggedUser(user.get()));
+        if (!user.isPresent())
+          return NO_MATCH;
+        else
+          rc.setLoggedInUser(new LoggedUser(user.get()));
+
+      Optional<Set<String>> roles = this.extractRoles(jws);
+      if (settings.getRolesClaim().isPresent()) {
+        if (!roles.isPresent())
+          return NO_MATCH; 
+      }
+      if (!settings.getRoles().isEmpty()) {
+        if (!roles.isPresent())
+          return NO_MATCH;
+        Set<String> r = roles.get();
+        if (r.isEmpty() || Sets.intersection(r, settings.getRoles()).isEmpty())
+          return NO_MATCH;
+      }
 
       return MATCH;
     } catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | SignatureException e) {
@@ -116,5 +135,38 @@ public class JwtAuthSyncRule extends UserRule implements Authentication {
   @Override
   public String getKey() {
     return settings.getName();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Optional<Set<String>> extractRoles(Jws<Claims> jws) {
+    // Get claim roles
+    Optional<Object> rolesObj = settings.getRolesClaim().map(claim -> {
+      String[] path = claim.split("[.]");
+      if (path.length < 2)
+        return jws.getBody().get(claim, Object.class);
+      else {
+        // Ok we need to parse all sub sequent path
+        Object value = jws.getBody().get(path[0], Object.class);
+        int i = 1;
+        while (i < path.length && value != null && value instanceof Map<?, ?>) {
+          value = ((Map<String, Object>) value).get(path[i]);
+          i++;
+        }
+        return value;
+      }
+    });
+
+    // Casting
+    return rolesObj.flatMap(value ->{
+      Set<String> set = new HashSet<>();
+
+      if (value instanceof Collection<?>) {
+        set.addAll((Collection<String>) value);
+      } else if (value instanceof String) {
+        set.add((String) value);
+      }
+      if (set.isEmpty()) return Optional.empty();
+      return Optional.of(set);
+    });
   }
 }

--- a/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthSyncRule.java
+++ b/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthSyncRule.java
@@ -27,9 +27,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 
@@ -114,16 +112,16 @@ public class JwtAuthSyncRule extends UserRule implements Authentication {
           rc.setLoggedInUser(new LoggedUser(user.get()));
 
       Optional<Set<String>> roles = this.extractRoles(jws);
-      if (settings.getRolesClaim().isPresent()) {
-        if (!roles.isPresent())
-          return NO_MATCH; 
-      }
+      if (settings.getRolesClaim().isPresent() && !roles.isPresent())
+          return NO_MATCH;
       if (!settings.getRoles().isEmpty()) {
-        if (!roles.isPresent())
+        if (!roles.isPresent()) {
           return NO_MATCH;
-        Set<String> r = roles.get();
-        if (r.isEmpty() || Sets.intersection(r, settings.getRoles()).isEmpty())
-          return NO_MATCH;
+        } else {
+          Set<String> r = roles.get();
+          if (r.isEmpty() || Sets.intersection(r, settings.getRoles()).isEmpty())
+            return NO_MATCH;
+        }
       }
 
       return MATCH;

--- a/core/src/main/java/tech/beshu/ror/settings/RorSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/RorSettings.java
@@ -22,6 +22,7 @@ import tech.beshu.ror.commons.Verbosity;
 import tech.beshu.ror.commons.settings.RawSettings;
 import tech.beshu.ror.commons.settings.SettingsMalformedException;
 import tech.beshu.ror.settings.definitions.ExternalAuthenticationServiceSettingsCollection;
+import tech.beshu.ror.settings.definitions.JwtAuthDefinitionSettingsCollection;
 import tech.beshu.ror.settings.definitions.LdapSettingsCollection;
 import tech.beshu.ror.settings.definitions.ProxyAuthDefinitionSettingsCollection;
 import tech.beshu.ror.settings.definitions.UserGroupsProviderSettingsCollection;
@@ -69,10 +70,13 @@ public class RorSettings {
     LdapSettingsCollection ldapSettingsCollection = LdapSettingsCollection.from(raw);
     UserGroupsProviderSettingsCollection userGroupsProviderSettingsCollection = UserGroupsProviderSettingsCollection.from(raw);
     ProxyAuthDefinitionSettingsCollection proxyAuthDefinitionSettingsCollection = ProxyAuthDefinitionSettingsCollection.from(raw);
-    ExternalAuthenticationServiceSettingsCollection externalAuthenticationServiceSettingsCollection =
-      ExternalAuthenticationServiceSettingsCollection.from(raw);
-    AuthMethodCreatorsRegistry authMethodCreatorsRegistry =
-      new AuthMethodCreatorsRegistry(proxyAuthDefinitionSettingsCollection, ldapSettingsCollection);
+    ExternalAuthenticationServiceSettingsCollection externalAuthenticationServiceSettingsCollection = ExternalAuthenticationServiceSettingsCollection.from(raw);
+    JwtAuthDefinitionSettingsCollection jwtAuthDefinitionSettingsCollection = JwtAuthDefinitionSettingsCollection.from(raw);
+    AuthMethodCreatorsRegistry authMethodCreatorsRegistry = new AuthMethodCreatorsRegistry(
+      proxyAuthDefinitionSettingsCollection, 
+      ldapSettingsCollection,
+      jwtAuthDefinitionSettingsCollection
+    );
 
     this.forbiddenMessage = raw.stringOpt(ATTRIBUTE_FORBIDDEN_RESPONSE).orElse(DEFAULT_FORBIDDEN_MESSAGE);
     this.blocksSettings = raw.notEmptyListOpt(BlockSettings.ATTRIBUTE_NAME).orElse(DEFAULT_BLOCK_SETTINGS).stream()

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
@@ -17,10 +17,7 @@
 
 package tech.beshu.ror.settings.definitions;
 
-import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
-
 import com.google.common.base.Strings;
 
 import tech.beshu.ror.commons.settings.RawSettings;
@@ -46,7 +43,6 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
     private final Optional<String> algo;
     private final String headerName;
 
-    @SuppressWarnings("unchecked")
     public JwtAuthDefinitionSettings(RawSettings settings) {
         this.name = settings.stringReq(NAME);
 

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
@@ -1,0 +1,107 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.settings.definitions;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.base.Strings;
+
+import tech.beshu.ror.commons.settings.RawSettings;
+import tech.beshu.ror.commons.settings.SettingsMalformedException;
+import tech.beshu.ror.settings.rules.NamedSettings;
+
+/**
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public class JwtAuthDefinitionSettings implements NamedSettings {
+    private static final String NAME = "name";
+    private static final String SIGNATURE_ALGO = "signature_algo";
+    private static final String SIGNATURE_KEY = "signature_key";
+    private static final String USER_CLAIM = "user_claim";
+    private static final String ROLES_CLAIM = "roles_claim";
+    private static final String HEADER_NAME = "header_name";
+    private static final String DEFAULT_HEADER_NAME = "Authorization";
+
+    private final String name;
+    private final byte[] key;
+    private final Optional<String> userClaim;
+    private final Optional<String> rolesClaim;
+    private final Optional<String> algo;
+    private final String headerName;
+
+    @SuppressWarnings("unchecked")
+    public JwtAuthDefinitionSettings(RawSettings settings) {
+        this.name = settings.stringReq(NAME);
+
+        String key = evalPrefixedSignatureKey(ensureString(settings, SIGNATURE_KEY));
+        if (Strings.isNullOrEmpty(key))
+            throw new SettingsMalformedException(
+                    "Attribute '" + SIGNATURE_KEY + "' shall not evaluate to an empty string");
+
+        this.key = key.getBytes();
+        this.algo = settings.stringOpt(SIGNATURE_ALGO);
+        this.userClaim = settings.stringOpt(USER_CLAIM);
+        this.rolesClaim = settings.stringOpt(ROLES_CLAIM);
+        this.headerName = settings.stringOpt(HEADER_NAME).orElse(DEFAULT_HEADER_NAME);
+    }
+
+    private static String ensureString(RawSettings settings, String key) {
+        Object value = settings.req(key);
+        if (value instanceof String)
+            return (String) value;
+        else
+            throw new SettingsMalformedException(
+                    "Attribute '" + key + "' must be a string; if it looks like a number try adding quotation marks");
+    }
+
+    private static String evalPrefixedSignatureKey(String s) {
+        if (s.startsWith("text:"))
+            return s.substring(5);
+        else if (s.startsWith("env:"))
+            return System.getenv(s.substring(4));
+        else
+            return s;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public byte[] getKey() {
+        return key;
+    }
+
+    public Optional<String> getAlgo() {
+        return algo;
+    }
+
+    public Optional<String> getUserClaim() {
+        return userClaim;
+    }
+
+    public Optional<String> getRolesClaim() {
+        return rolesClaim;
+    }
+
+    public String getHeaderName() {
+        return headerName;
+    }
+}

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettingsCollection.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettingsCollection.java
@@ -1,0 +1,67 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.settings.definitions;
+
+import com.google.common.collect.Lists;
+import tech.beshu.ror.commons.settings.RawSettings;
+import tech.beshu.ror.commons.settings.SettingsMalformedException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.jooq.lambda.Seq.seq;
+
+/**
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public class JwtAuthDefinitionSettingsCollection {
+    public static final String ATTRIBUTE_NAME = "jwt";
+
+    private final Map<String, JwtAuthDefinitionSettings> jwtAuthConfigsSettingsMap;
+
+    private JwtAuthDefinitionSettingsCollection(List<JwtAuthDefinitionSettings> jwtAuthConfigsSettings) {
+        validate(jwtAuthConfigsSettings);
+        this.jwtAuthConfigsSettingsMap = seq(jwtAuthConfigsSettings).toMap(JwtAuthDefinitionSettings::getName, Function.identity());
+    }
+
+    @SuppressWarnings("unchecked")
+    public static JwtAuthDefinitionSettingsCollection from(RawSettings data) {
+        return data.notEmptyListOpt(ATTRIBUTE_NAME)
+                .map(list -> list.stream().map(l -> new JwtAuthDefinitionSettings(new RawSettings((Map<String, ?>) l)))
+                        .collect(Collectors.toList()))
+                .map(JwtAuthDefinitionSettingsCollection::new)
+                .orElse(new JwtAuthDefinitionSettingsCollection(Lists.newArrayList()));
+    }
+
+    public JwtAuthDefinitionSettings get(String name) {
+        if (!jwtAuthConfigsSettingsMap.containsKey(name))
+            throw new SettingsMalformedException("Cannot find Jwt Auth Config definition with name '" + name + "'");
+        return jwtAuthConfigsSettingsMap.get(name);
+    }
+
+    private void validate(List<JwtAuthDefinitionSettings> jwtAuthConfigsSettings) {
+        List<String> names = seq(jwtAuthConfigsSettings)
+                            .map(JwtAuthDefinitionSettings::getName)
+                            .collect(Collectors.toList());
+        if (names.stream().distinct().count() != names.size()) {
+            throw new SettingsMalformedException("Duplicated Jwt Auth Config name in '" + ATTRIBUTE_NAME + "' section");
+        }
+    }
+}

--- a/core/src/test/java/tech/beshu/ror/acl/blocks/BlockTest.java
+++ b/core/src/test/java/tech/beshu/ror/acl/blocks/BlockTest.java
@@ -49,7 +49,7 @@ public class BlockTest {
                                    "proxy_auth: \"*\"\n" +
                                    "indices: [\"allowed-index\"]"
         ),
-        new AuthMethodCreatorsRegistry(ProxyAuthDefinitionSettingsCollection.from(RawSettings.empty()), null),
+        new AuthMethodCreatorsRegistry(ProxyAuthDefinitionSettingsCollection.from(RawSettings.empty()), null, null),
         null, null,
         null, null
       ),

--- a/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthRuleTests.java
+++ b/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthRuleTests.java
@@ -16,8 +16,11 @@
  */
 package tech.beshu.ror.acl.blocks.rules.impl;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.jayway.jsonpath.internal.function.text.Length;
+
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.junit.Test;
@@ -30,6 +33,7 @@ import tech.beshu.ror.commons.settings.RawSettings;
 import tech.beshu.ror.commons.settings.SettingsMalformedException;
 import tech.beshu.ror.mocks.MockedESContext;
 import tech.beshu.ror.requestcontext.RequestContext;
+import tech.beshu.ror.settings.definitions.JwtAuthDefinitionSettingsCollection;
 import tech.beshu.ror.settings.rules.JwtAuthRuleSettings;
 
 import java.security.KeyException;
@@ -37,8 +41,12 @@ import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
@@ -50,15 +58,18 @@ import static org.mockito.Mockito.when;
 
 public class JwtAuthRuleTests {
 
-  private static final String SETTINGS_SIGNATURE_KEY = JwtAuthRuleSettings.SIGNATURE_KEY;
-  private static final String SETTINGS_SIGNATURE_ALGO = JwtAuthRuleSettings.SIGNATURE_ALGO;
-  private static final String SETTINGS_USER_CLAIM = JwtAuthRuleSettings.USER_CLAIM;
+  private static final String JWT_NAME = "test-jwt";;
+  private static final String SETTINGS_SIGNATURE_KEY = "signature_key";
+  private static final String SETTINGS_SIGNATURE_ALGO = "signature_algo";
+  private static final String SETTINGS_USER_CLAIM = "user_claim";
+  private static final String SETTINGS_ROLES_CLAIM = "roles_claim";
   private static final String ALGO = "HS256";
   private static final String SECRET = "123456";
   private static final String BAD_SECRET = "abcdef";
   private static final String SUBJECT = "test";
   private static final String USER_CLAIM = "user";
   private static final String USER1 = "user1";
+  private static final String ROLES_CLAIM = "roles";
   private static final String EMPTY_VAR = "HOPE_THIS_VARIABLE_IS_NOT_IN_THE_ENVIRONMENT";
 
   @Test
@@ -211,7 +222,7 @@ public class JwtAuthRuleTests {
   @Test
   public void shouldSupportTextPrefixInSignatureKey() {
     RawSettings raw = makeSettings(SETTINGS_SIGNATURE_KEY, "text:" + SECRET);
-    JwtAuthRuleSettings settings = JwtAuthRuleSettings.from(raw);
+    JwtAuthRuleSettings settings = JwtAuthRuleSettings.from(JWT_NAME, JwtAuthDefinitionSettingsCollection.from(raw));
     assertArrayEquals(SECRET.getBytes(), settings.getKey());
   }
 
@@ -229,26 +240,174 @@ public class JwtAuthRuleTests {
     /* ************************************************************* */
 
     RawSettings raw = makeSettings(SETTINGS_SIGNATURE_KEY, "env:" + variable);
-    JwtAuthRuleSettings settings = JwtAuthRuleSettings.from(raw);
+    JwtAuthRuleSettings settings = JwtAuthRuleSettings.from(JWT_NAME, JwtAuthDefinitionSettingsCollection.from(raw));
     assertArrayEquals(value.getBytes(), settings.getKey());
   }
 
   @Test(expected = SettingsMalformedException.class)
   public void shouldFailWhenKeytIsEmpty() {
     RawSettings raw = makeSettings(SETTINGS_SIGNATURE_KEY, "");
-    JwtAuthRuleSettings.from(raw);
+    JwtAuthRuleSettings.from(JWT_NAME, JwtAuthDefinitionSettingsCollection.from(raw));
   }
 
   @Test(expected = SettingsMalformedException.class)
   public void shouldFailWhenKeyFromEnvironmentIsEmpty() {
     RawSettings raw = makeSettings(SETTINGS_SIGNATURE_KEY, "env:" + EMPTY_VAR);
-    JwtAuthRuleSettings.from(raw);
+    JwtAuthRuleSettings.from(JWT_NAME, JwtAuthDefinitionSettingsCollection.from(raw));
   }
 
   @Test(expected = SettingsMalformedException.class)
   public void shouldFailInAControlledFashionWhenKeyIsNotAString() {
-    RawSettings raw = makeSettings(false, SETTINGS_SIGNATURE_KEY, "123456");
-    JwtAuthRuleSettings.from(raw);
+    RawSettings raw = makeSettings(JWT_NAME, false, SETTINGS_SIGNATURE_KEY, "123456");
+    JwtAuthRuleSettings.from(JWT_NAME, JwtAuthDefinitionSettingsCollection.from(raw));
+  }
+
+  @Test
+  public void shouldAcceptRolesClaimSetting() {
+    RawSettings settings = makeSettings(
+      SETTINGS_SIGNATURE_KEY, SECRET, 
+      SETTINGS_ROLES_CLAIM, ROLES_CLAIM
+    );
+    Optional<SyncRule> rule = makeRule(settings);
+    assertTrue(rule.isPresent());
+  }
+
+  @Test
+  public void shouldRejectTokenWithoutTheConfiguredRolesClaim() {
+    String token = Jwts.builder()
+      .setSubject(SUBJECT)
+      .signWith(SignatureAlgorithm.valueOf(ALGO), SECRET.getBytes())
+      .compact();
+    RawSettings settings = makeSettings(
+      SETTINGS_SIGNATURE_KEY, SECRET,
+      SETTINGS_ROLES_CLAIM, ROLES_CLAIM
+    );
+    RequestContext rc = getMock(token);
+
+    Optional<SyncRule> rule = makeRule(settings);
+    Optional<RuleExitResult> res = rule.map(r -> r.match(rc));
+    rc.commit();
+
+    assertTrue(rule.isPresent());
+    assertTrue(res.isPresent());
+    assertFalse(res.get().isMatch());
+  }
+
+  @Test
+  public void shouldAuthorizeWithASimpleRole() {
+    String token = Jwts.builder()
+      .setSubject(SUBJECT)
+      .claim(ROLES_CLAIM, "role_test")
+      .signWith(SignatureAlgorithm.valueOf(ALGO), SECRET.getBytes())
+      .compact();
+    RawSettings settings = makeSettings(
+      SETTINGS_SIGNATURE_KEY, SECRET,
+      SETTINGS_ROLES_CLAIM, ROLES_CLAIM
+    );
+    RequestContext rc = getMock(token);
+
+    Optional<SyncRule> rule = makeRule(JWT_NAME, "role_test", settings);
+    Optional<RuleExitResult> res = rule.map(r -> r.match(rc));
+    rc.commit();
+
+    assertTrue(rule.isPresent());
+    assertTrue(res.isPresent());
+    assertTrue(res.get().isMatch());
+  }
+
+  @Test
+  public void shouldAuthorizeWithAnArrayOfRoles() {
+    String token = Jwts.builder()
+      .setSubject(SUBJECT)
+      .claim(ROLES_CLAIM, new String[] { "role_1", "role_2", "role_test" })
+      .signWith(SignatureAlgorithm.valueOf(ALGO), SECRET.getBytes())
+      .compact();
+    RawSettings settings = makeSettings(
+      SETTINGS_SIGNATURE_KEY, SECRET,
+      SETTINGS_ROLES_CLAIM, ROLES_CLAIM
+    );
+    RequestContext rc = getMock(token);
+
+    Optional<SyncRule> rule = makeRule(JWT_NAME, "role_test", settings);
+    Optional<RuleExitResult> res = rule.map(r -> r.match(rc));
+    rc.commit();
+
+    assertTrue(rule.isPresent());
+    assertTrue(res.isPresent());
+    assertTrue(res.get().isMatch());
+  }
+
+  @Test
+  public void shouldAuthorizeWithIntersectRoles() {
+    String token = Jwts.builder()
+      .setSubject(SUBJECT)
+      .claim(ROLES_CLAIM, new String[] { "role_1", "role_2", "role_test" })
+      .signWith(SignatureAlgorithm.valueOf(ALGO), SECRET.getBytes())
+      .compact();
+
+    RawSettings settings = makeSettings(
+      SETTINGS_SIGNATURE_KEY, SECRET,
+      SETTINGS_ROLES_CLAIM, ROLES_CLAIM
+    );
+    RequestContext rc = getMock(token);
+
+    Optional<SyncRule> rule = makeRule(JWT_NAME, "role_3,role_test", settings);
+    Optional<RuleExitResult> res = rule.map(r -> r.match(rc));
+    rc.commit();
+
+    assertTrue(rule.isPresent());
+    assertTrue(res.isPresent());
+    assertTrue(res.get().isMatch());
+  }
+
+  @Test
+  public void shouldRejectTokenWithWrongPath() {
+    Map<String, String> m = new HashMap<>();
+    m.put("subpath", "role_test");
+
+    String token = Jwts.builder()
+      .setSubject(SUBJECT)
+      .claim("roles", m)
+      .signWith(SignatureAlgorithm.valueOf(ALGO), SECRET.getBytes())
+      .compact();
+    RawSettings settings = makeSettings(
+      SETTINGS_SIGNATURE_KEY, SECRET,
+      SETTINGS_ROLES_CLAIM, "roles.wrong_path"
+    );
+    RequestContext rc = getMock(token);
+
+    Optional<SyncRule> rule = makeRule(JWT_NAME, "role_test", settings);
+    Optional<RuleExitResult> res = rule.map(r -> r.match(rc));
+    rc.commit();
+
+    assertTrue(rule.isPresent());
+    assertTrue(res.isPresent());
+    assertFalse(res.get().isMatch());
+  }
+
+  @Test
+  public void shouldAuthorizeWithRolePath() {
+    Map<String, String> m = new HashMap<>();
+    m.put("subpath", "role_test");
+
+    String token = Jwts.builder()
+      .setSubject(SUBJECT)
+      .claim("roles", m)
+      .signWith(SignatureAlgorithm.valueOf(ALGO), SECRET.getBytes())
+      .compact();
+    RawSettings settings = makeSettings(
+      SETTINGS_SIGNATURE_KEY, SECRET,
+      SETTINGS_ROLES_CLAIM, "roles.subpath"
+    );
+    RequestContext rc = getMock(token);
+
+    Optional<SyncRule> rule = makeRule(JWT_NAME, "role_test", settings);
+    Optional<RuleExitResult> res = rule.map(r -> r.match(rc));
+    rc.commit();
+
+    assertTrue(rule.isPresent());
+    assertTrue(res.isPresent());
+    assertTrue(res.get().isMatch());
   }
 
   private RequestContext getMock(String token) {
@@ -258,16 +417,18 @@ public class JwtAuthRuleTests {
   }
 
   private RawSettings makeSettings(String... kvp) {
-    return makeSettings(true, kvp);
+    return makeSettings(JWT_NAME, true, kvp);
   }
 
-  private RawSettings makeSettings(boolean escapeValues, String... kvp) {
+  private RawSettings makeSettings(String jwtName, boolean escapeValues, String... kvp) {
     assert kvp.length % 2 == 0;
 
     StringBuilder sb = new StringBuilder();
+    sb.append("jwt:\n");
+    sb.append(" - name: ").append(jwtName).append("\n");
+
     for (int i = 0; i < kvp.length; i += 2) {
-      sb.append(kvp[i]);
-      sb.append(": ");
+      sb.append("   ").append(kvp[i]).append(": ");
       if (escapeValues) sb.append('"');
       sb.append(kvp[i + 1]);
       if (escapeValues) sb.append('"');
@@ -278,8 +439,36 @@ public class JwtAuthRuleTests {
   }
 
   private Optional<SyncRule> makeRule(RawSettings settings) {
+   return makeRule(JWT_NAME, null, settings);
+  }
+
+  private Optional<SyncRule> makeRule(String jwtName, String forRoles, RawSettings settings) {
     try {
-      return Optional.of(new JwtAuthSyncRule(JwtAuthRuleSettings.from(settings), MockedESContext.INSTANCE));
+      StringBuilder sb = new StringBuilder();
+      sb.append("jwt_auth:\n");
+      sb.append("  name: \"").append(jwtName).append("\"\n");
+      if (forRoles != null) {
+        sb.append("  roles: ");
+        String[] roles = forRoles.split(",");
+        if (roles.length > 1) 
+          sb.append("[");
+        for (int i = 0; i < roles.length; i ++) {
+          sb.append('"')
+            .append(roles[i])
+            .append('"')
+            .append(", ");
+        }
+        sb.setLength(sb.length() - 2);  // remove last ", "
+        if (roles.length > 1) 
+          sb.append("]");
+        sb.append("\n");
+      }
+
+      return Optional.of(new JwtAuthSyncRule(
+        JwtAuthRuleSettings.from(TestUtils.fromYAMLString(sb.toString()).inner(JwtAuthRuleSettings.ATTRIBUTE_NAME),
+        JwtAuthDefinitionSettingsCollection.from(settings)), 
+        MockedESContext.INSTANCE
+      ));
     } catch (Exception e) {
       e.printStackTrace();
       return Optional.empty();
@@ -329,5 +518,4 @@ public class JwtAuthRuleTests {
   private String getInvalidPublicKey() {
     return getRsaPublicKey().replace("QAB", "QAC");
   }
-
 }

--- a/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthRuleTests.java
+++ b/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthRuleTests.java
@@ -16,15 +16,15 @@
  */
 package tech.beshu.ror.acl.blocks.rules.impl;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import com.jayway.jsonpath.internal.function.text.Length;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import tech.beshu.ror.TestUtils;
 import tech.beshu.ror.acl.blocks.rules.RuleExitResult;
 import tech.beshu.ror.acl.blocks.rules.SyncRule;
@@ -45,8 +45,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;

--- a/integration-tests/src/test/java/tech/beshu/ror/integration/JwtAuthTests.java
+++ b/integration-tests/src/test/java/tech/beshu/ror/integration/JwtAuthTests.java
@@ -38,9 +38,11 @@ public class JwtAuthTests {
 
   private static final String ALGO = "HS256";
   private static final String KEY = "123456";
+  private static final String KEY_ROLE = "123456789";
   private static final String WRONG_KEY = "abcdef";
   private static final String SUBJECT = "test";
   private static final String USER_CLAIM = "user";
+  private static final String ROLES_CLAIM = "roles";
   private static final String EXP = "exp";
 
   @ClassRule
@@ -93,6 +95,23 @@ public class JwtAuthTests {
     assertEquals(401, sc);
   }
 
+  @Test
+  public void rejectTokenWithoutRolesClaim() throws Exception {
+    int sc = test(makeToken(KEY_ROLE));
+    assertEquals(401, sc);
+  }
+
+  @Test
+  public void rejectTokenWithWrongRolesClaim() throws Exception {
+    int sc = test(makeToken(KEY_ROLE, makeClaimMap(ROLES_CLAIM, "role_wrong")));
+    assertEquals(401, sc);
+  }
+
+  @Test
+  public void acceptValidTokentWithRolesClaim() throws Exception {
+    int sc = test(makeToken(KEY, makeClaimMap(USER_CLAIM, "role_viewer")));
+    assertEquals(200, sc);
+  }
 
   private int test(Optional<String> token) throws Exception {
     return test(token, Optional.empty(), true);

--- a/integration-tests/src/test/resources/jwt_auth/elasticsearch.yml
+++ b/integration-tests/src/test/resources/jwt_auth/elasticsearch.yml
@@ -18,13 +18,31 @@ readonlyrest:
 
     - name: Valid JWT token is present
       type: allow
-      jwt_auth:
-        signature_key: "123456"
-        user_claim: user
+      jwt_auth: "jwt1"
 
     - name: Valid JWT token is present in custom header
       type: allow
-      jwt_auth:
-        header_name: x-custom-header
-        signature_key: "123456"
-        user_claim: user
+      jwt_auth: "jwt2"
+
+    - name: Valid JWT token is present with roles
+      type: allow
+      jwt_auth: 
+        name: "jwt3"
+        roles: ["role_viewer"]
+
+  jwt:
+    - name: jwt1
+      signature_key: "123456"
+      user_claim: user
+
+    - name: jwt2
+      header_name: x-custom-header
+      signature_key: "123456"
+      user_claim: user
+
+    - name: jwt3
+      signature_key: "123456789"
+      user_claim: user
+      roles_claim: roles
+
+


### PR DESCRIPTION
Hi !

This pull request allows a role base-based access controls on a jwt_auth.
Instead of repeat the jwt_auth configuration,  we define now a list of jwts providers

This is an example for a keycloak provider.


```yml
readonlyrest:
    access_control_rules:
    - name: Valid JWT token with a viewer role
      jwt_auth:
        name: "keycloak"
        roles: ["viewer"]
    jwt: 
    - name: keycloak
      signature_algo: RSA
      signature_key: "your_signature"
      user_claim: email
      roles_claim: resource_access.client-app.roles
      header_name: Authorization
```
