### PR TITLE
Document level security for ROR

### DIFF
--- a/commons/src/main/java/tech/beshu/ror/commons/Constants.java
+++ b/commons/src/main/java/tech/beshu/ror/commons/Constants.java
@@ -39,7 +39,8 @@ public class Constants {
   public final static String REST_REFRESH_PATH = "/_readonlyrest/admin/refreshconfig";
   public final static String REST_CONFIGURATION_PATH = "/_readonlyrest/admin/config";
   public final static String REST_CONFIGURATION_FILE_PATH = "/_readonlyrest/admin/config/file";
-
+  public final static String FILTER_TRANSIENT = "_filter";
+  
   public static String makeAbsolutePath(String path, String basePath) {
 
     if (Strings.isNullOrEmpty(basePath)) {

--- a/commons/src/main/java/tech/beshu/ror/commons/utils/FilterTransient.java
+++ b/commons/src/main/java/tech/beshu/ror/commons/utils/FilterTransient.java
@@ -1,0 +1,90 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.commons.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Base64;
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+// We created a class to store the filter instead of using a String var
+// because we'll use it in further updates for the field level security
+public class FilterTransient implements Serializable {
+	private static final long serialVersionUID = -8866625802695512997L;
+    private final String _filter;
+    
+    public static FilterTransient CreateFromFilter(String filter) {
+    	return new FilterTransient(filter);
+    }
+    
+    private FilterTransient(String filter) {
+        this._filter = filter;
+    }
+
+    public String getFilter() {
+    	return this._filter;
+    }
+    
+    @Override
+    public String toString() {
+        return "{ "
+                + "FILTER: " + this._filter
+                + "}";
+    }
+    
+    public String serialize() {
+    	ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos;
+		try {
+			oos = new ObjectOutputStream(baos);
+			oos.writeObject(this);
+	        oos.close();
+		} catch (IOException e) {
+			return null;
+		}
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+    
+    public static FilterTransient Deserialize(String userTransientEncoded) {
+    	FilterTransient userTransient = null;
+    	if (userTransientEncoded == null)
+    		return userTransient;
+		try {
+			byte [] data = Base64.getDecoder().decode(userTransientEncoded);
+	        ObjectInputStream ois;
+			ois = new ObjectInputStream(new ByteArrayInputStream(data));
+			Object o  = ois.readObject();
+			if (o instanceof FilterTransient) {
+				userTransient = (FilterTransient) o;
+			}
+	        ois.close();
+		} catch (IOException e) {
+			throw new IllegalStateException("Couldn't extract userTransient from threadContext.");
+		} catch (ClassNotFoundException e) {
+			throw new IllegalStateException("Couldn't extract userTransient from threadContext.");
+		}
+		return userTransient;
+
+    }
+}

--- a/core/src/main/java/tech/beshu/ror/acl/blocks/Block.java
+++ b/core/src/main/java/tech/beshu/ror/acl/blocks/Block.java
@@ -17,7 +17,20 @@
 
 package tech.beshu.ror.acl.blocks;
 
+import static tech.beshu.ror.commons.Constants.ANSI_CYAN;
+import static tech.beshu.ror.commons.Constants.ANSI_RESET;
+import static tech.beshu.ror.commons.Constants.ANSI_YELLOW;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
 import com.google.common.collect.Sets;
+
 import tech.beshu.ror.acl.BlockPolicy;
 import tech.beshu.ror.acl.blocks.rules.AsyncRule;
 import tech.beshu.ror.acl.blocks.rules.RuleExitResult;
@@ -33,17 +46,6 @@ import tech.beshu.ror.requestcontext.RequestContext;
 import tech.beshu.ror.settings.BlockSettings;
 import tech.beshu.ror.utils.FuturesSequencer;
 import tech.beshu.ror.utils.RulesUtils;
-
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
-import static tech.beshu.ror.commons.Constants.ANSI_CYAN;
-import static tech.beshu.ror.commons.Constants.ANSI_RESET;
-import static tech.beshu.ror.commons.Constants.ANSI_YELLOW;
 
 /**
  * Created by sscarduzio on 13/02/2016.
@@ -97,6 +99,10 @@ public class Block {
 
   public Verbosity getVerbosity() {
     return settings.getVerbosity();
+  }
+  
+  public Optional<String> getFilter() {
+	  return settings.getFilter();
   }
 
   public boolean isAuthHeaderAccepted() {

--- a/es51x/src/main/java/tech/beshu/ror/es/ReadonlyRestPlugin.java
+++ b/es51x/src/main/java/tech/beshu/ror/es/ReadonlyRestPlugin.java
@@ -17,7 +17,12 @@
 
 package tech.beshu.ror.es;
 
-import com.google.common.collect.Lists;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -27,7 +32,9 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
@@ -36,22 +43,24 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.threadpool.ThreadPool;
+
+import com.google.common.collect.Lists;
+
 import tech.beshu.ror.configuration.AllowedSettings;
 import tech.beshu.ror.es.rradmin.RRAdminAction;
 import tech.beshu.ror.es.rradmin.TransportRRAdminAction;
 import tech.beshu.ror.es.rradmin.rest.RestRRAdminAction;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
+import tech.beshu.ror.es.security.RoleIndexSearcherWrapper;
 
 public class ReadonlyRestPlugin extends Plugin
   implements ScriptPlugin, ActionPlugin, IngestPlugin, NetworkPlugin {
 
+  private Settings settings;
+  private Environment environment;
+  
   public ReadonlyRestPlugin(Settings s) {
+	  this.settings = s;
+	  this.environment = new Environment(s);
   }
 
   @Override
@@ -111,4 +120,15 @@ public class ReadonlyRestPlugin extends Plugin
     return Lists.newArrayList(ReadonlyRestAction.class, RestRRAdminAction.class);
   }
 
+  @Override
+  public void onIndexModule(IndexModule module) {
+	module.setSearcherWrapper(indexService -> {
+		try {
+			return new RoleIndexSearcherWrapper(indexService, this.settings, this.environment);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	});
+  }
 }

--- a/es51x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
+++ b/es51x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
@@ -1,0 +1,130 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.ExceptionsHelper;
+
+// Code based on
+// https://stackoverflow.com/questions/40949286/apply-lucene-query-on-bits
+// https://github.com/apache/lucene-solr/blob/master/lucene/misc/src/java/org/apache/lucene/index/PKIndexSplitter.java#L127-L170
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public final class DocumentFilterReader extends FilterLeafReader {
+
+    private final Bits liveDocs;
+    private final int numDocs;
+
+    public static DocumentFilterDirectoryReader wrap(DirectoryReader in, Query filterQuery) throws IOException {
+        return new DocumentFilterDirectoryReader(in, filterQuery);
+    }
+
+    private DocumentFilterReader(LeafReader reader, Query query) throws IOException {
+        super(reader);
+        final IndexSearcher searcher = new IndexSearcher(this);
+        searcher.setQueryCache(null);
+        final boolean needsScores = false;
+        final Weight preserveWeight = searcher.createNormalizedWeight(query, needsScores);
+
+        final int maxDoc = this.in.maxDoc();
+        final FixedBitSet bits = new FixedBitSet(maxDoc);
+        final Scorer preverveScorer = preserveWeight.scorer(this.getContext());
+        if (preverveScorer != null) {
+            bits.or(preverveScorer.iterator());
+        }
+
+        if (in.hasDeletions()) {
+            final Bits oldLiveDocs = in.getLiveDocs();
+            assert oldLiveDocs != null;
+            final DocIdSetIterator it = new BitSetIterator(bits, 0L);
+            for (int i = it.nextDoc(); i != DocIdSetIterator.NO_MORE_DOCS; i = it.nextDoc()) {
+                if (!oldLiveDocs.get(i)) {
+                    bits.clear(i);
+                }
+            }
+        }
+
+        this.liveDocs = bits;
+        this.numDocs = bits.cardinality();
+    }
+
+    @Override
+    public int numDocs() {
+        return numDocs;
+    }
+
+    @Override
+    public Bits getLiveDocs() {
+        return liveDocs;
+    }
+
+    @Override
+    public Object getCoreCacheKey() {
+        return this.in.getCoreCacheKey();
+    }
+    
+    private static final class DocumentFilterDirectorySubReader extends FilterDirectoryReader.SubReaderWrapper {
+        private final Query query;
+
+        public DocumentFilterDirectorySubReader(Query filterQuery) {
+            this.query = filterQuery;
+        }
+
+        @Override
+        public LeafReader wrap(LeafReader reader) {
+            try {
+                return new DocumentFilterReader(reader, this.query);
+            } catch (Exception e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+        }
+    }
+
+    public static final class DocumentFilterDirectoryReader extends FilterDirectoryReader {
+        private final Query filterQuery;
+        
+        DocumentFilterDirectoryReader(DirectoryReader in, Query filterQuery) throws IOException {
+            super(in, new DocumentFilterDirectorySubReader(filterQuery));
+            this.filterQuery = filterQuery;
+        }
+
+        @Override
+        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+            return new DocumentFilterDirectoryReader(in, this.filterQuery);
+        }
+        
+        @Override 
+        public Object getCoreCacheKey() {
+            return this.in.getCoreCacheKey();
+        }
+    }
+}

--- a/es51x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
+++ b/es51x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
@@ -1,0 +1,122 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.EngineException;
+import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.shard.IndexSearcherWrapper;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardUtils;
+
+import com.unboundid.util.args.ArgumentException;
+
+import tech.beshu.ror.commons.Constants;
+import tech.beshu.ror.commons.settings.BasicSettings;
+import tech.beshu.ror.commons.shims.es.LoggerShim;
+import tech.beshu.ror.commons.utils.FilterTransient;
+import tech.beshu.ror.es.ESContextImpl;
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public class RoleIndexSearcherWrapper extends IndexSearcherWrapper {
+    private final LoggerShim logger;
+    private final Function<ShardId, QueryShardContext> queryShardContextProvider;
+    private final ThreadContext threadContext;
+	private final Boolean enabled;
+	
+	public RoleIndexSearcherWrapper(IndexService indexService, Settings s, Environment env) throws Exception {
+        if (indexService == null) {
+            throw new ArgumentException("Please provide an indexService");
+        }
+		Logger logger = Loggers.getLogger(this.getClass(), new String[0]);
+		logger.info("Create new RoleIndexSearcher wrapper, [{}]", indexService.getIndexSettings().getIndex().getName());
+        this.queryShardContextProvider = shardId -> indexService.newQueryShardContext(shardId.id(), null, null);
+        this.threadContext = indexService.getThreadPool().getThreadContext();
+		
+		this.logger = ESContextImpl.mkLoggerShim(logger);
+		BasicSettings baseSettings = BasicSettings.fromFile(this.logger, env.configFile().toAbsolutePath(), s.getAsStructuredMap());
+		this.enabled = baseSettings.isEnabled();
+	}
+
+	@Override
+	protected DirectoryReader wrap(DirectoryReader reader) {
+		if (!this.enabled) {
+			logger.warn("Document filtering not available. Return defaut reader");
+			return reader;
+		}
+
+		FilterTransient userTransient = FilterTransient.Deserialize(threadContext.getHeader(Constants.FILTER_TRANSIENT));
+		if (userTransient == null) {
+			logger.warn("Couldn't extract userTransient from threadContext.");
+			return reader;
+		}
+
+        ShardId shardId = ShardUtils.extractShardId(reader);
+		if (shardId == null) {
+			throw new IllegalStateException(
+					LoggerMessageFormat.format("Couldn't extract shardId from reader [{}]", new Object[] { reader }));
+		}
+		String filter = userTransient.getFilter();
+
+		if (filter == null || filter.equals("")) {
+			return reader;
+        }
+		
+		try {
+			BooleanQuery.Builder boolQuery = new BooleanQuery.Builder();
+            boolQuery.setMinimumNumberShouldMatch(1);
+            QueryShardContext queryShardContext = this.queryShardContextProvider.apply(shardId);
+            XContentParser parser = XContentFactory.xContent(filter).createParser(filter);
+            QueryBuilder queryBuilder = queryShardContext.newParseContext(parser).parseInnerQueryBuilder().get();
+            ParsedQuery parsedQuery = queryShardContext.toFilter(queryBuilder);
+			boolQuery.add(parsedQuery.query(), BooleanClause.Occur.SHOULD);
+            reader = DocumentFilterReader.wrap(reader, new ConstantScoreQuery(boolQuery.build()));
+			return reader;
+		} catch (IOException e) {
+			this.logger.error("Unable to setup document security");
+			throw ExceptionsHelper.convertToElastic((Exception) e);
+		}
+    }
+
+	@Override
+	protected IndexSearcher wrap(IndexSearcher indexSearcher) throws EngineException {
+		return indexSearcher;
+    }
+}

--- a/es52x/src/main/java/tech/beshu/ror/es/IndexLevelActionFilter.java
+++ b/es52x/src/main/java/tech/beshu/ror/es/IndexLevelActionFilter.java
@@ -17,11 +17,18 @@
 
 package tech.beshu.ror.es;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.client.node.NodeClient;
@@ -36,17 +43,16 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+
 import tech.beshu.ror.acl.ACL;
+import tech.beshu.ror.acl.blocks.BlockExitResult;
+import tech.beshu.ror.commons.Constants;
 import tech.beshu.ror.commons.settings.BasicSettings;
 import tech.beshu.ror.commons.settings.RawSettings;
 import tech.beshu.ror.commons.shims.es.ACLHandler;
 import tech.beshu.ror.commons.shims.es.ESContext;
 import tech.beshu.ror.commons.shims.es.LoggerShim;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
+import tech.beshu.ror.commons.utils.FilterTransient;
 
 
 /**
@@ -178,6 +184,29 @@ public class IndexLevelActionFilter extends AbstractComponent implements ActionF
       public void onAllow(Object blockExitResult) {
         boolean hasProceeded = false;
         try {
+        	// Cache disabling for those 2 kind of request is crucial for
+        	// document level security to work. Otherwise we'd get an answer from
+        	// the cache some times and would not be filtered
+        	if (request instanceof SearchRequest) {
+				((SearchRequest)request).requestCache(Boolean.FALSE);
+			} else if (request instanceof MultiSearchRequest) {
+				for (SearchRequest sr : ((MultiSearchRequest)request).requests()) {
+					sr.requestCache(Boolean.FALSE);
+				}
+			}
+
+        	if (blockExitResult instanceof BlockExitResult) {
+        		BlockExitResult ber = (BlockExitResult) blockExitResult;
+        		Optional<String> filter = ber.getBlock().getFilter();
+        		if (filter.isPresent()) {
+        			String encodedUser = FilterTransient.CreateFromFilter(filter.get()).serialize();
+        			if (encodedUser == null) 
+						logger.error("Error while serializing user transient");
+					if (threadPool.getThreadContext().getHeader(Constants.FILTER_TRANSIENT) == null) {
+						threadPool.getThreadContext().putHeader(Constants.FILTER_TRANSIENT, encodedUser);
+					}
+        		}
+        	}
           //         @SuppressWarnings("unchecked")
 //          ActionListener<Response> aclActionListener = (ActionListener<Response>) new ACLActionListener(
 //            request, (ActionListener<ActionResponse>) listener, rc, blockExitResult, context, acl

--- a/es52x/src/main/java/tech/beshu/ror/es/ReadonlyRestPlugin.java
+++ b/es52x/src/main/java/tech/beshu/ror/es/ReadonlyRestPlugin.java
@@ -17,6 +17,14 @@
 
 package tech.beshu.ror.es;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -28,7 +36,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
@@ -37,23 +47,22 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.threadpool.ThreadPool;
+
 import tech.beshu.ror.configuration.AllowedSettings;
 import tech.beshu.ror.es.rradmin.RRAdminAction;
 import tech.beshu.ror.es.rradmin.TransportRRAdminAction;
 import tech.beshu.ror.es.rradmin.rest.RestRRAdminAction;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
+import tech.beshu.ror.es.security.RoleIndexSearcherWrapper;
 
 public class ReadonlyRestPlugin extends Plugin
   implements ScriptPlugin, ActionPlugin, IngestPlugin, NetworkPlugin {
 
+  private Settings settings;
+  private Environment environment;
+  
   public ReadonlyRestPlugin(Settings s) {
+	  this.settings = s;
+	  this.environment = new Environment(s);
   }
 
   @Override
@@ -124,5 +133,17 @@ public class ReadonlyRestPlugin extends Plugin
       ThreadRepo.channel.set(channel);
       restHandler.handleRequest(request, channel, client);
     };
+  }
+  
+  @Override
+  public void onIndexModule(IndexModule module) {
+	module.setSearcherWrapper(indexService -> {
+		try {
+			return new RoleIndexSearcherWrapper(indexService, this.settings, this.environment);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	});
   }
 }

--- a/es52x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
+++ b/es52x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
@@ -1,0 +1,130 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.ExceptionsHelper;
+
+// Code based on
+// https://stackoverflow.com/questions/40949286/apply-lucene-query-on-bits
+// https://github.com/apache/lucene-solr/blob/master/lucene/misc/src/java/org/apache/lucene/index/PKIndexSplitter.java#L127-L170
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public final class DocumentFilterReader extends FilterLeafReader {
+
+    private final Bits liveDocs;
+    private final int numDocs;
+
+    public static DocumentFilterDirectoryReader wrap(DirectoryReader in, Query filterQuery) throws IOException {
+        return new DocumentFilterDirectoryReader(in, filterQuery);
+    }
+
+    private DocumentFilterReader(LeafReader reader, Query query) throws IOException {
+        super(reader);
+        final IndexSearcher searcher = new IndexSearcher(this);
+        searcher.setQueryCache(null);
+        final boolean needsScores = false;
+        final Weight preserveWeight = searcher.createNormalizedWeight(query, needsScores);
+
+        final int maxDoc = this.in.maxDoc();
+        final FixedBitSet bits = new FixedBitSet(maxDoc);
+        final Scorer preverveScorer = preserveWeight.scorer(this.getContext());
+        if (preverveScorer != null) {
+            bits.or(preverveScorer.iterator());
+        }
+
+        if (in.hasDeletions()) {
+            final Bits oldLiveDocs = in.getLiveDocs();
+            assert oldLiveDocs != null;
+            final DocIdSetIterator it = new BitSetIterator(bits, 0L);
+            for (int i = it.nextDoc(); i != DocIdSetIterator.NO_MORE_DOCS; i = it.nextDoc()) {
+                if (!oldLiveDocs.get(i)) {
+                    bits.clear(i);
+                }
+            }
+        }
+
+        this.liveDocs = bits;
+        this.numDocs = bits.cardinality();
+    }
+
+    @Override
+    public int numDocs() {
+        return numDocs;
+    }
+
+    @Override
+    public Bits getLiveDocs() {
+        return liveDocs;
+    }
+
+    @Override
+    public Object getCoreCacheKey() {
+        return this.in.getCoreCacheKey();
+    }
+    
+    private static final class DocumentFilterDirectorySubReader extends FilterDirectoryReader.SubReaderWrapper {
+        private final Query query;
+
+        public DocumentFilterDirectorySubReader(Query filterQuery) {
+            this.query = filterQuery;
+        }
+
+        @Override
+        public LeafReader wrap(LeafReader reader) {
+            try {
+                return new DocumentFilterReader(reader, this.query);
+            } catch (Exception e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+        }
+    }
+
+    public static final class DocumentFilterDirectoryReader extends FilterDirectoryReader {
+        private final Query filterQuery;
+        
+        DocumentFilterDirectoryReader(DirectoryReader in, Query filterQuery) throws IOException {
+            super(in, new DocumentFilterDirectorySubReader(filterQuery));
+            this.filterQuery = filterQuery;
+        }
+
+        @Override
+        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+            return new DocumentFilterDirectoryReader(in, this.filterQuery);
+        }
+        
+        @Override 
+        public Object getCoreCacheKey() {
+            return this.in.getCoreCacheKey();
+        }
+    }
+}

--- a/es52x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
+++ b/es52x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
@@ -1,0 +1,123 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.EngineException;
+import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.shard.IndexSearcherWrapper;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardUtils;
+
+import com.unboundid.util.args.ArgumentException;
+
+import tech.beshu.ror.commons.Constants;
+import tech.beshu.ror.commons.settings.BasicSettings;
+import tech.beshu.ror.commons.shims.es.LoggerShim;
+import tech.beshu.ror.commons.utils.FilterTransient;
+import tech.beshu.ror.es.ESContextImpl;
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public class RoleIndexSearcherWrapper extends IndexSearcherWrapper {
+    private final LoggerShim logger;
+    private final Function<ShardId, QueryShardContext> queryShardContextProvider;
+    private final ThreadContext threadContext;
+	private final Boolean enabled;
+	
+	public RoleIndexSearcherWrapper(IndexService indexService, Settings s, Environment env) throws Exception {
+        if (indexService == null) {
+            throw new ArgumentException("Please provide an indexService");
+        }
+		Logger logger = Loggers.getLogger(this.getClass(), new String[0]);
+		logger.info("Create new RoleIndexSearcher wrapper, [{}]", indexService.getIndexSettings().getIndex().getName());
+        this.queryShardContextProvider = shardId -> indexService.newQueryShardContext(shardId.id(), null, null);
+        this.threadContext = indexService.getThreadPool().getThreadContext();
+        logger.info("Create new RoleIndexSearcher wrapper, [{}]", indexService.getIndexSettings().getIndex().getName());
+		
+		this.logger = ESContextImpl.mkLoggerShim(logger);
+		BasicSettings baseSettings = BasicSettings.fromFile(this.logger, env.configFile().toAbsolutePath(), s.getAsStructuredMap());
+		this.enabled = baseSettings.isEnabled();
+	}
+
+	@Override
+	protected DirectoryReader wrap(DirectoryReader reader) {
+		if (!this.enabled) {
+			logger.warn("Document filtering not available. Return defaut reader");
+			return reader;
+		}
+
+		FilterTransient userTransient = FilterTransient.Deserialize(threadContext.getHeader(Constants.FILTER_TRANSIENT));
+		if (userTransient == null) {
+			logger.debug("Couldn't extract userTransient from threadContext.");
+			return reader;
+		}
+
+        ShardId shardId = ShardUtils.extractShardId(reader);
+		if (shardId == null) {
+			throw new IllegalStateException(
+					LoggerMessageFormat.format("Couldn't extract shardId from reader [{}]", new Object[] { reader }));
+		}
+		String filter = userTransient.getFilter();
+
+		if (filter == null || filter.equals("")) {
+			return reader;
+        }
+		
+		try {
+			BooleanQuery.Builder boolQuery = new BooleanQuery.Builder();
+            boolQuery.setMinimumNumberShouldMatch(1);
+            QueryShardContext queryShardContext = this.queryShardContextProvider.apply(shardId);
+            XContentParser parser = XContentFactory.xContent(filter).createParser(queryShardContext.getXContentRegistry(), filter);
+            QueryBuilder queryBuilder = queryShardContext.newParseContext(parser).parseInnerQueryBuilder().get();
+            ParsedQuery parsedQuery = queryShardContext.toFilter(queryBuilder);
+			boolQuery.add(parsedQuery.query(), BooleanClause.Occur.SHOULD);
+            reader = DocumentFilterReader.wrap(reader, new ConstantScoreQuery(boolQuery.build()));
+			return reader;
+		} catch (IOException e) {
+			this.logger.error("Unable to setup document security");
+			throw ExceptionsHelper.convertToElastic((Exception) e);
+		}
+    }
+    
+
+	@Override
+	protected IndexSearcher wrap(IndexSearcher indexSearcher) throws EngineException {
+		return indexSearcher;
+    }
+}

--- a/es53x/src/main/java/tech/beshu/ror/es/IndexLevelActionFilter.java
+++ b/es53x/src/main/java/tech/beshu/ror/es/IndexLevelActionFilter.java
@@ -17,11 +17,19 @@
 
 package tech.beshu.ror.es;
 
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.client.node.NodeClient;
@@ -36,17 +44,15 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+
 import tech.beshu.ror.acl.ACL;
+import tech.beshu.ror.acl.blocks.BlockExitResult;
+import tech.beshu.ror.commons.Constants;
 import tech.beshu.ror.commons.settings.BasicSettings;
 import tech.beshu.ror.commons.shims.es.ACLHandler;
 import tech.beshu.ror.commons.shims.es.ESContext;
 import tech.beshu.ror.commons.shims.es.LoggerShim;
-
-import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
+import tech.beshu.ror.commons.utils.FilterTransient;
 
 
 /**
@@ -181,6 +187,29 @@ public class IndexLevelActionFilter extends AbstractComponent implements ActionF
       public void onAllow(Object blockExitResult) {
         boolean hasProceeded = false;
         try {
+        	// Cache disabling for those 2 kind of request is crucial for
+        	// document level security to work. Otherwise we'd get an answer from
+        	// the cache some times and would not be filtered
+        	if (request instanceof SearchRequest) {
+				((SearchRequest)request).requestCache(Boolean.FALSE);
+			} else if (request instanceof MultiSearchRequest) {
+				for (SearchRequest sr : ((MultiSearchRequest)request).requests()) {
+					sr.requestCache(Boolean.FALSE);
+				}
+			}
+        	
+        	if (blockExitResult instanceof BlockExitResult) {
+        		BlockExitResult ber = (BlockExitResult) blockExitResult;
+        		Optional<String> filter = ber.getBlock().getFilter();
+        		if (filter.isPresent()) {
+        			String encodedUser = FilterTransient.CreateFromFilter(filter.get()).serialize();
+        			if (encodedUser == null)
+						logger.error("Error while serializing user transient");
+					if (threadPool.getThreadContext().getHeader(Constants.FILTER_TRANSIENT) == null) {
+						threadPool.getThreadContext().putHeader(Constants.FILTER_TRANSIENT, encodedUser);
+					}
+        		}
+        	}
           //         @SuppressWarnings("unchecked")
 //          ActionListener<Response> aclActionListener = (ActionListener<Response>) new ACLActionListener(
 //            request, (ActionListener<ActionResponse>) listener, rc, blockExitResult, context, acl

--- a/es53x/src/main/java/tech/beshu/ror/es/ReadonlyRestPlugin.java
+++ b/es53x/src/main/java/tech/beshu/ror/es/ReadonlyRestPlugin.java
@@ -17,12 +17,23 @@
 
 package tech.beshu.ror.es;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -33,7 +44,10 @@ import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
@@ -42,25 +56,26 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.watcher.ResourceWatcherService;
+
 import tech.beshu.ror.commons.shims.es.AbstractESContext;
 import tech.beshu.ror.configuration.AllowedSettings;
 import tech.beshu.ror.es.rradmin.RRAdminAction;
 import tech.beshu.ror.es.rradmin.TransportRRAdminAction;
 import tech.beshu.ror.es.rradmin.rest.RestRRAdminAction;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
+import tech.beshu.ror.es.security.RoleIndexSearcherWrapper;
 
 public class ReadonlyRestPlugin extends Plugin
   implements ScriptPlugin, ActionPlugin, IngestPlugin, NetworkPlugin {
 
+  private Settings settings;
+  private Environment environment;
+  
   public ReadonlyRestPlugin(Settings s) {
+	  this.settings = s;
+	  this.environment = new Environment(s);
   }
 
   @Override
@@ -137,5 +152,17 @@ public class ReadonlyRestPlugin extends Plugin
       restHandler.handleRequest(request, channel, client);
     };
   }
+
+  @Override
+	public void onIndexModule(IndexModule module) {
+		module.setSearcherWrapper(indexService -> {
+			try {
+				return new RoleIndexSearcherWrapper(indexService, this.settings, this.environment);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			return null;
+		});
+	}
 
 }

--- a/es53x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
+++ b/es53x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
@@ -1,0 +1,130 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.ExceptionsHelper;
+
+// Code based on
+// https://stackoverflow.com/questions/40949286/apply-lucene-query-on-bits
+// https://github.com/apache/lucene-solr/blob/master/lucene/misc/src/java/org/apache/lucene/index/PKIndexSplitter.java#L127-L170
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public final class DocumentFilterReader extends FilterLeafReader {
+
+    private final Bits liveDocs;
+    private final int numDocs;
+
+    public static DocumentFilterDirectoryReader wrap(DirectoryReader in, Query filterQuery) throws IOException {
+        return new DocumentFilterDirectoryReader(in, filterQuery);
+    }
+
+    private DocumentFilterReader(LeafReader reader, Query query) throws IOException {
+        super(reader);
+        final IndexSearcher searcher = new IndexSearcher(this);
+        searcher.setQueryCache(null);
+        final boolean needsScores = false;
+        final Weight preserveWeight = searcher.createNormalizedWeight(query, needsScores);
+
+        final int maxDoc = this.in.maxDoc();
+        final FixedBitSet bits = new FixedBitSet(maxDoc);
+        final Scorer preverveScorer = preserveWeight.scorer(this.getContext());
+        if (preverveScorer != null) {
+            bits.or(preverveScorer.iterator());
+        }
+
+        if (in.hasDeletions()) {
+            final Bits oldLiveDocs = in.getLiveDocs();
+            assert oldLiveDocs != null;
+            final DocIdSetIterator it = new BitSetIterator(bits, 0L);
+            for (int i = it.nextDoc(); i != DocIdSetIterator.NO_MORE_DOCS; i = it.nextDoc()) {
+                if (!oldLiveDocs.get(i)) {
+                    bits.clear(i);
+                }
+            }
+        }
+
+        this.liveDocs = bits;
+        this.numDocs = bits.cardinality();
+    }
+
+    @Override
+    public int numDocs() {
+        return numDocs;
+    }
+
+    @Override
+    public Bits getLiveDocs() {
+        return liveDocs;
+    }
+
+    @Override
+    public Object getCoreCacheKey() {
+        return this.in.getCoreCacheKey();
+    }
+    
+    private static final class DocumentFilterDirectorySubReader extends FilterDirectoryReader.SubReaderWrapper {
+        private final Query query;
+
+        public DocumentFilterDirectorySubReader(Query filterQuery) {
+            this.query = filterQuery;
+        }
+
+        @Override
+        public LeafReader wrap(LeafReader reader) {
+            try {
+                return new DocumentFilterReader(reader, this.query);
+            } catch (Exception e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+        }
+    }
+
+    public static final class DocumentFilterDirectoryReader extends FilterDirectoryReader {
+        private final Query filterQuery;
+        
+        DocumentFilterDirectoryReader(DirectoryReader in, Query filterQuery) throws IOException {
+            super(in, new DocumentFilterDirectorySubReader(filterQuery));
+            this.filterQuery = filterQuery;
+        }
+
+        @Override
+        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+            return new DocumentFilterDirectoryReader(in, this.filterQuery);
+        }
+        
+        @Override 
+        public Object getCoreCacheKey() {
+            return this.in.getCoreCacheKey();
+        }
+    }
+}

--- a/es53x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
+++ b/es53x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
@@ -1,0 +1,122 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.EngineException;
+import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.shard.IndexSearcherWrapper;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardUtils;
+
+import com.unboundid.util.args.ArgumentException;
+
+import tech.beshu.ror.commons.Constants;
+import tech.beshu.ror.commons.settings.BasicSettings;
+import tech.beshu.ror.commons.shims.es.LoggerShim;
+import tech.beshu.ror.commons.utils.FilterTransient;
+import tech.beshu.ror.es.ESContextImpl;
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public class RoleIndexSearcherWrapper extends IndexSearcherWrapper {
+    private final LoggerShim logger;
+    private final Function<ShardId, QueryShardContext> queryShardContextProvider;
+    private final ThreadContext threadContext;
+	private final Boolean enabled;
+	
+	public RoleIndexSearcherWrapper(IndexService indexService, Settings s, Environment env) throws Exception {
+        if (indexService == null) {
+            throw new ArgumentException("Please provide an indexService");
+        }
+		Logger logger = Loggers.getLogger(this.getClass(), new String[0]);
+		logger.info("Create new RoleIndexSearcher wrapper, [{}]", indexService.getIndexSettings().getIndex().getName());
+        this.queryShardContextProvider = shardId -> indexService.newQueryShardContext(shardId.id(), null, null);
+        this.threadContext = indexService.getThreadPool().getThreadContext();
+
+		this.logger = ESContextImpl.mkLoggerShim(logger);
+		BasicSettings baseSettings = BasicSettings.fromFile(this.logger, env.configFile().toAbsolutePath(), s.getAsStructuredMap());
+		this.enabled = baseSettings.isEnabled();
+	}
+
+	@Override
+	protected DirectoryReader wrap(DirectoryReader reader) {
+		if (!this.enabled) {
+			logger.warn("Document filtering not available. Return defaut reader");
+			return reader;
+		}
+
+		FilterTransient userTransient = FilterTransient.Deserialize(threadContext.getHeader(Constants.FILTER_TRANSIENT));
+		if (userTransient == null) {
+			logger.debug("Couldn't extract userTransient from threadContext.");
+			return reader;
+		}
+
+        ShardId shardId = ShardUtils.extractShardId(reader);
+		if (shardId == null) {
+			throw new IllegalStateException(
+					LoggerMessageFormat.format("Couldn't extract shardId from reader [{}]", new Object[] { reader }));
+		}
+		String filter = userTransient.getFilter();
+
+		if (filter == null || filter.equals("")) {
+			return reader;
+        }
+		
+		try {
+			BooleanQuery.Builder boolQuery = new BooleanQuery.Builder();
+            boolQuery.setMinimumNumberShouldMatch(1);
+            QueryShardContext queryShardContext = this.queryShardContextProvider.apply(shardId);
+            XContentParser parser = XContentFactory.xContent(filter).createParser(queryShardContext.getXContentRegistry(), filter);
+            QueryBuilder queryBuilder = queryShardContext.newParseContext(parser).parseInnerQueryBuilder().get();
+            ParsedQuery parsedQuery = queryShardContext.toFilter(queryBuilder);
+			boolQuery.add(parsedQuery.query(), BooleanClause.Occur.SHOULD);
+            reader = DocumentFilterReader.wrap(reader, new ConstantScoreQuery(boolQuery.build()));
+			return reader;
+		} catch (IOException e) {
+			this.logger.error("Unable to setup document security");
+			throw ExceptionsHelper.convertToElastic((Exception) e);
+		}
+    }
+    
+
+	@Override
+	protected IndexSearcher wrap(IndexSearcher indexSearcher) throws EngineException {
+		return indexSearcher;
+    }
+}

--- a/es60x/src/main/java/tech/beshu/ror/es/IndexLevelActionFilter.java
+++ b/es60x/src/main/java/tech/beshu/ror/es/IndexLevelActionFilter.java
@@ -17,11 +17,19 @@
 
 package tech.beshu.ror.es;
 
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.client.node.NodeClient;
@@ -37,17 +45,15 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
 import tech.beshu.ror.acl.ACL;
+import tech.beshu.ror.acl.blocks.BlockExitResult;
+import tech.beshu.ror.commons.Constants;
 import tech.beshu.ror.commons.settings.BasicSettings;
 import tech.beshu.ror.commons.shims.es.ACLHandler;
 import tech.beshu.ror.commons.shims.es.ESContext;
 import tech.beshu.ror.commons.shims.es.LoggerShim;
-
-import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
+import tech.beshu.ror.commons.utils.FilterTransient;
 
 
 /**
@@ -189,6 +195,29 @@ public class IndexLevelActionFilter extends AbstractComponent implements ActionF
       public void onAllow(Object blockExitResult) {
         boolean hasProceeded = false;
         try {
+        	// Cache disabling for those 2 kind of request is crucial for
+        	// document level security to work. Otherwise we'd get an answer from
+        	// the cache some times and would not be filtered
+        	if (request instanceof SearchRequest) {
+				((SearchRequest)request).requestCache(Boolean.FALSE);
+			} else if (request instanceof MultiSearchRequest) {
+				for (SearchRequest sr : ((MultiSearchRequest)request).requests()) {
+					sr.requestCache(Boolean.FALSE);
+				}
+			}
+
+        	if (blockExitResult instanceof BlockExitResult) {
+        		BlockExitResult ber = (BlockExitResult) blockExitResult;
+        		Optional<String> filter = ber.getBlock().getFilter();
+        		if (filter.isPresent()) {
+        			String encodedUser = FilterTransient.CreateFromFilter(filter.get()).serialize();
+        			if (encodedUser == null) 
+						logger.error("Error while serializing user transient");
+					if (threadPool.getThreadContext().getHeader(Constants.FILTER_TRANSIENT) == null) {
+						threadPool.getThreadContext().putHeader(Constants.FILTER_TRANSIENT, encodedUser);
+					}
+        		}
+        	}
           //         @SuppressWarnings("unchecked")
 //          ActionListener<Response> aclActionListener = (ActionListener<Response>) new ACLActionListener(
 //            request, (ActionListener<ActionResponse>) listener, rc, blockExitResult, context, acl

--- a/es60x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
+++ b/es60x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
@@ -1,0 +1,136 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.ExceptionsHelper;
+
+// Code based on
+// https://stackoverflow.com/questions/40949286/apply-lucene-query-on-bits
+// https://github.com/apache/lucene-solr/blob/master/lucene/misc/src/java/org/apache/lucene/index/PKIndexSplitter.java#L127-L170
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public final class DocumentFilterReader extends FilterLeafReader {
+
+    private final Bits liveDocs;
+    private final int numDocs;
+
+    public static DocumentFilterDirectoryReader wrap(DirectoryReader in, Query filterQuery) throws IOException {
+        return new DocumentFilterDirectoryReader(in, filterQuery);
+    }
+
+    private DocumentFilterReader(LeafReader reader, Query query) throws IOException {
+        super(reader);
+        final IndexSearcher searcher = new IndexSearcher(this);
+        searcher.setQueryCache(null);
+        final boolean needsScores = false;
+        final Weight preserveWeight = searcher.createNormalizedWeight(query, needsScores);
+
+        final int maxDoc = this.in.maxDoc();
+        final FixedBitSet bits = new FixedBitSet(maxDoc);
+        final Scorer preverveScorer = preserveWeight.scorer(this.getContext());
+        if (preverveScorer != null) {
+            bits.or(preverveScorer.iterator());
+        }
+
+        if (in.hasDeletions()) {
+            final Bits oldLiveDocs = in.getLiveDocs();
+            assert oldLiveDocs != null;
+            final DocIdSetIterator it = new BitSetIterator(bits, 0L);
+            for (int i = it.nextDoc(); i != DocIdSetIterator.NO_MORE_DOCS; i = it.nextDoc()) {
+                if (!oldLiveDocs.get(i)) {
+                    bits.clear(i);
+                }
+            }
+        }
+
+        this.liveDocs = bits;
+        this.numDocs = bits.cardinality();
+    }
+
+    @Override
+    public int numDocs() {
+        return numDocs;
+    }
+
+    @Override
+    public Bits getLiveDocs() {
+        return liveDocs;
+    }
+
+    private static final class DocumentFilterDirectorySubReader extends FilterDirectoryReader.SubReaderWrapper {
+        private final Query query;
+
+        public DocumentFilterDirectorySubReader(Query filterQuery) {
+            this.query = filterQuery;
+        }
+
+        @Override
+        public LeafReader wrap(LeafReader reader) {
+            try {
+                return new DocumentFilterReader(reader, this.query);
+            } catch (Exception e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+        }
+    }
+
+    public static final class DocumentFilterDirectoryReader extends FilterDirectoryReader {
+        private final Query filterQuery;
+        
+        DocumentFilterDirectoryReader(DirectoryReader in, Query filterQuery) throws IOException {
+            super(in, new DocumentFilterDirectorySubReader(filterQuery));
+            this.filterQuery = filterQuery;
+        }
+
+        @Override
+        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+            return new DocumentFilterDirectoryReader(in, this.filterQuery);
+        }
+
+		@Override
+		public CacheHelper getReaderCacheHelper() {
+			return this.in.getReaderCacheHelper();
+		}
+
+    }
+
+	@Override
+	public CacheHelper getCoreCacheHelper() {
+		return this.in.getCoreCacheHelper();
+	}
+
+	@Override
+	public CacheHelper getReaderCacheHelper() {
+		return this.in.getReaderCacheHelper();
+	}
+}

--- a/es60x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
+++ b/es60x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
@@ -1,0 +1,121 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.EngineException;
+import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.shard.IndexSearcherWrapper;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardUtils;
+
+import com.unboundid.util.args.ArgumentException;
+
+import tech.beshu.ror.commons.Constants;
+import tech.beshu.ror.commons.settings.BasicSettings;
+import tech.beshu.ror.commons.shims.es.LoggerShim;
+import tech.beshu.ror.commons.utils.FilterTransient;
+import tech.beshu.ror.es.ESContextImpl;
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public class RoleIndexSearcherWrapper extends IndexSearcherWrapper {
+    private final LoggerShim logger;
+    private final Function<ShardId, QueryShardContext> queryShardContextProvider;
+    private final ThreadContext threadContext;
+	private final Boolean enabled;
+	
+	public RoleIndexSearcherWrapper(IndexService indexService, Settings s, Environment env) throws Exception {
+        if (indexService == null) {
+            throw new ArgumentException("Please provide an indexService");
+        }
+		Logger logger = Loggers.getLogger(this.getClass(), new String[0]);
+		logger.info("Create new RoleIndexSearcher wrapper, [{}]", indexService.getIndexSettings().getIndex().getName());
+        this.queryShardContextProvider = shardId -> indexService.newQueryShardContext(shardId.id(), null, null, null);
+        this.threadContext = indexService.getThreadPool().getThreadContext();
+
+		this.logger = ESContextImpl.mkLoggerShim(logger);
+		BasicSettings baseSettings = BasicSettings.fromFileObj(this.logger, env.configFile().toAbsolutePath(), s);
+		this.enabled = baseSettings.isEnabled();
+	}
+
+	@Override
+	protected DirectoryReader wrap(DirectoryReader reader) {
+		if (!this.enabled) {
+			logger.warn("Document filtering not available. Return defaut reader");
+			return reader;
+		}
+
+		FilterTransient userTransient = FilterTransient.Deserialize(threadContext.getHeader(Constants.FILTER_TRANSIENT));
+		if (userTransient == null) {
+			return reader;
+		}
+
+        ShardId shardId = ShardUtils.extractShardId(reader);
+		if (shardId == null) {
+			throw new IllegalStateException(
+					LoggerMessageFormat.format("Couldn't extract shardId from reader [{}]", new Object[] { reader }));
+		}
+		String filter = userTransient.getFilter();
+
+		if (filter == null || filter.equals("")) {
+			return reader;
+        }
+		
+		try {
+			BooleanQuery.Builder boolQuery = new BooleanQuery.Builder();
+            boolQuery.setMinimumNumberShouldMatch(1);
+            QueryShardContext queryShardContext = this.queryShardContextProvider.apply(shardId);
+            XContentParser parser = JsonXContent.jsonXContent.createParser(queryShardContext.getXContentRegistry(), filter);
+            QueryBuilder queryBuilder = queryShardContext.parseInnerQueryBuilder(parser);
+            ParsedQuery parsedQuery = queryShardContext.toFilter(queryBuilder);
+			boolQuery.add(parsedQuery.query(), BooleanClause.Occur.SHOULD);
+            reader = DocumentFilterReader.wrap(reader, new ConstantScoreQuery(boolQuery.build()));
+			return reader;
+		} catch (IOException e) {
+			this.logger.error("Unable to setup document security");
+			throw ExceptionsHelper.convertToElastic((Exception) e);
+		}
+    }
+    
+
+	@Override
+	protected IndexSearcher wrap(IndexSearcher indexSearcher) throws EngineException {
+		return indexSearcher;
+    }
+}

--- a/es61x/src/main/java/tech/beshu/ror/es/IndexLevelActionFilter.java
+++ b/es61x/src/main/java/tech/beshu/ror/es/IndexLevelActionFilter.java
@@ -17,11 +17,19 @@
 
 package tech.beshu.ror.es;
 
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.client.node.NodeClient;
@@ -35,17 +43,15 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
+
 import tech.beshu.ror.acl.ACL;
+import tech.beshu.ror.acl.blocks.BlockExitResult;
+import tech.beshu.ror.commons.Constants;
 import tech.beshu.ror.commons.settings.BasicSettings;
 import tech.beshu.ror.commons.shims.es.ACLHandler;
 import tech.beshu.ror.commons.shims.es.ESContext;
 import tech.beshu.ror.commons.shims.es.LoggerShim;
-
-import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
+import tech.beshu.ror.commons.utils.FilterTransient;
 
 
 /**
@@ -173,6 +179,28 @@ public class IndexLevelActionFilter extends AbstractComponent implements ActionF
       public void onAllow(Object blockExitResult) {
         boolean hasProceeded = false;
         try {
+        	// Cache disabling for those 2 kind of request is crucial for
+        	// document level security to work. Otherwise we'd get an answer from
+        	// the cache some times and would not be filtered
+        	if (request instanceof SearchRequest) {
+				((SearchRequest)request).requestCache(Boolean.FALSE);
+			} else if (request instanceof MultiSearchRequest) {
+				for (SearchRequest sr : ((MultiSearchRequest)request).requests()) {
+					sr.requestCache(Boolean.FALSE);
+				}
+			}
+        	if (blockExitResult instanceof BlockExitResult) {
+        		BlockExitResult ber = (BlockExitResult) blockExitResult;
+        		Optional<String> filter = ber.getBlock().getFilter();
+        		if (filter.isPresent()) {
+        			String encodedUser = FilterTransient.CreateFromFilter(filter.get()).serialize();
+        			if (encodedUser == null) 
+						logger.error("Error while serializing user transient");
+					if (threadPool.getThreadContext().getHeader(Constants.FILTER_TRANSIENT) == null) {
+						threadPool.getThreadContext().putHeader(Constants.FILTER_TRANSIENT, encodedUser);
+					}
+        		}
+        	}
           //         @SuppressWarnings("unchecked")
 //          ActionListener<Response> aclActionListener = (ActionListener<Response>) new ACLActionListener(
 //            request, (ActionListener<ActionResponse>) listener, rc, blockExitResult, context, acl

--- a/es61x/src/main/java/tech/beshu/ror/es/ReadonlyRestPlugin.java
+++ b/es61x/src/main/java/tech/beshu/ror/es/ReadonlyRestPlugin.java
@@ -17,6 +17,19 @@
 
 package tech.beshu.ror.es;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -52,23 +65,12 @@ import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
+
 import tech.beshu.ror.configuration.AllowedSettings;
 import tech.beshu.ror.es.rradmin.RRAdminAction;
 import tech.beshu.ror.es.rradmin.TransportRRAdminAction;
 import tech.beshu.ror.es.rradmin.rest.RestRRAdminAction;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
+import tech.beshu.ror.es.security.RoleIndexSearcherWrapper;
 
 public class ReadonlyRestPlugin extends Plugin
   implements ScriptPlugin, ActionPlugin, IngestPlugin, NetworkPlugin {
@@ -112,7 +114,14 @@ public class ReadonlyRestPlugin extends Plugin
 
   @Override
   public void onIndexModule(IndexModule indexModule) {
-    super.onIndexModule(indexModule);
+    indexModule.setSearcherWrapper(indexService -> {
+    	try {
+    		return new RoleIndexSearcherWrapper(indexService, this.settings, this.environment);
+    	}catch (Exception e) {
+			e.printStackTrace();
+		}
+    	return null;
+    });
   }
 
   @Override

--- a/es61x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
+++ b/es61x/src/main/java/tech/beshu/ror/es/security/DocumentFilterReader.java
@@ -1,0 +1,136 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BitSetIterator;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.FixedBitSet;
+import org.elasticsearch.ExceptionsHelper;
+
+// Code based on
+// https://stackoverflow.com/questions/40949286/apply-lucene-query-on-bits
+// https://github.com/apache/lucene-solr/blob/master/lucene/misc/src/java/org/apache/lucene/index/PKIndexSplitter.java#L127-L170
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public final class DocumentFilterReader extends FilterLeafReader {
+
+    private final Bits liveDocs;
+    private final int numDocs;
+
+    public static DocumentFilterDirectoryReader wrap(DirectoryReader in, Query filterQuery) throws IOException {
+        return new DocumentFilterDirectoryReader(in, filterQuery);
+    }
+
+    private DocumentFilterReader(LeafReader reader, Query query) throws IOException {
+        super(reader);
+        final IndexSearcher searcher = new IndexSearcher(this);
+        searcher.setQueryCache(null);
+        final boolean needsScores = false;
+        final Weight preserveWeight = searcher.createNormalizedWeight(query, needsScores);
+
+        final int maxDoc = this.in.maxDoc();
+        final FixedBitSet bits = new FixedBitSet(maxDoc);
+        final Scorer preverveScorer = preserveWeight.scorer(this.getContext());
+        if (preverveScorer != null) {
+            bits.or(preverveScorer.iterator());
+        }
+
+        if (in.hasDeletions()) {
+            final Bits oldLiveDocs = in.getLiveDocs();
+            assert oldLiveDocs != null;
+            final DocIdSetIterator it = new BitSetIterator(bits, 0L);
+            for (int i = it.nextDoc(); i != DocIdSetIterator.NO_MORE_DOCS; i = it.nextDoc()) {
+                if (!oldLiveDocs.get(i)) {
+                    bits.clear(i);
+                }
+            }
+        }
+
+        this.liveDocs = bits;
+        this.numDocs = bits.cardinality();
+    }
+
+    @Override
+    public int numDocs() {
+        return numDocs;
+    }
+
+    @Override
+    public Bits getLiveDocs() {
+        return liveDocs;
+    }
+
+    private static final class DocumentFilterDirectorySubReader extends FilterDirectoryReader.SubReaderWrapper {
+        private final Query query;
+
+        public DocumentFilterDirectorySubReader(Query filterQuery) {
+            this.query = filterQuery;
+        }
+
+        @Override
+        public LeafReader wrap(LeafReader reader) {
+            try {
+                return new DocumentFilterReader(reader, this.query);
+            } catch (Exception e) {
+                throw ExceptionsHelper.convertToElastic(e);
+            }
+        }
+    }
+
+    public static final class DocumentFilterDirectoryReader extends FilterDirectoryReader {
+        private final Query filterQuery;
+        
+        DocumentFilterDirectoryReader(DirectoryReader in, Query filterQuery) throws IOException {
+            super(in, new DocumentFilterDirectorySubReader(filterQuery));
+            this.filterQuery = filterQuery;
+        }
+
+        @Override
+        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+            return new DocumentFilterDirectoryReader(in, this.filterQuery);
+        }
+
+		@Override
+		public CacheHelper getReaderCacheHelper() {
+			return this.in.getReaderCacheHelper();
+		}
+
+    }
+
+	@Override
+	public CacheHelper getCoreCacheHelper() {
+		return this.in.getCoreCacheHelper();
+	}
+
+	@Override
+	public CacheHelper getReaderCacheHelper() {
+		return this.in.getReaderCacheHelper();
+	}
+}

--- a/es61x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
+++ b/es61x/src/main/java/tech/beshu/ror/es/security/RoleIndexSearcherWrapper.java
@@ -1,0 +1,122 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.es.security;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.engine.EngineException;
+import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.shard.IndexSearcherWrapper;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardUtils;
+
+import com.unboundid.util.args.ArgumentException;
+
+import tech.beshu.ror.commons.Constants;
+import tech.beshu.ror.commons.settings.BasicSettings;
+import tech.beshu.ror.commons.shims.es.LoggerShim;
+import tech.beshu.ror.commons.utils.FilterTransient;
+import tech.beshu.ror.es.ESContextImpl;
+
+/*
+ * @author Datasweet <contact@datasweet.fr>
+ */
+public class RoleIndexSearcherWrapper extends IndexSearcherWrapper {
+    private final LoggerShim logger;
+    private final Function<ShardId, QueryShardContext> queryShardContextProvider;
+    private final ThreadContext threadContext;
+	private final Boolean enabled;
+	
+	public RoleIndexSearcherWrapper(IndexService indexService, Settings s, Environment env) throws Exception {
+        if (indexService == null) {
+            throw new ArgumentException("Please provide an indexService");
+        }
+		Logger logger = Loggers.getLogger(this.getClass(), new String[0]);
+		logger.info("Create new RoleIndexSearcher wrapper, [{}]", indexService.getIndexSettings().getIndex().getName());
+        this.queryShardContextProvider = shardId -> indexService.newQueryShardContext(shardId.id(), null, null, null);
+        this.threadContext = indexService.getThreadPool().getThreadContext();
+
+		this.logger = ESContextImpl.mkLoggerShim(logger);
+		BasicSettings baseSettings = BasicSettings.fromFileObj(this.logger, env.configFile().toAbsolutePath(), s);
+		this.enabled = baseSettings.isEnabled();
+	}
+
+	@Override
+	protected DirectoryReader wrap(DirectoryReader reader) {
+		if (!this.enabled) {
+			logger.warn("Document filtering not available. Return defaut reader");
+			return reader;
+		}
+
+		FilterTransient userTransient = FilterTransient.Deserialize(threadContext.getHeader(Constants.FILTER_TRANSIENT));
+		if (userTransient == null) {
+			logger.debug("Couldn't extract userTransient from threadContext.");
+			return reader;
+		}
+
+        ShardId shardId = ShardUtils.extractShardId(reader);
+		if (shardId == null) {
+			throw new IllegalStateException(
+					LoggerMessageFormat.format("Couldn't extract shardId from reader [{}]", new Object[] { reader }));
+		}
+		String filter = userTransient.getFilter();
+
+		if (filter == null || filter.equals("")) {
+			return reader;
+        }
+		
+		try {
+			BooleanQuery.Builder boolQuery = new BooleanQuery.Builder();
+            boolQuery.setMinimumNumberShouldMatch(1);
+            QueryShardContext queryShardContext = this.queryShardContextProvider.apply(shardId);
+            XContentParser parser = JsonXContent.jsonXContent.createParser(queryShardContext.getXContentRegistry(), filter);
+            QueryBuilder queryBuilder = queryShardContext.parseInnerQueryBuilder(parser);
+            ParsedQuery parsedQuery = queryShardContext.toFilter(queryBuilder);
+			boolQuery.add(parsedQuery.query(), BooleanClause.Occur.SHOULD);
+            reader = DocumentFilterReader.wrap(reader, new ConstantScoreQuery(boolQuery.build()));
+			return reader;
+		} catch (IOException e) {
+			this.logger.error("Unable to setup document security");
+			throw ExceptionsHelper.convertToElastic((Exception) e);
+		}
+    }
+    
+
+	@Override
+	protected IndexSearcher wrap(IndexSearcher indexSearcher) throws EngineException {
+		return indexSearcher;
+    }
+}

--- a/integration-tests/src/test/java/tech/beshu/ror/integration/FiltersTests.java
+++ b/integration-tests/src/test/java/tech/beshu/ror/integration/FiltersTests.java
@@ -1,0 +1,157 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static tech.beshu.ror.utils.containers.ESWithReadonlyRestContainer.create;
+
+import java.util.Optional;
+import java.util.Random;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import tech.beshu.ror.utils.containers.ESWithReadonlyRestContainer;
+import tech.beshu.ror.utils.gradle.RorPluginGradleProject;
+import tech.beshu.ror.utils.httpclient.RestClient;
+
+public class FiltersTests {
+
+	private static final String IDX_PREFIX = "testfilter";
+
+	private static RestClient adminClient;
+	@ClassRule
+	public static ESWithReadonlyRestContainer container = create(RorPluginGradleProject.fromSystemProperty(),
+			"/filters/elasticsearch.yml", Optional.of(c -> {
+				insertDoc("a1", c, "a", "title");
+				insertDoc("a2", c, "a", "title");
+				insertDoc("b1", c, "bandc", "title");
+				insertDoc("b2", c, "bandc", "title");
+				insertDoc("c1", c, "bandc", "title");
+				insertDoc("c2", c, "bandc", "title");
+				insertDoc("d1", c, "d", "title");
+				insertDoc("d2", c, "d", "title");
+				insertDoc("d1", c, "d", "nottitle");
+				insertDoc("d2", c, "d", "nottitle");
+			})
+
+	);
+
+	private static void insertDoc(String docName, RestClient restClient, String idx, String field) {
+		if (adminClient == null) {
+			adminClient = restClient;
+		}
+
+		String path = "/" + IDX_PREFIX + idx + "/documents/doc-" + docName + String.valueOf(Math.random());
+		try {
+
+			HttpPut request = new HttpPut(restClient.from(path));
+			request.setHeader("Content-Type", "application/json");
+			request.setHeader("refresh", "true");
+			request.setHeader("timeout", "50s");
+			request.setEntity(new StringEntity("{\"" + field + "\": \"" + docName + "\"}"));
+			System.out.println(body(restClient.execute(request)));
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new IllegalStateException("Test problem", e);
+		}
+
+		// Polling phase.. #TODO is there a better way?
+		try {
+			HttpResponse response;
+			do {
+				HttpHead request = new HttpHead(restClient.from(path));
+				request.setHeader("x-api-key", "p");
+				response = restClient.execute(request);
+				System.out
+						.println("polling for " + docName + ".. result: " + response.getStatusLine().getReasonPhrase());
+				Thread.sleep(200);
+			} while (response.getStatusLine().getStatusCode() != 200);
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new IllegalStateException("Cannot configure test case", e);
+		}
+	}
+
+	private static String body(HttpResponse r) throws Exception {
+		return EntityUtils.toString(r.getEntity());
+	}
+	
+	@Test
+	public void testDirectSingleIdxa() throws Exception {
+		String body = search("/" + IDX_PREFIX + "a/_search");
+		assertTrue(body.contains("a1"));
+		assertFalse(body.contains("a2"));
+		assertFalse(body.contains("b1"));
+		assertFalse(body.contains("b2"));
+		assertFalse(body.contains("c1"));
+		assertFalse(body.contains("c2"));
+	}
+	
+	@Test
+	public void testDirectMultipleIdxbandc() throws Exception {
+		String body = search("/" + IDX_PREFIX + "bandc/_search");
+		assertFalse(body.contains("a1"));
+		assertFalse(body.contains("a2"));
+		assertTrue(body.contains("b1"));
+		assertFalse(body.contains("b2"));
+		assertFalse(body.contains("c1"));
+		assertTrue(body.contains("c2"));
+	}
+	
+	@Test
+	public void testDirectSingleIdxd() throws Exception {
+		String body = search("/" + IDX_PREFIX + "d/_search");
+		assertFalse(body.contains("a1"));
+		assertFalse(body.contains("a2"));
+		assertFalse(body.contains("b1"));
+		assertFalse(body.contains("b2"));
+		assertFalse(body.contains("c1"));
+		assertFalse(body.contains("c2"));
+		assertTrue(body.contains("\"title\": \"d1\""));
+		assertFalse(body.contains("\"title\": \"d2\""));
+		assertFalse(body.contains("\"nottitle\": \"d1\""));
+		assertFalse(body.contains("\"nottitle\": \"d2\""));
+	}
+	
+	private String search(String endpoint) throws Exception {
+	    HttpGet request = new HttpGet(adminClient.from(endpoint));
+
+	    request.setHeader("timeout", "50s");
+	    String caller = Thread.currentThread().getStackTrace()[2].getMethodName();
+	    request.setHeader("x-caller-" + caller, "true");
+	    request.setHeader("x-api-key", "g");
+
+	    HttpResponse resp = adminClient.execute(request);
+
+	    String body = body(resp);
+	    System.out.println("SEARCH RESPONSE for " + caller + ": " + body);
+	    assertEquals(200, resp.getStatusLine().getStatusCode());
+	    return body;
+	  }
+}

--- a/integration-tests/src/test/resources/filters/elasticsearch.yml
+++ b/integration-tests/src/test/resources/filters/elasticsearch.yml
@@ -1,0 +1,41 @@
+http.host: 0.0.0.0
+
+http.type: ssl_netty4
+#transport.type: local
+readonlyrest:
+  ssl:
+    enable: true
+    keystore_file: "keystore.jks"
+    keystore_pass: readonlyrest
+    key_pass: readonlyrest
+
+  enable: true
+
+  access_control_rules:
+
+  - name: Gettera
+    api_keys: ["g"]
+    indices: ["testfiltera"]
+    filter: "{\"bool\": {\"must\": [{\"term\": {\"title\": {\"value\": \"a1\"}}}]}}"
+    
+  - name: Getterbandc
+    api_keys: ["g"]
+    indices: ["testfilterbandc"]
+    filter: "{\"bool\": {\"should\": [{\"term\": {\"title\": {\"value\": \"b1\"}}},{\"term\": {\"title\": {\"value\": \"c2\"}}}]}}"
+    
+  - name: Getterbandc
+    api_keys: ["g"]
+    indices: ["testfilterd"]
+    filter: "{\"bool\": {\"must\": [{\"term\": {\"title\": {\"value\": \"d1\"}}}]}}"
+    
+  # ES container initializer need this rule to configure ES instance after startup
+  - name: "CONTAINER ADMIN"
+    auth_key: admin:container
+    verbosity: error
+
+  - name: passthrough
+    actions: ["cluster:monitor*", "indices:*/write*", "*create*"]
+
+  - name: Poller
+    api_keys: ["p"]
+    verbosity: error


### PR DESCRIPTION
Hi,

This pull request allows to set up document level security.
I kept it really simple for now, I added a new property to the rule named 'filter'.
You put a DLS query and it will wrap this query to the ES query if the rule is matched.
For example: 
```yaml
	access_control_rules:

    - name: Just certain indices, and read only
      actions: ["indices:data/read/*"]
      indices: ["product_catalogue-*"]
	  filter: ""{\"bool\": {\"must\": [{\"term\": {\"name\": {\"value\": \"test\"}}}]}}""
```
So if the rule is matched, if will filter all the documents that have the 'name' equals to 'test'

Regards,