### PR TITLE
Add getContent() method to the RequestContextShim interface.

### DIFF
--- a/commons/src/main/java/tech/beshu/ror/commons/shims/request/RequestContextShim.java
+++ b/commons/src/main/java/tech/beshu/ror/commons/shims/request/RequestContextShim.java
@@ -37,6 +37,8 @@ public interface RequestContextShim {
 
   String getHistoryString();
 
+  String getContent();
+
   Integer getContentLength();
 
   String getRemoteAddress();

--- a/core/src/test/java/tech/beshu/ror/core/requestcontext/SerializationToolTests.java
+++ b/core/src/test/java/tech/beshu/ror/core/requestcontext/SerializationToolTests.java
@@ -78,6 +78,11 @@ public class SerializationToolTests {
     }
 
     @Override
+    public String getContent() {
+      return "";
+    }
+
+    @Override
     public Integer getContentLength() {
       return 0;
     }


### PR DESCRIPTION
This is to enable including the body of the request in the custom
AuditLogSerializer.

This method was already provided in all concrete implementation, this is just exposing it via the interface.