### PR TITLE
fix issue [jwt_auth rule throws ArrayIndexOutOfBoundsException #390] :

### DIFF
--- a/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthSyncRule.java
+++ b/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthSyncRule.java
@@ -117,6 +117,10 @@ public class JwtAuthSyncRule extends AsyncRule implements Authentication {
       }
       else {
         String[] ar = token.get().split("\\.");
+        if (ar.length < 2) {
+          // token is not a valid JWT
+          return CompletableFuture.completedFuture(NO_MATCH);
+        }
         String tokenNoSig = ar[0] + "." + ar[1] + ".";
         jws = parser.parseClaimsJwt(tokenNoSig).getBody();
       }


### PR DESCRIPTION
When using external validator in jwt_auth rule,
 avoid ArrayIndexOutOfBoundsException to be thrown when JWT is not valid