### PR TITLE
fixed: _cat/templates empty response when there was no indices rule i…

### DIFF
--- a/es51x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es51x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -163,7 +163,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es52x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es52x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -163,7 +163,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es53x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es53x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -163,7 +163,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es55x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es55x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -163,7 +163,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es60x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -166,7 +166,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es61x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -163,7 +163,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es63x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -166,7 +166,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es66x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -163,7 +163,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es70x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -167,7 +167,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es73x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -167,7 +167,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/es74x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/request/regular/RegularRequestHandler.scala
@@ -167,7 +167,10 @@ class RegularRequestHandler(engine: Engine,
   }
 
   private def emptySetOfFoundIndices(blockContext: BlockContext) = {
-    blockContext.indices.forall(_.isEmpty)
+    blockContext.indices match {
+      case Outcome.Exist(foundIndices) => foundIndices.isEmpty
+      case Outcome.NotExist => false
+    }
   }
 
   private def onForbidden(causes: NonEmptyList[ForbiddenCause]): Unit = {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.18.8
-pluginVersion=1.18.8
+pluginVersion=1.18.9-pre1
 pluginName=readonlyrest

--- a/integration-tests-scala/src/test/resources/cat_api/readonlyrest.yml
+++ b/integration-tests-scala/src/test/resources/cat_api/readonlyrest.yml
@@ -20,3 +20,6 @@ readonlyrest:
     - name: "dev2 indexes"
       indices: ["@{user}_index", "custom_@{user}_index_*"]
       auth_key: dev2:test
+
+    - name: "dev3 - no indices rule"
+      auth_key: dev3:test

--- a/integration-tests/src/test/eshome/config/readonlyrest.yml
+++ b/integration-tests/src/test/eshome/config/readonlyrest.yml
@@ -1,46 +1,25 @@
 readonlyrest:
-  enable: false
   ssl:
     enable: true
     keystore_file: "keystore.jks"
     keystore_pass: readonlyrest
     key_pass: readonlyrest
 
-  prompt_for_basic_auth: false
-
-  audit_collector: true
-
   access_control_rules:
 
-    # MACHINES ##################
-    - name: "::KIBANA-SRV::"
-      auth_key: kibana:kibana
+    # ES containter initializer need this rule to configure ES instance after startup
+    - name: "CONTAINER ADMIN"
       verbosity: error
+      type: allow
+      auth_key: admin:container
 
-    # GROUPS ####################
+    - name: "dev1 indexes"
+      indices: ["custom_@{user}_index_*", "@{user}_index"]
+      auth_key: dev1:test
 
-    - name: "::PERSONAL_GRP::"
-      groups: ["Personal"]
-      kibana_access: rw
-      kibana_hide_apps: ["readonlyrest_kbn", "timelion"]
-      kibana_index: ".kibana_@{user}"
+    - name: "dev2 indexes"
+      indices: ["@{user}_index", "custom_@{user}_index_*"]
+      auth_key: dev2:test
 
-    - name: "::ADMIN_GRP::"
-      groups: ["ROR (admin)"]
-      kibana_access: admin
-
-    - name: "::Infosec::"
-      groups: ["Infosec"]
-      kibana_access: rw
-      kibana_hide_apps: ["readonlyrest_kbn", "timelion"]
-      kibana_index: ".kibana_infosec"
-
-  # USERS TO GROUPS ############
-  users:
-    - username: admin
-      auth_key: admin:dev
-      groups: ["ROR (admin)", "Infosec"]
-
-    - username: simone
-      auth_key: simone:dev
-      groups: ["ROR (admin)", "Personal", "Infosec"]
+    - name: "dev3 - no indices rule"
+      auth_key: dev3:test

--- a/tests-utils/src/main/scala/tech.beshu.ror.utils/elasticsearch/ClusterStateManager.scala
+++ b/tests-utils/src/main/scala/tech.beshu.ror.utils/elasticsearch/ClusterStateManager.scala
@@ -58,7 +58,7 @@ class ClusterStateManager(client: RestClient)
   private def createCatIndicesRequest(index: Option[String]) = {
     new HttpGet(client.from(
       s"/_cat/indices${index.map(i => s"/$i").getOrElse("")}",
-      Map("format" -> "json").asJava
+      Map("format" -> "json", "s" -> "index:asc").asJava
     ))
   }
 }


### PR DESCRIPTION
🐞Fix (ES) _cat/indices empty response when matched block doesn't contain 'indices' rule