### PR TITLE
Result map was created but never used.

### DIFF
--- a/core/src/main/java/tech/beshu/ror/requestcontext/DefaultAuditLogSerializer.java
+++ b/core/src/main/java/tech/beshu/ror/requestcontext/DefaultAuditLogSerializer.java
@@ -23,7 +23,6 @@ import tech.beshu.ror.commons.shims.request.RequestContextShim;
 
 import java.text.SimpleDateFormat;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -36,11 +35,10 @@ public class DefaultAuditLogSerializer implements AuditLogSerializer<Map<String,
 
   @Override
   public Map<String, ?> createLoggableEntry(ResponseContext rc) {
-    Map<String, Object> result = new LinkedHashMap<>();
-    result.put("match", rc.getIsMatch());
-    result.put("block", rc.getReason());
-
     Map<String, Object> map = Maps.newHashMap();
+
+    map.put("match", rc.getIsMatch());
+    map.put("block", rc.getReason());
 
     map.put("id", rc.getRequestContext().getId());
     map.put("final_state", rc.finalState().name());

--- a/core/src/test/java/tech/beshu/ror/core/requestcontext/SerializationToolTests.java
+++ b/core/src/test/java/tech/beshu/ror/core/requestcontext/SerializationToolTests.java
@@ -137,7 +137,7 @@ public class SerializationToolTests {
     SerializationTool st = new SerializationTool(new MockedESContext());
     String ser = st.toJson(new ResponseContext(ResponseContext.FinalState.ALLOWED, requestContextShim, null, Verbosity.INFO, "because", true));
     System.out.println(ser);
-    Map<String, Object> ours = gson.fromJson("{\"error_message\":null,\"headers\":[\"Authorization\", \"X-Forwarded-For\"],\"acl_history\":\"history\",\"origin\":\"OA\",\"final_state\":\"ALLOWED\",\"destination\"=\"DA\",\"task_id\":0,\"type\":\"Object\",\"req_method\":\"GET\",\"path\":\"/_search\",\"indices\":[\"index1\"],\"@timestamp\":\"1970-01-01T00:00:00Z\",\"content_len_kb\":0,\"error_type\":null,\"processingMillis\":1510699696944,\"xff\"=\"123\",\"action\":\"theAction\",\"id\":\"123\",\"content_len\":0,\"user\":\"user\"}", Map.class);
+    Map<String, Object> ours = gson.fromJson("{\"error_message\":null,\"headers\":[\"Authorization\", \"X-Forwarded-For\"],\"acl_history\":\"history\",\"origin\":\"OA\",\"match\":true,\"final_state\":\"ALLOWED\",\"destination\"=\"DA\",\"task_id\":0,\"type\":\"Object\",\"req_method\":\"GET\",\"path\":\"/_search\",\"indices\":[\"index1\"],\"@timestamp\":\"1970-01-01T00:00:00Z\",\"content_len_kb\":0,\"error_type\":null,\"processingMillis\":1510699696944,\"xff\"=\"123\",\"action\":\"theAction\",\"block\":\"because\", \"id\":\"123\",\"content_len\":0,\"user\":\"user\"}", Map.class);
     Map<String, Object> theirs = gson.fromJson(ser, Map.class);
 
     // The processing millis is calculated on the fly, cannot predict that


### PR DESCRIPTION
As the consequence, "match" and "block" were never included in the
audit log entry.