### PR TITLE
Allow custom jwt header prefix

### DIFF
--- a/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthAsyncRule.java
+++ b/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthAsyncRule.java
@@ -152,7 +152,6 @@ public class JwtAuthAsyncRule extends AsyncRule implements Authentication {
       }
       else {
         String[] ar = token.get().split("\\.");
-        logger.info("1--- " +  ar.toString());
         if (ar.length < 2) {
           // token is not a valid JWT
           return CompletableFuture.completedFuture(NO_MATCH);

--- a/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthAsyncRule.java
+++ b/core/src/main/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthAsyncRule.java
@@ -64,9 +64,9 @@ public class JwtAuthAsyncRule extends AsyncRule implements Authentication {
     this.secureStringHasher = new SecureStringHasher("sha256");
   }
 
-  private static Optional<String> extractToken(String authHeader) {
-    if (authHeader.startsWith("Bearer ")) {
-      String token = authHeader.substring(7).trim();
+  private Optional<String> extractToken(String authHeader) {
+    if (authHeader.startsWith(settings.getHeaderPrefix())) {
+      String token = authHeader.substring(settings.getHeaderPrefix().length()).trim();
       return Optional.ofNullable(Strings.emptyToNull(token));
     }
 
@@ -76,7 +76,7 @@ public class JwtAuthAsyncRule extends AsyncRule implements Authentication {
   @Override
   public CompletableFuture<RuleExitResult> match(RequestContext rc) {
     Optional<String> token = Optional.of(rc.getHeaders()).map(m -> m.get(settings.getHeaderName()))
-                                     .flatMap(JwtAuthAsyncRule::extractToken);
+                                     .flatMap(this::extractToken);
 
     /*
       JWT ALGO    FAMILY
@@ -152,6 +152,7 @@ public class JwtAuthAsyncRule extends AsyncRule implements Authentication {
       }
       else {
         String[] ar = token.get().split("\\.");
+        logger.info("1--- " +  ar.toString());
         if (ar.length < 2) {
           // token is not a valid JWT
           return CompletableFuture.completedFuture(NO_MATCH);

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
@@ -35,11 +35,13 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
   private static final String USER_CLAIM = "user_claim";
   private static final String ROLES_CLAIM = "roles_claim";
   private static final String HEADER_NAME = "header_name";
+  private static final String HEADER_PREFIX = "header_prefix";
   private static final String EXTERNAL_VALIDATOR = "external_validator.url";
   private static final String EXTERNAL_VALIDATOR_VALIDATE = "external_validator.validate";
   private static final String EXTERNAL_VALIDATOR_SUCCESS_STATUS_CODE = "external_validator.success_status_code";
   private static final String EXTERNAL_VALIDATOR_CACHE_TTL = "external_validator.cache_ttl_in_sec";
   private static final String DEFAULT_HEADER_NAME = "Authorization";
+  private static final String DEFAULT_HEADER_PREFIX = "Bearer ";
 
   private final String name;
   private final byte[] key;
@@ -48,6 +50,7 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
   private final Optional<String> algo;
   private final Optional<String> externalValidator;
   private final String headerName;
+  private final String headerPrefix;
   private final int externalValidatorCacheTtlSec;
   private final Boolean externalValidatorValidate;
   private final int externalValidatorSuccessStatusCode;
@@ -80,6 +83,7 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
     this.externalValidatorSuccessStatusCode = settings.intOpt(EXTERNAL_VALIDATOR_SUCCESS_STATUS_CODE).orElse(200);
     this.externalValidatorCacheTtlSec = settings.intOpt(EXTERNAL_VALIDATOR_CACHE_TTL).orElse(60);
     this.headerName = settings.stringOpt(HEADER_NAME).orElse(DEFAULT_HEADER_NAME);
+    this.headerPrefix = settings.stringOpt(HEADER_PREFIX).orElse(DEFAULT_HEADER_PREFIX);
   }
 
   private static String ensureString(RawSettings settings, String key) {
@@ -137,6 +141,10 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
 
   public String getHeaderName() {
     return headerName;
+  }
+
+  public String getHeaderPrefix() {
+    return headerPrefix;
   }
 
   public boolean getExternalValidatorValidate() {

--- a/core/src/main/java/tech/beshu/ror/settings/rules/JwtAuthRuleSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/rules/JwtAuthRuleSettings.java
@@ -80,6 +80,10 @@ public class JwtAuthRuleSettings implements RuleSettings, AuthKeyProviderSetting
     return jwtAuthSettings.getHeaderName();
   }
 
+  public String getHeaderPrefix() {
+    return jwtAuthSettings.getHeaderPrefix();
+  }
+
   public Optional<String> getExternalValidator() {
     return jwtAuthSettings.getExternalValidator();
   }

--- a/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthRuleTests.java
+++ b/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthRuleTests.java
@@ -63,6 +63,8 @@ public class JwtAuthRuleTests {
   private static final String SETTINGS_SIGNATURE_ALGO = "signature_algo";
   private static final String SETTINGS_USER_CLAIM = "user_claim";
   private static final String SETTINGS_ROLES_CLAIM = "roles_claim";
+  private static final String SETTINGS_HEADER_NAME = "header_name";
+  private static final String SETTINGS_HEADER_PREFIX = "header_prefix";
   private static final String ALGO = "HS256";
   private static final String SECRET = "123456";
   private static final String BAD_SECRET = "abcdef";
@@ -118,6 +120,28 @@ public class JwtAuthRuleTests {
 
     RawSettings settings = makeSettings(
         SETTINGS_SIGNATURE_ALGO, "NONE"
+    );
+
+    RequestContext rc = getMock(token);
+
+    Optional<AsyncRule> rule = makeRule(settings);
+    Optional<CompletableFuture<RuleExitResult>> res = rule.map(r -> r.match(rc));
+    rc.commit();
+
+    assertTrue(rule.isPresent());
+    assertTrue(res.isPresent());
+    res.get().thenAccept(r -> assertTrue(r.isMatch()));
+  }
+
+  @Test
+  public void shouldAcceptTokenWithCustomHeaderNameAndPrefix() throws KeyException {
+    String token = Jwts.builder()
+                       .setSubject(SUBJECT)
+                       .compact();
+
+    RawSettings settings = makeSettings(
+        SETTINGS_HEADER_NAME, "Cookie",
+        SETTINGS_HEADER_PREFIX, "JWT="
     );
 
     RequestContext rc = getMock(token);

--- a/es63x/src/main/java/tech/beshu/ror/es/RequestInfo.java
+++ b/es63x/src/main/java/tech/beshu/ror/es/RequestInfo.java
@@ -62,7 +62,6 @@ import tech.beshu.ror.commons.utils.RCUtils;
 import tech.beshu.ror.commons.utils.ReflecUtils;
 
 import java.lang.reflect.Field;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -445,17 +444,7 @@ public class RequestInfo implements RequestInfoShim {
 
   @Override
   public String extractRemoteAddress() {
-    InetSocketAddress remoteAddress = (InetSocketAddress) request.getRemoteAddress();
-    String remoteHost = null;
-    if (remoteAddress != null) {
-    	InetAddress address = remoteAddress.getAddress();
-    	if (address != null) {
-    		remoteHost = address.getHostAddress();
-    	}
-    }
-    if (remoteHost == null) {
-    	remoteHost = request.header("X-Forwarded-For");
-    }
+    String remoteHost = ((InetSocketAddress) request.getRemoteAddress()).getAddress().getHostAddress();
     // Make sure we recognize localhost even when IPV6 is involved
     if (RCUtils.isLocalHost(remoteHost)) {
       remoteHost = RCUtils.LOCALHOST;

--- a/es63x/src/main/java/tech/beshu/ror/es/RequestInfo.java
+++ b/es63x/src/main/java/tech/beshu/ror/es/RequestInfo.java
@@ -62,6 +62,7 @@ import tech.beshu.ror.commons.utils.RCUtils;
 import tech.beshu.ror.commons.utils.ReflecUtils;
 
 import java.lang.reflect.Field;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -444,7 +445,17 @@ public class RequestInfo implements RequestInfoShim {
 
   @Override
   public String extractRemoteAddress() {
-    String remoteHost = ((InetSocketAddress) request.getRemoteAddress()).getAddress().getHostAddress();
+    InetSocketAddress remoteAddress = (InetSocketAddress) request.getRemoteAddress();
+    String remoteHost = null;
+    if (remoteAddress != null) {
+    	InetAddress address = remoteAddress.getAddress();
+    	if (address != null) {
+    		remoteHost = address.getHostAddress();
+    	}
+    }
+    if (remoteHost == null) {
+    	remoteHost = request.header("X-Forwarded-For");
+    }
     // Make sure we recognize localhost even when IPV6 is involved
     if (RCUtils.isLocalHost(remoteHost)) {
       remoteHost = RCUtils.LOCALHOST;

--- a/integration-tests/src/test/java/tech/beshu/ror/integration/JwtAuthTests.java
+++ b/integration-tests/src/test/java/tech/beshu/ror/integration/JwtAuthTests.java
@@ -88,6 +88,12 @@ public class JwtAuthTests {
   }
 
   @Test
+  public void acceptValidTokentWithUserClaimAndCustomHeaderAndCustomHeaderPrefix() throws Exception {
+    int sc = test(makeToken(KEY, makeClaimMap(USER_CLAIM, "user")), Optional.of("x-custom-header2"), Optional.of("x-custom-prefix"));
+    assertEquals(200, sc);
+  }
+
+  @Test
   public void rejectTokentWithUserClaimAndCustomHeader() throws Exception {
     int sc = test(makeToken(KEY, makeClaimMap("inexistent_claim", "user")), Optional.of("x-custom-header"), false);
     assertEquals(401, sc);
@@ -126,9 +132,13 @@ public class JwtAuthTests {
   }
 
   private int test(Optional<String> token, Optional<String> headerName, boolean withBearer) throws Exception {
+    return test(token, headerName, Optional.of(withBearer ? "Bearer " : ""));
+  }
+
+  private int test(Optional<String> token, Optional<String> headerName, Optional<String> headerPrefix) throws Exception {
     RestClient rc = container.getClient();
     HttpGet req = new HttpGet(rc.from("/_cat/indices"));
-    token.ifPresent(t -> req.addHeader(headerName.orElse("Authorization"), (withBearer ? "Bearer " : "") + t));
+    token.ifPresent(t -> req.addHeader(headerName.orElse("Authorization"), headerPrefix.orElse("") + t));
     HttpResponse resp = rc.execute(req);
     return resp.getStatusLine().getStatusCode();
   }

--- a/integration-tests/src/test/resources/jwt_auth/elasticsearch.yml
+++ b/integration-tests/src/test/resources/jwt_auth/elasticsearch.yml
@@ -30,6 +30,10 @@ readonlyrest:
         name: "jwt3"
         roles: ["role_viewer", "role_xyz"]
 
+    - name: Valid JWT token is present in custom header and header prefix
+      type: allow
+      jwt_auth: "jwt4"
+
   jwt:
     - name: jwt1
       signature_key: "123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456"
@@ -44,6 +48,12 @@ readonlyrest:
       signature_key: "1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890.1234567890"
       user_claim: user
       roles_claim: roles
+
+    - name: jwt4
+      header_name: x-custom-header2
+      header_prefix: x-custom-prefix
+      signature_key: "123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456.123456"
+      user_claim: user
 
 
 


### PR DESCRIPTION
I'm saving the token in cookies (https://docs.micronaut.io/latest/guide/index.html#cookieToken), so by default, the request is sent with a different header.

For example, instead of Authorization: Bearer <token>, allow this: Cookie: JWT=<token>

