### PR TITLE
fixed: if groups field is not found, we treat this situation as same …

### DIFF
--- a/corex/src/main/scala/tech/beshu/ror/acl/blocks/rules/JwtAuthRule.scala
+++ b/corex/src/main/scala/tech/beshu/ror/acl/blocks/rules/JwtAuthRule.scala
@@ -143,7 +143,8 @@ class JwtAuthRule(val settings: JwtAuthRule.Settings)
   private def handleGroupsClaimSearchResult(blockContext: BlockContext, result: Option[ClaimSearchResult[Set[Group]]]) = {
     result match {
       case None if settings.groups.nonEmpty => Left(())
-      case Some(NotFound) => Left(())
+      case Some(NotFound) if settings.groups.nonEmpty => Left(())
+      case Some(NotFound) => Right(blockContext) // if groups field is not found, we treat this situation as same as empty groups would be passed
       case Some(Found(groups)) if settings.groups.nonEmpty =>
         NonEmptySet.fromSet(SortedSet.empty[Group] ++ groups.intersect(settings.groups)) match {
           case Some(matchedGroups) => Right {

--- a/corex/src/main/scala/tech/beshu/ror/acl/blocks/rules/RorKbnAuthRule.scala
+++ b/corex/src/main/scala/tech/beshu/ror/acl/blocks/rules/RorKbnAuthRule.scala
@@ -110,7 +110,8 @@ class RorKbnAuthRule(val settings: Settings)
 
   private def handleGroupsClaimSearchResult(blockContext: BlockContext, result: ClaimSearchResult[Set[Group]]) = {
     result match {
-      case NotFound => Left(())
+      case NotFound if settings.groups.nonEmpty => Left(())
+      case NotFound => Right(blockContext) // if groups field is not found, we treat this situation as same as empty groups would be passed
       case Found(groups) if settings.groups.nonEmpty =>
         NonEmptySet.fromSet(SortedSet.empty[Group] ++ groups.intersect(settings.groups)) match {
           case Some(matchedGroups) => Right {

--- a/corex/src/main/scala/tech/beshu/ror/acl/utils/ClaimsOps.scala
+++ b/corex/src/main/scala/tech/beshu/ror/acl/utils/ClaimsOps.scala
@@ -47,7 +47,8 @@ class ClaimsOps(val claims: Claims) extends AnyVal {
   // todo: use json path (with jackson? or maybe we can convert java map to json?)
   def groupsClaim(name: ClaimName): ClaimSearchResult[Set[Group]] = {
     val result = name.value.value.split("[.]").toList match {
-      case Nil | _ :: Nil => Option(claims.get(name.value.value, classOf[Object]))
+      case Nil | _ :: Nil =>
+        Option(claims.get(name.value.value, classOf[Object]))
       case path :: restPaths =>
         restPaths.foldLeft(Option(claims.get(path, classOf[Object]))) {
           case (None, _) => None

--- a/corex/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/JwtAuthRuleTests.scala
+++ b/corex/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/JwtAuthRuleTests.scala
@@ -360,6 +360,7 @@ class JwtAuthRuleTests
             userClaim = Some(ClaimName("userId".nonempty)),
             groupsClaim = Some(ClaimName("tech.beshu.groups.subgroups".nonempty))
           ),
+          configuredGroups = Set(Group("group1".nonempty)),
           tokenHeader = Header(
             Header.Name.authorization,
             {

--- a/corex/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/RorKbnAuthRuleTests.scala
+++ b/corex/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/RorKbnAuthRuleTests.scala
@@ -94,6 +94,31 @@ class RorKbnAuthRuleTests
             )(blockContext)
         }
       }
+      "groups claim name is defined and no groups field is passed in token claim" in {
+        val key: Key = Keys.secretKeyFor(SignatureAlgorithm.valueOf("HS256"))
+        assertMatchRule(
+          configuredRorKbnDef = RorKbnDef(
+            RorKbnDef.Name("test".nonempty),
+            SignatureCheckMethod.Hmac(key.getEncoded)
+          ),
+          configuredGroups = Set.empty,
+          tokenHeader = Header(
+            Header.Name.authorization,
+            {
+              val jwtBuilder = Jwts.builder
+                .signWith(key)
+                .setSubject("test")
+                .claim("user", "user1")
+              NonEmptyString.unsafeFrom(s"Bearer ${jwtBuilder.compact}")
+            }
+          )
+        ) {
+          blockContext =>
+            assertBlockContext(
+              loggedUser = Some(LoggedUser(User.Id("user1")))
+            )(blockContext)
+        }
+      }
       "rule groups are defined and intersection between those groups and Ror Kbn ones is not empty" in {
         val key: Key = Keys.secretKeyFor(SignatureAlgorithm.valueOf("HS256"))
         assertMatchRule(

--- a/corex/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/RorKbnAuthRuleTests.scala
+++ b/corex/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/RorKbnAuthRuleTests.scala
@@ -211,13 +211,14 @@ class RorKbnAuthRuleTests
           )
         )
       }
-      "groups aren't passed in JWT token claim" in {
+      "groups aren't passed in JWT token claim while some groups are defined in settings" in {
         val key: Key = Keys.secretKeyFor(SignatureAlgorithm.valueOf("HS256"))
         assertNotMatchRule(
           configuredRorKbnDef = RorKbnDef(
             RorKbnDef.Name("test".nonempty),
             SignatureCheckMethod.Hmac(key.getEncoded)
           ),
+          configuredGroups = Set(Group("g1".nonempty)),
           tokenHeader = Header(
             Header.Name.authorization,
             {


### PR DESCRIPTION
…as empty groups would be passed