### PR TITLE
Add a boolean group_attribute_is_dn to query user_dn or user_uid

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/acl/blocks/definitions/ldap/implementations/UnboundidLdapService.scala
+++ b/core/src/main/scala/tech/beshu/ror/acl/blocks/definitions/ldap/implementations/UnboundidLdapService.scala
@@ -155,7 +155,8 @@ class UnboundidLdapAuthorizationService private(override val id: LdapService#Id,
   }
 
   private def searchFilterFrom(mode: DefaultGroupSearch, user: LdapUser) = {
-    s"(&${mode.groupSearchFilter}(${mode.uniqueMemberAttribute}=${Filter.encodeValue(user.dn.value.value)}))"
+    if (mode.groupAttributeIsDN) s"(&${mode.groupSearchFilter}(${mode.uniqueMemberAttribute}=${Filter.encodeValue(user.dn.value.value)}))"
+    else s"(&${mode.groupSearchFilter}(${mode.uniqueMemberAttribute}=${user.id.value}))"
   }
 
   private def searchGroupsLdapRequest(listener: AsyncSearchResultListener,
@@ -316,7 +317,8 @@ object UserGroupsSearchFilterConfig {
     final case class DefaultGroupSearch(searchGroupBaseDN: Dn,
                                         groupNameAttribute: NonEmptyString,
                                         uniqueMemberAttribute: NonEmptyString,
-                                        groupSearchFilter: NonEmptyString)
+                                        groupSearchFilter: NonEmptyString,
+                                        groupAttributeIsDN: Boolean)
       extends UserGroupsSearchMode
 
     final case class GroupsFromUserAttribute(searchGroupBaseDN: Dn,

--- a/core/src/main/scala/tech/beshu/ror/acl/factory/decoders/definitions/LdapServicesDecoder.scala
+++ b/core/src/main/scala/tech/beshu/ror/acl/factory/decoders/definitions/LdapServicesDecoder.scala
@@ -153,11 +153,13 @@ object LdapServicesDecoder {
         groupNameAttribute <- c.downNonEmptyOptionalField("group_name_attribute")
         uniqueMemberAttribute <- c.downNonEmptyOptionalField("unique_member_attribute")
         groupSearchFilter <- c.downNonEmptyOptionalField("group_search_filter")
+        groupAttributeIsDN <- c.downField("group_attribute_is_dn").as[Option[Boolean]]
       } yield DefaultGroupSearch(
         searchGroupBaseDn,
         groupNameAttribute.getOrElse(NonEmptyString.unsafeFrom("cn")),
         uniqueMemberAttribute.getOrElse(NonEmptyString.unsafeFrom("uniqueMember")),
-        groupSearchFilter.getOrElse(NonEmptyString.unsafeFrom("(cn=*)"))
+        groupSearchFilter.getOrElse(NonEmptyString.unsafeFrom("(cn=*)")),
+        groupAttributeIsDN.getOrElse(true)
       )
     }
 

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/definitions/UnboundidLdapAuthorizationServiceTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/definitions/UnboundidLdapAuthorizationServiceTests.scala
@@ -77,7 +77,8 @@ class UnboundidLdapAuthorizationServiceTests extends WordSpec with ForAllTestCon
           Dn("ou=Groups,dc=example,dc=com".nonempty),
           "cn".nonempty,
           "uniqueMember".nonempty,
-          "(cn=*)".nonempty
+          "(cn=*)".nonempty,
+          true
         ))
       )
       .runSyncUnsafe()


### PR DESCRIPTION
Hi,

Apache allows to authorize an user with its dn or uid (cf. http://httpd.apache.org/docs/2.4/mod/mod_authnz_ldap.html#authldapgroupattributeisdn). This change adds a boolean to reproduce Apache behavious with RoR. It solves #402, #300, and #478.

Best regards.