### PR TITLE
Added QueryAuditSerializer which logs request content

### DIFF
--- a/core/src/main/java/tech/beshu/ror/requestcontext/QueryAuditLogSerializer.java
+++ b/core/src/main/java/tech/beshu/ror/requestcontext/QueryAuditLogSerializer.java
@@ -16,6 +16,8 @@
  */
 package tech.beshu.ror.requestcontext;
 
+import tech.beshu.ror.commons.ResponseContext;
+
 import java.util.Map;
 
 public class QueryAuditLogSerializer extends DefaultAuditLogSerializer {

--- a/core/src/main/java/tech/beshu/ror/requestcontext/QueryAuditLogSerializer.java
+++ b/core/src/main/java/tech/beshu/ror/requestcontext/QueryAuditLogSerializer.java
@@ -1,0 +1,31 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+package tech.beshu.ror.requestcontext;
+
+import java.util.Map;
+
+public class QueryAuditLogSerializer extends DefaultAuditLogSerializer {
+
+  @Override
+  public Map<String, ?> createLoggableEntry(ResponseContext rc) {
+    Map<String, Object> map = (Map<String, Object>)super.createLoggableEntry(rc);
+
+    map.put("content", rc.getRequestContext().getContent());
+
+    return map;
+  }
+}


### PR DESCRIPTION
The default serializer does not log the user request, e.g. what a user is searching for, which is necessary for some audit requirements.

This extended serializer logs the content part of the user's request.

It can be enabled by the configuratiion:
 audit_serializer: tech.beshu.ror.requestcontext.QueryAuditLogSerializer

If this pull request is successful I will do a pull request in the docs github to provide an example.