### PR TITLE
[RORDEV-235] unboundId request timeout handling + all queries will be made on separate, io executor

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/definitions/ldap/implementations/UnboundidLdapConnectionPoolProvider.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/definitions/ldap/implementations/UnboundidLdapConnectionPoolProvider.scala
@@ -45,7 +45,13 @@ class UnboundidLdapConnectionPoolProvider {
   private def createConnection(connectionConfig: LdapConnectionConfig): Task[LDAPConnectionPool] = retry {
     Task {
       val serverSet = createLdapServerSet(connectionConfig)
-      new LDAPConnectionPool(serverSet, bindRequest(connectionConfig.bindRequestUser), connectionConfig.poolSize.value)
+      val pool = new LDAPConnectionPool(
+        serverSet,
+        bindRequest(connectionConfig.bindRequestUser),
+        connectionConfig.poolSize.value
+      )
+      pool.setMaxConnectionAgeMillis(60000)
+      pool
     }
   }
 }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/definitions/ldap/implementations/UnboundidLdapService.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/definitions/ldap/implementations/UnboundidLdapService.scala
@@ -25,6 +25,7 @@ import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.string.NonEmptyString
 import io.lemonlabs.uri.UrlWithAuthority
 import monix.eval.Task
+import monix.execution.Scheduler
 import org.apache.logging.log4j.scala.Logging
 import tech.beshu.ror.accesscontrol.blocks.definitions.ldap._
 import tech.beshu.ror.accesscontrol.blocks.definitions.ldap.implementations.LdapConnectionConfig.{BindRequestUser, ConnectionMethod}
@@ -43,6 +44,7 @@ class UnboundidLdapAuthenticationService private(override val id: LdapService#Id
                                                  connectionPool: LDAPConnectionPool,
                                                  userSearchFiler: UserSearchFilterConfig,
                                                  requestTimeout: FiniteDuration Refined Positive)
+                                                (implicit blockingScheduler: Scheduler)
   extends BaseUnboundidLdapService(connectionPool, userSearchFiler, requestTimeout)
     with LdapAuthenticationService {
 
@@ -73,9 +75,11 @@ class UnboundidLdapAuthenticationService private(override val id: LdapService#Id
 
 object UnboundidLdapAuthenticationService {
   def create(id: LdapService#Id,
-             poolProvider:UnboundidLdapConnectionPoolProvider,
+             poolProvider: UnboundidLdapConnectionPoolProvider,
              connectionConfig: LdapConnectionConfig,
-             userSearchFiler: UserSearchFilterConfig): Task[Either[ConnectionError, UnboundidLdapAuthenticationService]] = {
+             userSearchFiler: UserSearchFilterConfig,
+             blockingScheduler: Scheduler): Task[Either[ConnectionError, UnboundidLdapAuthenticationService]] = {
+    implicit val blockingSchedulerImplicit: Scheduler = blockingScheduler
     (for {
       _ <- EitherT(UnboundidLdapConnectionPoolProvider.testBindingForAllHosts(connectionConfig))
       connectionPool <- EitherT.liftF[Task, ConnectionError, LDAPConnectionPool](poolProvider.connect(connectionConfig))
@@ -88,6 +92,7 @@ class UnboundidLdapAuthorizationService private(override val id: LdapService#Id,
                                                 groupsSearchFilter: UserGroupsSearchFilterConfig,
                                                 userSearchFiler: UserSearchFilterConfig,
                                                 requestTimeout: FiniteDuration Refined Positive)
+                                               (implicit blockingScheduler: Scheduler)
   extends BaseUnboundidLdapService(connectionPool, userSearchFiler, requestTimeout)
     with LdapAuthorizationService {
 
@@ -206,10 +211,12 @@ class UnboundidLdapAuthorizationService private(override val id: LdapService#Id,
 
 object UnboundidLdapAuthorizationService {
   def create(id: LdapService#Id,
-             poolProvider:UnboundidLdapConnectionPoolProvider,
+             poolProvider: UnboundidLdapConnectionPoolProvider,
              connectionConfig: LdapConnectionConfig,
              userSearchFiler: UserSearchFilterConfig,
-             userGroupsSearchFilter: UserGroupsSearchFilterConfig): Task[Either[ConnectionError, UnboundidLdapAuthorizationService]] = {
+             userGroupsSearchFilter: UserGroupsSearchFilterConfig,
+             blockingScheduler: Scheduler): Task[Either[ConnectionError, UnboundidLdapAuthorizationService]] = {
+    implicit val blockingSchedulerImplicit: Scheduler = blockingScheduler
     (for {
       _ <- EitherT(UnboundidLdapConnectionPoolProvider.testBindingForAllHosts(connectionConfig))
       connectionPool <- EitherT.liftF[Task, ConnectionError, LDAPConnectionPool](poolProvider.connect(connectionConfig))
@@ -220,6 +227,7 @@ object UnboundidLdapAuthorizationService {
 abstract class BaseUnboundidLdapService(connectionPool: LDAPConnectionPool,
                                         userSearchFiler: UserSearchFilterConfig,
                                         requestTimeout: FiniteDuration Refined Positive)
+                                       (implicit blockingScheduler: Scheduler)
   extends LdapUserService with Logging {
 
   override def ldapUserBy(userId: User.Id): Task[Option[LdapUser]] = {
@@ -267,9 +275,11 @@ final case class LdapConnectionConfig(connectionMethod: ConnectionMethod,
 
 object LdapConnectionConfig {
 
-  final case class LdapHost private (url: UrlWithAuthority) {
+  final case class LdapHost private(url: UrlWithAuthority) {
     def isSecure: Boolean = url.schemeOption.contains(LdapHost.ldapsSchema)
+
     def host: String = url.host.value
+
     def port: Int = url.port.getOrElse(LdapHost.defaultPort)
   }
   object LdapHost {
@@ -282,8 +292,8 @@ object LdapConnectionConfig {
         .orElse(Try(UrlWithAuthority.parse(s"""//$value""")))
         .toOption
         .flatMap { url =>
-          if(url.path.nonEmpty) None
-          else if(!url.schemeOption.forall(Set(ldapSchema, ldapsSchema).contains)) None
+          if (url.path.nonEmpty) None
+          else if (!url.schemeOption.forall(Set(ldapSchema, ldapsSchema).contains)) None
           else Some(LdapHost(url))
         }
     }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/definitions/LdapServicesDecoder.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/definitions/LdapServicesDecoder.scala
@@ -41,6 +41,7 @@ import tech.beshu.ror.accesscontrol.factory.decoders.common._
 import tech.beshu.ror.accesscontrol.refined._
 import tech.beshu.ror.accesscontrol.utils.CirceOps._
 import tech.beshu.ror.accesscontrol.utils._
+import tech.beshu.ror.boot.SchedulerPools
 
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.language.postfixOps
@@ -98,7 +99,8 @@ object LdapServicesDecoder {
         name,
         ldapConnectionPoolProvider,
         connectionConfig,
-        userSearchFiler
+        userSearchFiler,
+        SchedulerPools.ldapUnboundIdBlockingScheduler
       )
       ldapServiceDecodingResult match {
         case Left(error) => Task.now(Left(error))
@@ -125,7 +127,8 @@ object LdapServicesDecoder {
         ldapConnectionPoolProvider,
         connectionConfig,
         userSearchFiler,
-        userGroupsSearchFilter
+        userGroupsSearchFilter,
+        SchedulerPools.ldapUnboundIdBlockingScheduler
       )
       ldapServiceDecodingResult match {
         case Left(error) => Task.now(Left(error))

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/rules/LdapRulesDecoders.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/rules/LdapRulesDecoders.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import io.circe.Decoder
-import tech.beshu.ror.accesscontrol.blocks.definitions.ldap.{LdapAuthService, _}
+import tech.beshu.ror.accesscontrol.blocks.definitions.ldap._
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule.RuleWithVariableUsageDefinition
 import tech.beshu.ror.accesscontrol.blocks.rules.{LdapAuthRule, LdapAuthenticationRule, LdapAuthorizationRule, Rule}
 import tech.beshu.ror.accesscontrol.domain.Group

--- a/core/src/main/scala/tech/beshu/ror/boot/SchedulerPools.scala
+++ b/core/src/main/scala/tech/beshu/ror/boot/SchedulerPools.scala
@@ -20,5 +20,6 @@ import monix.execution.Scheduler
 
 object SchedulerPools {
 
-  implicit val adminRestApiScheduler: Scheduler = Scheduler.fixedPool("admin-rest-api", 5)
+  implicit val adminRestApiScheduler: Scheduler = Scheduler.fixedPool("admin-rest-api-executor", 5)
+  val ldapUnboundIdBlockingScheduler: Scheduler = Scheduler.io("unboundid-executor")
 }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/definitions/UnboundidLdapAuthenticationServiceTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/definitions/UnboundidLdapAuthenticationServiceTests.scala
@@ -19,6 +19,7 @@ package tech.beshu.ror.unit.acl.blocks.definitions
 import cats.data._
 import com.dimafeng.testcontainers.{Container, ForAllTestContainer, MultipleContainers}
 import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.Matchers._
@@ -103,16 +104,17 @@ class UnboundidLdapAuthenticationServiceTests
         ldapConnectionPoolProvider,
         LdapConnectionConfig(
           ConnectionMethod.SingleServer(LdapHost.from(s"ldap://${ldap1Container.ldapHost}:${ldap1Container.ldapPort}").get),
-          Refined.unsafeApply(10),
-          Refined.unsafeApply(5 seconds),
-          Refined.unsafeApply(5 seconds),
+          poolSize = 1,
+          connectionTimeout = Refined.unsafeApply(5 seconds),
+          requestTimeout = Refined.unsafeApply(5 seconds),
           trustAllCerts = false,
           BindRequestUser.CustomUser(
             Dn("cn=admin,dc=example,dc=com".nonempty),
             PlainTextSecret("password".nonempty)
           )
         ),
-        UserSearchFilterConfig(Dn("ou=People,dc=example,dc=com".nonempty), "uid".nonempty)
+        UserSearchFilterConfig(Dn("ou=People,dc=example,dc=com".nonempty), "uid".nonempty),
+        global
       )
       .runSyncUnsafe()
       .right.getOrElse(throw new IllegalStateException("LDAP connection problem"))
@@ -131,16 +133,17 @@ class UnboundidLdapAuthenticationServiceTests
             ),
             HaMethod.RoundRobin
           ),
-          Refined.unsafeApply(10),
-          Refined.unsafeApply(5 seconds),
-          Refined.unsafeApply(5 seconds),
+          poolSize = 1,
+          connectionTimeout = Refined.unsafeApply(5 seconds),
+          requestTimeout = Refined.unsafeApply(5 seconds),
           trustAllCerts = false,
           BindRequestUser.CustomUser(
             Dn("cn=admin,dc=example,dc=com".nonempty),
             PlainTextSecret("password".nonempty)
           )
         ),
-        UserSearchFilterConfig(Dn("ou=People,dc=example,dc=com".nonempty), "uid".nonempty)
+        UserSearchFilterConfig(Dn("ou=People,dc=example,dc=com".nonempty), "uid".nonempty),
+        global
       )
       .runSyncUnsafe()
       .right.getOrElse(throw new IllegalStateException("LDAP connection problem"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.19.4
-pluginVersion=1.19.5-pre5
+pluginVersion=1.19.5-pre6
 pluginName=readonlyrest


### PR DESCRIPTION
🐞Fix (ES) better LDAP request timeout handling
🧐Enhancement (ES) LDAP connection pool improvement