### PR TITLE
Configurable headers and parameters for Group Service Api Calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,13 @@ readonlyrest:
       auth_token_passed_as: QUERY_PARAM                        # HEADER OR QUERY_PARAM
       response_groups_json_path: "$..groups[?(@.name)].name"   # see: https://github.com/json-path/JsonPath
       cache_ttl_in_sec: 60
+      default_headers:                                         # default headers to be passed with api call
+        header1: value1
+        header2: value2
+      default_query_parameters:                                # default params to be passed with api calls
+        param1: value1
+        param2: value2
+      http_method: get/post                                    # method to invoke GET/POST.  
 ```
 
 In example above, a user is authenticated by reverse proxy and then external service is asked for groups for that user. 

--- a/core/src/main/java/tech/beshu/ror/acl/definitions/DefinitionsFactory.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/DefinitionsFactory.java
@@ -181,8 +181,11 @@ public class DefinitionsFactory implements LdapClientFactory,
           new ApacheHttpCoreClient(context, true),
           settings.getEndpoint(),
           settings.getAuthTokenName(),
+          settings.getMethod(),
           settings.getAuthTokenPassedMethod(),
           settings.getResponseGroupsJsonPath(),
+          settings.getDefaultHeaders(),
+          settings.getDefaultQueryParameters(),
           context
         )
       )

--- a/core/src/main/java/tech/beshu/ror/acl/definitions/groupsproviders/GroupsProviderServiceHttpClient.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/groupsproviders/GroupsProviderServiceHttpClient.java
@@ -47,7 +47,7 @@ public class GroupsProviderServiceHttpClient implements GroupsProviderServiceCli
   private final String responseGroupsJsonPath;
   private final ImmutableMap<String, String> defaultHeaders;
   private final ImmutableMap<String, String> defaultQueryParameters;
-  private final Function<LoggedUser,RRHttpRequest> requestBuilder;
+  private Function<LoggedUser,RRHttpRequest> requestBuilder;
 
   public GroupsProviderServiceHttpClient(String name,
                                          HttpClient client,

--- a/core/src/main/java/tech/beshu/ror/acl/definitions/groupsproviders/GroupsProviderServiceHttpClient.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/groupsproviders/GroupsProviderServiceHttpClient.java
@@ -47,7 +47,6 @@ public class GroupsProviderServiceHttpClient implements GroupsProviderServiceCli
   private final String responseGroupsJsonPath;
   private final ImmutableMap<String, String> defaultHeaders;
   private final ImmutableMap<String, String> defaultQueryParameters;
-  private final HttpMethod method;
   private final Function<LoggedUser,RRHttpRequest> requestBuilder;
 
   public GroupsProviderServiceHttpClient(String name,
@@ -68,19 +67,9 @@ public class GroupsProviderServiceHttpClient implements GroupsProviderServiceCli
     this.client = client;
     this.defaultHeaders = defaultHeaders;
     this.defaultQueryParameters = defaultQueryParameters;
-    this.method = method;
-    switch (method) {
-      case POST: {
-        requestBuilder = (t ->
-            RRHttpRequest.post(this.endpoint, createParams(t), createHeaders(t)));
-        break;
-      }
-      default: {
-        requestBuilder = (t ->
-            RRHttpRequest.get(this.endpoint, createParams(t), createHeaders(t)));
-      }
-
-    }
+    this.requestBuilder = method == HttpMethod.POST ? (t ->
+        RRHttpRequest.post(this.endpoint, createParams(t), createHeaders(t))) :
+        (t -> RRHttpRequest.get(this.endpoint, createParams(t), createHeaders(t)));
   }
 
   @Override

--- a/core/src/main/java/tech/beshu/ror/acl/definitions/groupsproviders/GroupsProviderServiceHttpClient.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/groupsproviders/GroupsProviderServiceHttpClient.java
@@ -24,6 +24,7 @@ import tech.beshu.ror.acl.domain.LoggedUser;
 import tech.beshu.ror.commons.shims.es.ESContext;
 import tech.beshu.ror.commons.shims.es.LoggerShim;
 import tech.beshu.ror.httpclient.HttpClient;
+import tech.beshu.ror.httpclient.HttpMethod;
 import tech.beshu.ror.httpclient.RRHttpRequest;
 import tech.beshu.ror.httpclient.RRHttpResponse;
 import tech.beshu.ror.settings.definitions.UserGroupsProviderSettings;
@@ -44,14 +45,20 @@ public class GroupsProviderServiceHttpClient implements GroupsProviderServiceCli
   private final String authTokenName;
   private final UserGroupsProviderSettings.TokenPassingMethod passingMethod;
   private final String responseGroupsJsonPath;
+  private final ImmutableMap<String, String> defaultHeaders;
+  private final ImmutableMap<String, String> defaultQueryParameters;
+  private final HttpMethod method;
+  private final Function<LoggedUser,RRHttpRequest> requestBuilder;
 
   public GroupsProviderServiceHttpClient(String name,
                                          HttpClient client,
                                          URI endpoint,
                                          String authTokenName,
+                                         HttpMethod method,
                                          UserGroupsProviderSettings.TokenPassingMethod passingMethod,
                                          String responseGroupsJsonPath,
-                                         ESContext context) {
+                                         ImmutableMap<String, String> defaultHeaders, ImmutableMap<String,
+      String> defaultQueryParameters, ESContext context) {
     this.logger = context.logger(getClass());
     this.name = name;
     this.endpoint = endpoint;
@@ -59,24 +66,40 @@ public class GroupsProviderServiceHttpClient implements GroupsProviderServiceCli
     this.passingMethod = passingMethod;
     this.responseGroupsJsonPath = responseGroupsJsonPath;
     this.client = client;
+    this.defaultHeaders = defaultHeaders;
+    this.defaultQueryParameters = defaultQueryParameters;
+    this.method = method;
+    switch (method) {
+      case POST: {
+        requestBuilder = (t ->
+            RRHttpRequest.post(this.endpoint, createParams(t), createHeaders(t)));
+        break;
+      }
+      default: {
+        requestBuilder = (t ->
+            RRHttpRequest.get(this.endpoint, createParams(t), createHeaders(t)));
+      }
+
+    }
   }
 
   @Override
   public CompletableFuture<Set<String>> fetchGroupsFor(LoggedUser user) {
-    return client.send(RRHttpRequest.get(endpoint, createParams(user), createHeaders(user)))
-      .thenApply(groupsFromResponse());
+
+    return client.send(requestBuilder.apply(user))
+        .thenApply(groupsFromResponse());
   }
 
   private Map<String, String> createParams(LoggedUser user) {
     return passingMethod == UserGroupsProviderSettings.TokenPassingMethod.QUERY
-      ? ImmutableMap.of(authTokenName, user.getId())
-      : ImmutableMap.of();
+        ? new ImmutableMap.Builder<String, String>().putAll(defaultQueryParameters.entrySet()).put(authTokenName, user.getId()).build()
+        : ImmutableMap.copyOf(defaultQueryParameters);
   }
 
   private Map<String, String> createHeaders(LoggedUser user) {
     return passingMethod == UserGroupsProviderSettings.TokenPassingMethod.HEADER
-      ? ImmutableMap.of(authTokenName, user.getId())
-      : ImmutableMap.of();
+        ? new ImmutableMap.Builder<String, String>().putAll(defaultHeaders.entrySet()).put(authTokenName, user.getId()).build()
+        : ImmutableMap.copyOf(defaultHeaders);
   }
 
   private Function<RRHttpResponse, Set<String>> groupsFromResponse() {
@@ -95,4 +118,5 @@ public class GroupsProviderServiceHttpClient implements GroupsProviderServiceCli
       return Sets.newHashSet();
     };
   }
+
 }

--- a/core/src/main/java/tech/beshu/ror/httpclient/RRHttpRequest.java
+++ b/core/src/main/java/tech/beshu/ror/httpclient/RRHttpRequest.java
@@ -45,6 +45,10 @@ public class RRHttpRequest {
     return new RRHttpRequest(HttpMethod.GET, url, queryParams, headers, Optional.empty());
   }
 
+  public static RRHttpRequest post(URI url, Map<String, String> queryParams, Map<String, String> headers) {
+    return new RRHttpRequest(HttpMethod.POST, url, queryParams, headers, Optional.empty());
+  }
+
   public static RRHttpRequest get(URI url, Map<String, String> headers) {
     return get(url, Maps.newHashMap(), headers);
   }

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/UserGroupsProviderSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/UserGroupsProviderSettings.java
@@ -16,13 +16,20 @@
  */
 package tech.beshu.ror.settings.definitions;
 
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.LoggerFactory;
 import tech.beshu.ror.commons.settings.RawSettings;
 import tech.beshu.ror.commons.settings.SettingsMalformedException;
+import tech.beshu.ror.httpclient.HttpMethod;
 import tech.beshu.ror.settings.rules.CacheSettings;
 import tech.beshu.ror.settings.rules.NamedSettings;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 public class UserGroupsProviderSettings implements CacheSettings, NamedSettings {
 
@@ -32,21 +39,59 @@ public class UserGroupsProviderSettings implements CacheSettings, NamedSettings 
   private static final String PASSED_AS = "auth_token_passed_as";
   private static final String JSON_PATH = "response_groups_json_path";
   private static final String CACHE = "cache_ttl_in_sec";
+  public static final String DEFAULT_QUERY_PARAMS = "default_query_parameters";
+  public static final String DEFAULT_HEADERS = "default_headers";
   private static final Duration DEFAULT_CACHE_TTL = Duration.ZERO;
+  private static final String HTTP_METHOD = "http_method" ;
   private final String name;
   private final URI endpoint;
   private final String authTokenName;
   private final TokenPassingMethod authTokenPassedMethod;
   private final String responseGroupsJsonPath;
   private final Duration cacheTtl;
+  private final ImmutableMap<String, String> defaultHeaders;
+  private final ImmutableMap<String, String> defaultQueryParameters;
+  private final HttpMethod method;
+
+  org.slf4j.Logger logger = LoggerFactory.getLogger(UserGroupsProviderSettings.class);
 
   public UserGroupsProviderSettings(RawSettings settings) {
+    logger.info("***************Trying things out******************");
     this.name = settings.stringReq(NAME);
     this.endpoint = settings.uriReq(ENDPOINT);
     this.authTokenName = settings.stringReq(AUTH_TOKEN_NAME);
     this.authTokenPassedMethod = tokenPassingMethodFromString(settings.stringReq(PASSED_AS));
     this.responseGroupsJsonPath = settings.stringReq(JSON_PATH);
     this.cacheTtl = settings.intOpt(CACHE).map(Duration::ofSeconds).orElse(DEFAULT_CACHE_TTL);
+    this.defaultHeaders = settings.stringOpt(DEFAULT_HEADERS).isPresent() ? toMap.apply(
+        (LinkedHashMap) settings.asMap().get(DEFAULT_HEADERS)) : ImmutableMap.<String, String>of();
+    this.defaultQueryParameters = settings.stringOpt(DEFAULT_HEADERS).isPresent() ? toMap.apply(
+        (LinkedHashMap) settings.asMap().get(DEFAULT_QUERY_PARAMS)) : ImmutableMap.<String, String>of();
+    //this.defaultQueryParameters = getQueryParameters(settings);
+    this.method = httpMethodFromString(settings.stringReq(HTTP_METHOD));
+    System.out.printf("******************** this is initialized*******");
+  }
+
+  Function<LinkedHashMap<String, Object>, ImmutableMap<String, String>> toMap = (t) -> {
+    Map<String, String> temp = new HashMap<>();
+    t.entrySet().forEach(e -> temp.put(e.getKey(), String.valueOf(e.getValue())));
+    return ImmutableMap.copyOf(temp);
+  };
+
+  private ImmutableMap<String, String> getHeaders(RawSettings settings) {
+    if (settings.stringOpt(DEFAULT_HEADERS).isPresent()) {
+      return toMap.apply((LinkedHashMap) settings.asMap().get(DEFAULT_HEADERS));
+
+    }
+    return null;
+  }
+
+  private ImmutableMap<String, String> getQueryParameters(RawSettings settings) {
+    if (settings.stringOpt(DEFAULT_QUERY_PARAMS).isPresent()) {
+      HashMap s = (LinkedHashMap) settings.asMap().get(DEFAULT_QUERY_PARAMS);
+      return ImmutableMap.copyOf(s);
+    }
+    return null;
   }
 
   @Override
@@ -86,7 +131,30 @@ public class UserGroupsProviderSettings implements CacheSettings, NamedSettings 
     }
   }
 
+  private HttpMethod httpMethodFromString(String method) {
+    switch (method) {
+      case "get":
+        return HttpMethod.GET;
+      case "post":
+        return HttpMethod.POST;
+      default:
+        return HttpMethod.GET;
+    }
+  }
+
   public enum TokenPassingMethod {
     QUERY, HEADER
+  }
+
+  public ImmutableMap<String, String> getDefaultHeaders() {
+    return defaultHeaders;
+  }
+
+  public ImmutableMap<String, String> getDefaultQueryParameters() {
+    return defaultQueryParameters;
+  }
+
+  public HttpMethod getMethod() {
+    return method;
   }
 }

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/UserGroupsProviderSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/UserGroupsProviderSettings.java
@@ -42,7 +42,7 @@ public class UserGroupsProviderSettings implements CacheSettings, NamedSettings 
   public static final String DEFAULT_QUERY_PARAMS = "default_query_parameters";
   public static final String DEFAULT_HEADERS = "default_headers";
   private static final Duration DEFAULT_CACHE_TTL = Duration.ZERO;
-  private static final String HTTP_METHOD = "http_method" ;
+  private static final String HTTP_METHOD = "http_method";
   private final String name;
   private final URI endpoint;
   private final String authTokenName;
@@ -56,7 +56,6 @@ public class UserGroupsProviderSettings implements CacheSettings, NamedSettings 
   org.slf4j.Logger logger = LoggerFactory.getLogger(UserGroupsProviderSettings.class);
 
   public UserGroupsProviderSettings(RawSettings settings) {
-    logger.info("***************Trying things out******************");
     this.name = settings.stringReq(NAME);
     this.endpoint = settings.uriReq(ENDPOINT);
     this.authTokenName = settings.stringReq(AUTH_TOKEN_NAME);
@@ -67,9 +66,8 @@ public class UserGroupsProviderSettings implements CacheSettings, NamedSettings 
         (LinkedHashMap) settings.asMap().get(DEFAULT_HEADERS)) : ImmutableMap.<String, String>of();
     this.defaultQueryParameters = settings.stringOpt(DEFAULT_HEADERS).isPresent() ? toMap.apply(
         (LinkedHashMap) settings.asMap().get(DEFAULT_QUERY_PARAMS)) : ImmutableMap.<String, String>of();
-    //this.defaultQueryParameters = getQueryParameters(settings);
-    this.method = httpMethodFromString(settings.stringReq(HTTP_METHOD));
-    System.out.printf("******************** this is initialized*******");
+    this.method = settings.opt(HTTP_METHOD).isPresent()?httpMethodFromString(settings.stringReq(HTTP_METHOD)):
+        HttpMethod.GET;
   }
 
   Function<LinkedHashMap<String, Object>, ImmutableMap<String, String>> toMap = (t) -> {

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/UserGroupsProviderSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/UserGroupsProviderSettings.java
@@ -51,7 +51,7 @@ public class UserGroupsProviderSettings implements CacheSettings, NamedSettings 
   private final ImmutableMap<String, String> defaultHeaders;
   private final ImmutableMap<String, String> defaultQueryParameters;
   private final HttpMethod method;
-  private final Function<LinkedHashMap<String, Object>, ImmutableMap<String, String>> toMap = (map) -> {
+  private Function<LinkedHashMap<String, Object>, ImmutableMap<String, String>> toMap = (map) -> {
     Map<String, String> tempMap = new HashMap<>();
     map.entrySet().forEach(e -> tempMap.put(e.getKey(), String.valueOf(e.getValue())));
     return ImmutableMap.copyOf(tempMap);
@@ -110,7 +110,7 @@ public class UserGroupsProviderSettings implements CacheSettings, NamedSettings 
   }
 
   private HttpMethod httpMethodFromString(String method) {
-    return method.toLowerCase() == "post" ? HttpMethod.POST : HttpMethod.GET;
+    return method.equalsIgnoreCase("post") ? HttpMethod.POST : HttpMethod.GET;
   }
 
   public enum TokenPassingMethod {

--- a/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/GroupsProviderAuthorizationAsyncRuleTests.java
+++ b/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/GroupsProviderAuthorizationAsyncRuleTests.java
@@ -48,6 +48,9 @@ public class GroupsProviderAuthorizationAsyncRuleTests {
   public static WireMockContainer wireMockContainer = WireMockContainer.create("/groups_provider_authorization.json",
       "/group_provider_authorization_complex.json");
 
+  private final Function<ImmutableMap<String, String>, String> mapFormatter = map -> map.entrySet().stream().
+      map(y -> "      " + y.getKey() + ": " + y.getValue()).reduce("", (x, y) -> x + "\n" + y).concat("\n");
+
   @Test
   public void testUserAuthorizationSuccess() throws Exception {
     RuleExitResult result = createRuleRunMatch(Lists.newArrayList("group1", "group3"),
@@ -107,7 +110,6 @@ public class GroupsProviderAuthorizationAsyncRuleTests {
     return rule.match(requestContext).get();
   }
 
-
   @NotNull
   private String apiConfigs(String uri, String method, ImmutableMap<String, String> headers, ImmutableMap<String, String> query_params) {
     StringBuilder builder = new StringBuilder("" +
@@ -124,10 +126,6 @@ public class GroupsProviderAuthorizationAsyncRuleTests {
     builder.append(method != null ? "    http_method: " + method : "");
     return builder.toString();
   }
-
-  Function<ImmutableMap<String, String>, String> mapFormatter = map -> map.entrySet().stream().
-      map(y -> "      " + y.getKey() + ": " + y.getValue()).reduce("", (x, y) -> x + "\n" + y).concat("\n");
-
 
   @NotNull
   private String groupProviderConfig(List<String> ruleGroups) {

--- a/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/GroupsProviderAuthorizationAsyncRuleTests.java
+++ b/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/GroupsProviderAuthorizationAsyncRuleTests.java
@@ -45,7 +45,8 @@ import java.util.stream.Collectors;
 public class GroupsProviderAuthorizationAsyncRuleTests {
 
   @ClassRule
-  public static WireMockContainer wireMockContainer = WireMockContainer.create("/groups_provider_authorization.json",
+  public static WireMockContainer wireMockContainer = WireMockContainer.create(
+      "/groups_provider_authorization.json",
       "/group_provider_authorization_complex.json");
 
   private final Function<ImmutableMap<String, String>, String> mapFormatter = map -> map.entrySet().stream().
@@ -59,7 +60,7 @@ public class GroupsProviderAuthorizationAsyncRuleTests {
     result = createRuleRunMatch(Lists.newArrayList("group1", "group3"),
         "/complex/groups", "POST",
         ImmutableMap.of("Content-Type", "application/x-www-form-urlencoded",
-            "Authorization", "Basic base64_encoded_token"),
+            "Auth", "Basic base64_encoded_token"),
         ImmutableMap.of("return_groups", "true")
     );
     assertTrue(result.isMatch());

--- a/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/GroupsProviderAuthorizationAsyncRuleTests.java
+++ b/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/GroupsProviderAuthorizationAsyncRuleTests.java
@@ -16,11 +16,17 @@
  */
 package tech.beshu.ror.acl.blocks.rules.impl;
 
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.jetbrains.annotations.NotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
 import tech.beshu.ror.TestUtils;
 import tech.beshu.ror.acl.blocks.rules.RuleExitResult;
 import tech.beshu.ror.acl.definitions.DefinitionsFactory;
@@ -36,48 +42,62 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
 public class GroupsProviderAuthorizationAsyncRuleTests {
 
   @ClassRule
-  public static WireMockContainer wireMockContainer = WireMockContainer.create("/groups_provider_authorization.json");
+  public static WireMockContainer wireMockContainer = WireMockContainer.create("/groups_provider_authorization.json",
+      "/group_provider_authorization_complex.json");
 
   @Test
   public void testUserAuthorizationSuccess() throws Exception {
-    RuleExitResult result = createRuleRunMatch(Lists.newArrayList("group1", "group3"));
+    RuleExitResult result = createRuleRunMatch(Lists.newArrayList("group1", "group3"),
+        "/groups", null, null, null);
+    assertTrue(result.isMatch());
+    result = createRuleRunMatch(Lists.newArrayList("group1", "group3"),
+        "/complex/groups", "POST",
+        ImmutableMap.of("Content-Type", "application/x-www-form-urlencoded",
+            "Authorization", "Basic base64_encoded_token"),
+        ImmutableMap.of("return_groups", "true")
+    );
     assertTrue(result.isMatch());
   }
 
   @Test
   public void testUserAuthorizationFailedDueToGroupMismatching() throws Exception {
-    RuleExitResult result = createRuleRunMatch(Lists.newArrayList("group3", "group4"));
+    RuleExitResult result = createRuleRunMatch(Lists.newArrayList("group3", "group4"),
+        "/groups", null, null, null);
+    assertFalse(result.isMatch());
+    result = createRuleRunMatch(Lists.newArrayList("group1", "group3"),
+        "/complex/groups", "POST",
+        ImmutableMap.of("Content-Type", "application/x-www-form-urlencoded",
+            "Authorization", "Basic base64_encoded_token"),
+        ImmutableMap.of("return_Role", "true")
+    );
+    assertFalse(result.isMatch());
+
+    result = createRuleRunMatch(Lists.newArrayList("group1", "group3"),
+        "/complex/groups", "POST",
+        ImmutableMap.of("Content-Type", "application/x-www-form-urlencoded"),
+        ImmutableMap.of("return_Role", "true")
+    );
     assertFalse(result.isMatch());
   }
 
-  private RuleExitResult createRuleRunMatch(List<String> ruleGroups) throws Exception {
+
+  private RuleExitResult createRuleRunMatch(List<String> ruleGroups,
+                                            String uri, String method, ImmutableMap<String, String> headers,
+                                            ImmutableMap<String, String> query_params
+  ) throws Exception {
     GroupsProviderAuthorizationAsyncRule rule = new GroupsProviderAuthorizationAsyncRule(
-      GroupsProviderAuthorizationRuleSettings.from(
-        TestUtils.fromYAMLString("" +
-                                   "groups_provider_authorization:\n" +
-                                   "  user_groups_provider: \"provider1\"\n" +
-                                   "  groups: [" + Joiner.on(",").join(ruleGroups.stream().map(g -> "\"" + g + "\"").collect(Collectors.toSet())) + "]\n" +
-                                   "  cache_ttl_in_sec: 60").inner(GroupsProviderAuthorizationRuleSettings.ATTRIBUTE_NAME),
-        UserGroupsProviderSettingsCollection.from(
-          TestUtils.fromYAMLString("" +
-                                     "user_groups_providers:\n" +
-                                     "  - name: provider1\n" +
-                                     "    groups_endpoint: \"http://localhost:" + wireMockContainer.getWireMockPort() + "/groups\"\n" +
-                                     "    auth_token_name: \"userId\"\n" +
-                                     "    auth_token_passed_as: QUERY_PARAM\n" +
-                                     "    response_groups_json_path: \"$..groups[?(@.name)].name\"\n"
-          )
-        )
-      ),
-      new DefinitionsFactory(MockedESContext.INSTANCE, MockedACL.getMock()),
-      MockedESContext.INSTANCE
+        GroupsProviderAuthorizationRuleSettings.from(
+            TestUtils.fromYAMLString(groupProviderConfig(ruleGroups)).inner(GroupsProviderAuthorizationRuleSettings.ATTRIBUTE_NAME),
+            UserGroupsProviderSettingsCollection.from(
+                TestUtils.fromYAMLString(apiConfigs(uri, method, headers, query_params)
+                )
+            )
+        ),
+        new DefinitionsFactory(MockedESContext.INSTANCE, MockedACL.getMock()),
+        MockedESContext.INSTANCE
     );
 
     LoggedUser user = new LoggedUser("example_user");
@@ -86,4 +106,37 @@ public class GroupsProviderAuthorizationAsyncRuleTests {
 
     return rule.match(requestContext).get();
   }
+
+
+  @NotNull
+  private String apiConfigs(String uri, String method, ImmutableMap<String, String> headers, ImmutableMap<String, String> query_params) {
+    StringBuilder builder = new StringBuilder("" +
+        "user_groups_providers:\n" +
+        "  - name: provider1\n" +
+        "    groups_endpoint: \"http://localhost:" + wireMockContainer.getWireMockPort() + uri + "\"\n" +
+        "    auth_token_name: \"userId\"\n" +
+        "    auth_token_passed_as: QUERY_PARAM\n" +
+        "    response_groups_json_path: \"$..groups[?(@.name)].name\"\n");
+    builder.append(headers != null ? new StringBuilder().
+        append("    default_headers:\n").append(mapFormatter.apply(headers)).toString() : "");
+    builder.append(headers != null ? new StringBuilder().
+        append("    default_query_parameters:\n").append(mapFormatter.apply(query_params)).toString() : "");
+    builder.append(method != null ? "    http_method: " + method : "");
+    return builder.toString();
+  }
+
+  Function<ImmutableMap<String, String>, String> mapFormatter = map -> map.entrySet().stream().
+      map(y -> "      " + y.getKey() + ": " + y.getValue()).reduce("", (x, y) -> x + "\n" + y).concat("\n");
+
+
+  @NotNull
+  private String groupProviderConfig(List<String> ruleGroups) {
+    return "" +
+        "groups_provider_authorization:\n" +
+        "  user_groups_provider: \"provider1\"\n" +
+        "  groups: [" + Joiner.on(",").join(ruleGroups.stream().map(g -> "\"" + g + "\"").collect(Collectors.toSet())) + "]\n" +
+        "  cache_ttl_in_sec: 60";
+  }
+
+
 }

--- a/core/src/test/resources/group_provider_authorization_complex.json
+++ b/core/src/test/resources/group_provider_authorization_complex.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "ANY",
+    "urlPath": "/complex/groups",
+    "queryParameters": {
+      "userId": {
+        "equalTo": "example_user"
+      },
+      "return_groups": {
+        "equalTo": "true"
+      }
+    },
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/x-www-form-urlencoded"
+      },
+      "Authorization": {
+        "equalTo": "Basic base64_encoded_token"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{ \"sth\": \"unknown\", \"groups\": [ { \"name\": \"group1\" }, { \"name\": \"group2\" } ] }"
+  }
+}

--- a/core/src/test/resources/group_provider_authorization_complex.json
+++ b/core/src/test/resources/group_provider_authorization_complex.json
@@ -1,26 +1,24 @@
 {
   "request": {
-    "method": "ANY",
+    "method": "POST",
     "urlPath": "/complex/groups",
-    "queryParameters": {
-      "userId": {
-        "equalTo": "example_user"
-      },
-      "return_groups": {
-        "equalTo": "true"
-      }
-    },
     "headers": {
       "Content-Type": {
         "equalTo": "application/x-www-form-urlencoded"
       },
-      "Authorization": {
+      "Auth": {
         "equalTo": "Basic base64_encoded_token"
       }
-    }
+    },
+    "bodyPatterns": [
+      {
+        "matches": ".*return_groups=true.*"
+      }
+    ]
   },
-  "response": {
-    "status": 200,
-    "body": "{ \"sth\": \"unknown\", \"groups\": [ { \"name\": \"group1\" }, { \"name\": \"group2\" } ] }"
-  }
+    "response": {
+      "status": 200,
+      "body": "{ \"sth\": \"unknown\", \"groups\": [ { \"name\": \"group1\" }, { \"name\": \"group2\" } ] }"
+    }
+
 }


### PR DESCRIPTION
Updated the Group Service Configurations to support static headers and parameters to be configured.
Some API's need basic auth, some need Hmac token as request param, which can be statically configured in the configuration Yml. New updates won't affect the existing configurations and won't take effect unless configured.


