### PR TITLE
Made HTTP Connection configurable

### DIFF
--- a/core/src/main/java/tech/beshu/ror/acl/definitions/DefinitionsFactory.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/DefinitionsFactory.java
@@ -76,7 +76,6 @@ public class DefinitionsFactory implements LdapClientFactory,
 
   public DefinitionsFactory(ESContext context, ACL acl) {
     this.acl = acl;
-    //this.httpClient = new ApacheHttpCoreClient(context);
     this.context = context;
     this.groupsProviderLdapClientsCache = CacheBuilder.newBuilder().build();
     this.authenticationLdapClientsCache = CacheBuilder.newBuilder().build();

--- a/core/src/main/java/tech/beshu/ror/acl/definitions/DefinitionsFactory.java
+++ b/core/src/main/java/tech/beshu/ror/acl/definitions/DefinitionsFactory.java
@@ -172,7 +172,7 @@ public class DefinitionsFactory implements LdapClientFactory,
         () -> wrapInCacheIfCacheIsEnabled(
             settings,
             new ExternalAuthenticationServiceHttpClient(
-                new ApacheHttpCoreClient(context, settings.getValidate()),
+                new ApacheHttpCoreClient(context, settings.getHttpConnectionSettings()),
                 settings.getEndpoint(),
                 settings.getSuccessStatusCode()
             )
@@ -189,7 +189,7 @@ public class DefinitionsFactory implements LdapClientFactory,
             settings,
             new GroupsProviderServiceHttpClient(
                 settings.getName(),
-                new ApacheHttpCoreClient(context, true),
+                new ApacheHttpCoreClient(context, settings.getHttpConnectionSettings()),
                 settings.getEndpoint(),
                 settings.getAuthTokenName(),
                 settings.getMethod(),
@@ -232,7 +232,7 @@ public class DefinitionsFactory implements LdapClientFactory,
     URI finalExternalUrl = externalUrl;
     NamedSettings ns = settings;
     ExternalAuthenticationServiceClient authcli = new JwtExternalValidationHttpClient(
-        new ApacheHttpCoreClient(context, settings.getExternalValidatorValidate()),
+        new ApacheHttpCoreClient(context, settings.getExternalValidatorHttpConnectionSettings()),
         finalExternalUrl,
         settings.getExternalValidatorSuccessStatusCode()
     );

--- a/core/src/main/java/tech/beshu/ror/settings/HttpConnectionSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/HttpConnectionSettings.java
@@ -1,3 +1,20 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
 package tech.beshu.ror.settings;
 
 import org.apache.http.client.config.RequestConfig;

--- a/core/src/main/java/tech/beshu/ror/settings/HttpConnectionSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/HttpConnectionSettings.java
@@ -1,0 +1,61 @@
+package tech.beshu.ror.settings;
+
+import org.apache.http.client.config.RequestConfig;
+import tech.beshu.ror.commons.settings.RawSettings;
+
+import java.time.Duration;
+
+public class HttpConnectionSettings {
+
+    private static final String CONNECTION_TIMEOUT = "connection_timeout_in_sec";
+    private static final String SOCKET_TIMEOUT = "socket_timeout_in_sec";
+    private static final String CONNECTION_REQUEST_TIMEOUT = "connection_request_timeout_in_sec";
+    private static final String CONNECTION_POOL_SIZE = "connection_pool_size";
+
+    private static final int DEFAULT_CONNECTION_POOL_SIZE = 30;
+    private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration DEFAULT_SOCKET_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration DEFAULT_CONNECTION_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private final Duration connectTimeout;
+    private final Duration socketTimeout;
+    private final Integer connectionPoolSize;
+    private final Duration connectionRequestTimeout;
+    private final boolean validate;
+
+    public HttpConnectionSettings(RawSettings settings, boolean validate) {
+        this.connectionPoolSize = settings.intOpt(CONNECTION_POOL_SIZE).orElse(DEFAULT_CONNECTION_POOL_SIZE);
+        this.connectionRequestTimeout = settings.intOpt(CONNECTION_REQUEST_TIMEOUT).map(Duration::ofSeconds).orElse(DEFAULT_CONNECTION_REQUEST_TIMEOUT);
+        this.connectTimeout = settings.intOpt(CONNECTION_TIMEOUT).map(Duration::ofSeconds).orElse(DEFAULT_CONNECTION_TIMEOUT);
+        this.socketTimeout = settings.intOpt(SOCKET_TIMEOUT).map(Duration::ofSeconds).orElse(DEFAULT_SOCKET_TIMEOUT);
+        this.validate = validate;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public Duration getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public Integer getConnectionPoolSize() {
+        return connectionPoolSize;
+    }
+
+    public Duration getConnectionRequestTimeout() {
+        return connectionRequestTimeout;
+    }
+
+    public boolean getValidateHttps() {
+        return validate;
+    }
+
+    public RequestConfig toRequestConfig() {
+        return RequestConfig.custom()
+                .setSocketTimeout((int) this.getSocketTimeout().toMillis())
+                .setConnectTimeout((int) this.getConnectTimeout().toMillis())
+                .setConnectionRequestTimeout((int) this.getConnectionRequestTimeout().toMillis())
+                .build();
+    }
+}

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/ExternalAuthenticationServiceSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/ExternalAuthenticationServiceSettings.java
@@ -17,6 +17,7 @@
 package tech.beshu.ror.settings.definitions;
 
 import tech.beshu.ror.commons.settings.RawSettings;
+import tech.beshu.ror.settings.HttpConnectionSettings;
 import tech.beshu.ror.settings.rules.CacheSettings;
 import tech.beshu.ror.settings.rules.NamedSettings;
 
@@ -30,6 +31,7 @@ public class ExternalAuthenticationServiceSettings implements CacheSettings, Nam
   private static final String SUCCESS_STATUS_CODE = "success_status_code";
   private static final String CACHE = "cache_ttl_in_sec";
   private static final String VALIDATE = "validate";
+  private static final String HTTP_CONNECTION_SETTINGS = "http_connection_settings";
 
   private static final int DEFAULT_SUCCESS_STATUS_CODE = 204;
   private static final Duration DEFAULT_CACHE_TTL = Duration.ZERO;
@@ -38,14 +40,16 @@ public class ExternalAuthenticationServiceSettings implements CacheSettings, Nam
   private final URI endpoint;
   private final int successStatusCode;
   private final Duration cacheTtl;
-  private final boolean validate;
+  private final HttpConnectionSettings httpConnectionSettings;
 
   public ExternalAuthenticationServiceSettings(RawSettings settings) {
     this.name = settings.stringReq(NAME);
     this.endpoint = settings.uriReq(ENDPOINT);
     this.successStatusCode = settings.intOpt(SUCCESS_STATUS_CODE).orElse(DEFAULT_SUCCESS_STATUS_CODE);
     this.cacheTtl = settings.intOpt(CACHE).map(Duration::ofSeconds).orElse(DEFAULT_CACHE_TTL);
-    this.validate = settings.booleanOpt(VALIDATE).orElse(true);
+
+    boolean validate = settings.booleanOpt(VALIDATE).orElse(true);
+    this.httpConnectionSettings = new HttpConnectionSettings(settings.innerOpt(HTTP_CONNECTION_SETTINGS).orElse(RawSettings.empty()), validate);
   }
 
   @Override
@@ -61,12 +65,12 @@ public class ExternalAuthenticationServiceSettings implements CacheSettings, Nam
     return successStatusCode;
   }
 
-  public boolean getValidate() {
-    return validate;
-  }
-
   @Override
   public Duration getCacheTtl() {
     return cacheTtl;
+  }
+
+  public HttpConnectionSettings getHttpConnectionSettings() {
+    return httpConnectionSettings;
   }
 }

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
@@ -20,6 +20,7 @@ package tech.beshu.ror.settings.definitions;
 import com.google.common.base.Strings;
 import tech.beshu.ror.commons.settings.RawSettings;
 import tech.beshu.ror.commons.settings.SettingsMalformedException;
+import tech.beshu.ror.settings.HttpConnectionSettings;
 import tech.beshu.ror.settings.rules.NamedSettings;
 
 import java.time.Duration;
@@ -39,6 +40,7 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
   private static final String EXTERNAL_VALIDATOR_VALIDATE = "external_validator.validate";
   private static final String EXTERNAL_VALIDATOR_SUCCESS_STATUS_CODE = "external_validator.success_status_code";
   private static final String EXTERNAL_VALIDATOR_CACHE_TTL = "external_validator.cache_ttl_in_sec";
+  private static final String EXTERNAL_VALIDATOR_HTTP_CONNECTION_SETTINGS = "external_validator.http_connection_settings";
   private static final String DEFAULT_HEADER_NAME = "Authorization";
 
   private final String name;
@@ -49,8 +51,8 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
   private final Optional<String> externalValidator;
   private final String headerName;
   private final int externalValidatorCacheTtlSec;
-  private final Boolean externalValidatorValidate;
   private final int externalValidatorSuccessStatusCode;
+  private HttpConnectionSettings externalValidatorHttpConnectionSettings;
 
   public JwtAuthDefinitionSettings(RawSettings settings) {
     this.name = settings.stringReq(NAME);
@@ -76,10 +78,12 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
     this.userClaim = settings.stringOpt(USER_CLAIM);
     this.rolesClaim = settings.stringOpt(ROLES_CLAIM);
     this.externalValidator = settings.stringOpt(EXTERNAL_VALIDATOR);
-    this.externalValidatorValidate = settings.booleanOpt(EXTERNAL_VALIDATOR_VALIDATE).orElse(true);
+    this.headerName = settings.stringOpt(HEADER_NAME).orElse(DEFAULT_HEADER_NAME);
     this.externalValidatorSuccessStatusCode = settings.intOpt(EXTERNAL_VALIDATOR_SUCCESS_STATUS_CODE).orElse(200);
     this.externalValidatorCacheTtlSec = settings.intOpt(EXTERNAL_VALIDATOR_CACHE_TTL).orElse(60);
-    this.headerName = settings.stringOpt(HEADER_NAME).orElse(DEFAULT_HEADER_NAME);
+
+    boolean externalValidatorValidate = settings.booleanOpt(EXTERNAL_VALIDATOR_VALIDATE).orElse(true);
+    this.externalValidatorHttpConnectionSettings = new HttpConnectionSettings(settings.innerOpt(EXTERNAL_VALIDATOR_HTTP_CONNECTION_SETTINGS).orElse(RawSettings.empty()), externalValidatorValidate);
   }
 
   private static String ensureString(RawSettings settings, String key) {
@@ -139,11 +143,11 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
     return headerName;
   }
 
-  public boolean getExternalValidatorValidate() {
-    return externalValidatorValidate;
-  }
-
   public int getExternalValidatorSuccessStatusCode() {
     return externalValidatorSuccessStatusCode;
+  }
+
+  public HttpConnectionSettings getExternalValidatorHttpConnectionSettings() {
+    return externalValidatorHttpConnectionSettings;
   }
 }

--- a/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/definitions/JwtAuthDefinitionSettings.java
@@ -81,7 +81,6 @@ public class JwtAuthDefinitionSettings implements NamedSettings {
     this.userClaim = settings.stringOpt(USER_CLAIM);
     this.rolesClaim = settings.stringOpt(ROLES_CLAIM);
     this.externalValidator = settings.stringOpt(EXTERNAL_VALIDATOR);
-    this.headerName = settings.stringOpt(HEADER_NAME).orElse(DEFAULT_HEADER_NAME);
     this.externalValidatorSuccessStatusCode = settings.intOpt(EXTERNAL_VALIDATOR_SUCCESS_STATUS_CODE).orElse(200);
     this.externalValidatorCacheTtlSec = settings.intOpt(EXTERNAL_VALIDATOR_CACHE_TTL).orElse(60);
     this.headerName = settings.stringOpt(HEADER_NAME).orElse(DEFAULT_HEADER_NAME);

--- a/core/src/main/java/tech/beshu/ror/settings/rules/JwtAuthRuleSettings.java
+++ b/core/src/main/java/tech/beshu/ror/settings/rules/JwtAuthRuleSettings.java
@@ -19,6 +19,7 @@ package tech.beshu.ror.settings.rules;
 
 import tech.beshu.ror.commons.settings.RawSettings;
 import tech.beshu.ror.settings.AuthKeyProviderSettings;
+import tech.beshu.ror.settings.HttpConnectionSettings;
 import tech.beshu.ror.settings.RuleSettings;
 import tech.beshu.ror.settings.definitions.JwtAuthDefinitionSettings;
 import tech.beshu.ror.settings.definitions.JwtAuthDefinitionSettingsCollection;
@@ -93,10 +94,6 @@ public class JwtAuthRuleSettings implements RuleSettings, AuthKeyProviderSetting
     return ATTRIBUTE_NAME;
   }
 
-  public boolean getExternalValidatorValidate() {
-    return jwtAuthSettings.getExternalValidatorValidate();
-  }
-
   public int getExternalValidatorSuccessStatusCode() {
     return jwtAuthSettings.getExternalValidatorSuccessStatusCode();
   }
@@ -104,5 +101,9 @@ public class JwtAuthRuleSettings implements RuleSettings, AuthKeyProviderSetting
   @Override
   public Duration getCacheTtl() {
     return jwtAuthSettings.getExternalValidatorCacheTtl();
+  }
+
+  public HttpConnectionSettings getExternalValidatorHttpConnectionSettings() {
+    return jwtAuthSettings.getExternalValidatorHttpConnectionSettings();
   }
 }

--- a/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthRuleTests.java
+++ b/core/src/test/java/tech/beshu/ror/acl/blocks/rules/impl/JwtAuthRuleTests.java
@@ -58,7 +58,6 @@ import static org.mockito.Mockito.when;
 public class JwtAuthRuleTests {
 
   private static final String JWT_NAME = "test-jwt";
-  ;
   private static final String SETTINGS_SIGNATURE_KEY = "signature_key";
   private static final String SETTINGS_SIGNATURE_ALGO = "signature_algo";
   private static final String SETTINGS_USER_CLAIM = "user_claim";

--- a/core/src/test/java/tech/beshu/ror/settings/ExternalAuthenticationSettingsTests.java
+++ b/core/src/test/java/tech/beshu/ror/settings/ExternalAuthenticationSettingsTests.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import tech.beshu.ror.TestUtils;
 import tech.beshu.ror.settings.definitions.ExternalAuthenticationServiceSettingsCollection;
 
-import java.net.URISyntaxException;
 import java.time.Duration;
 
 public class ExternalAuthenticationSettingsTests {

--- a/core/src/test/java/tech/beshu/ror/settings/ExternalAuthenticationSettingsTests.java
+++ b/core/src/test/java/tech/beshu/ror/settings/ExternalAuthenticationSettingsTests.java
@@ -16,31 +16,62 @@
  */
 package tech.beshu.ror.settings;
 
+import org.junit.Assert;
 import org.junit.Test;
 import tech.beshu.ror.TestUtils;
 import tech.beshu.ror.settings.definitions.ExternalAuthenticationServiceSettingsCollection;
 
 import java.net.URISyntaxException;
+import java.time.Duration;
 
 public class ExternalAuthenticationSettingsTests {
 
   @Test
-  public void testSuccessfulCreationFromRequiredSettings() throws URISyntaxException {
-    ExternalAuthenticationServiceSettingsCollection.from(
-      TestUtils.fromYAMLString("" +
-                                 "external_authentication_service_configs:\n" +
-                                 "    - name: \"ext1\"\n" +
-                                 "      authentication_endpoint: \"http://localhost:8080/auth1\"\n" +
-                                 "      success_status_code: 200\n" +
-                                 "      cache_ttl_in_sec: 60\n" +
-                                 "      validate: true\n" +
-                                 "\n" +
-                                 "    - name: \"ext2\"\n" +
-                                 "      authentication_endpoint: \"http://192.168.0.1:8080/auth2\"\n" +
-                                 "      success_status_code: 204\n" +
-                                 "      cache_ttl_in_sec: 60\n" +
-                                 "      validate: false"
-      )
+  public void testSuccessfulCreationFromRequiredSettingsWithoutHttpConnection() {
+    ExternalAuthenticationServiceSettingsCollection settings = ExternalAuthenticationServiceSettingsCollection.from(
+            TestUtils.fromYAMLString("" +
+                    "external_authentication_service_configs:\n" +
+                    "    - name: \"ext1\"\n" +
+                    "      authentication_endpoint: \"http://localhost:8080/auth1\"\n" +
+                    "      success_status_code: 200\n" +
+                    "      cache_ttl_in_sec: 60\n" +
+                    "      validate: true\n" +
+                    "\n" +
+                    "    - name: \"ext2\"\n" +
+                    "      authentication_endpoint: \"http://192.168.0.1:8080/auth2\"\n" +
+                    "      success_status_code: 204\n" +
+                    "      cache_ttl_in_sec: 60\n" +
+                    "      validate: false"
+            )
     );
+
+    Assert.assertEquals("Uses default connection pool size", 30, (long) settings.get("ext1").getHttpConnectionSettings().getConnectionPoolSize());
+    Assert.assertEquals("http://localhost:8080/auth1", settings.get("ext1").getEndpoint().toString());
+    Assert.assertEquals("http://192.168.0.1:8080/auth2", settings.get("ext2").getEndpoint().toString());
+  }
+
+  @Test
+  public void testSuccessfulCreationFromRequiredSettingsWithHttpConnection() {
+    ExternalAuthenticationServiceSettingsCollection settings = ExternalAuthenticationServiceSettingsCollection.from(
+            TestUtils.fromYAMLString("" +
+                    "external_authentication_service_configs:\n" +
+                    "    - name: \"ext1\"\n" +
+                    "      authentication_endpoint: \"http://localhost:8080/auth1\"\n" +
+                    "      success_status_code: 200\n" +
+                    "      cache_ttl_in_sec: 60\n" +
+                    "      validate: true\n" +
+                    "      http_connection_settings:\n" +
+                    "          connection_timeout_in_sec: 30\n" +
+                    "          socket_timeout_in_sec: 8\n" +
+                    "          connection_request_timeout_in_sec: 12\n" +
+                    "          connection_pool_size: 100\n"
+            )
+    );
+
+    HttpConnectionSettings connectionSettings = settings.get("ext1").getHttpConnectionSettings();
+    Assert.assertEquals(Duration.ofSeconds(30), connectionSettings.getConnectTimeout());
+    Assert.assertEquals(Duration.ofSeconds(8), connectionSettings.getSocketTimeout());
+    Assert.assertEquals(Duration.ofSeconds(12), connectionSettings.getConnectionRequestTimeout());
+    Assert.assertEquals(100, (long) connectionSettings.getConnectionPoolSize());
   }
 }


### PR DESCRIPTION
LDAP is already configurable, but this does not seem to be the case for other external autentication providers.

I considered adding a retry handler, but it doesn't look like that is supported in AsyncHttpClient, so it's probably better to not clutter things with some custom implementation of that (at least for now!).

Remaining work:

- [x] Docs
- [x] Consider adding retry support using [Apache DefaultHttpRequestRetryHandler](http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/DefaultHttpRequestRetryHandler.html)