### PR TITLE
[RORDEV-273] bugfix - available group order in user metadata response

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/AccessControl.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/AccessControl.scala
@@ -55,7 +55,7 @@ object AccessControl {
         case object ImpersonationNotAllowed extends Cause
       }
     }
-    final case class IndexNotFound[B <: BlockContext]() // todo; remove B
+    final case class IndexNotFound[B <: BlockContext]()
       extends RegularRequestResult[B]
     final case class Failed[B <: BlockContext](ex: Throwable)
       extends RegularRequestResult[B]

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/Block.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/Block.scala
@@ -48,7 +48,7 @@ class Block(val name: Name,
 
   import Lifter._
 
-  def execute[B <: BlockContext :  BlockContextUpdater](requestContext: RequestContext.Aux[B]): BlockResultWithHistory[B] = {
+  def execute[B <: BlockContext : BlockContextUpdater](requestContext: RequestContext.Aux[B]): BlockResultWithHistory[B] = {
     implicit val showHeader: Show[Header] = obfuscatedHeaderShow(loggingContext.obfuscatedHeaders)
     val initBlockContext = requestContext.initialBlockContext
     rules

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/BlockContext.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/BlockContext.scala
@@ -110,7 +110,7 @@ object BlockContext {
   }
   object HasIndices {
 
-    def apply[B <: BlockContext](implicit instance: HasIndices[B]) = instance
+    def apply[B <: BlockContext](implicit instance: HasIndices[B]): HasIndices[B] = instance
 
     implicit val indicesFromSearchBlockContext = new HasIndices[SearchRequestBlockContext] {
       override def indices(blockContext: SearchRequestBlockContext): Set[IndexName] = blockContext.indices
@@ -121,7 +121,7 @@ object BlockContext {
     }
 
     implicit class Ops[B <: BlockContext : HasIndices](blockContext: B) {
-      def indices = HasIndices[B].indices(blockContext)
+      def indices: Set[IndexName] = HasIndices[B].indices(blockContext)
     }
   }
 
@@ -130,7 +130,7 @@ object BlockContext {
   }
   object HasIndexPacks {
 
-    def apply[B <: BlockContext](implicit instance: HasIndexPacks[B]) = instance
+    def apply[B <: BlockContext](implicit instance: HasIndexPacks[B]): HasIndexPacks[B] = instance
 
     implicit val indexPacksFromMultiSearchBlockContext = new HasIndexPacks[MultiSearchRequestBlockContext] {
       override def indexPacks(blockContext: MultiSearchRequestBlockContext): List[Indices] = blockContext.indexPacks
@@ -141,7 +141,7 @@ object BlockContext {
     }
 
     implicit class Ops[B <: BlockContext : HasIndexPacks](blockContext: B) {
-      def indexPacks = HasIndexPacks[B].indexPacks(blockContext)
+      def indexPacks: List[Indices] = HasIndexPacks[B].indexPacks(blockContext)
     }
   }
 
@@ -150,7 +150,7 @@ object BlockContext {
   }
   object HasFilter {
 
-    def apply[B <: BlockContext](implicit instance: HasFilter[B]) = instance
+    def apply[B <: BlockContext](implicit instance: HasFilter[B]): HasFilter[B] = instance
 
     implicit val filterFromMultiSearchBlockContext = new HasFilter[MultiSearchRequestBlockContext] {
       override def filter(blockContext: MultiSearchRequestBlockContext): Option[Filter] = blockContext.filter
@@ -161,7 +161,7 @@ object BlockContext {
     }
 
     implicit class Ops[B <: BlockContext : HasFilter](blockContext: B) {
-      def filter = HasFilter[B].filter(blockContext)
+      def filter: Option[Filter] = HasFilter[B].filter(blockContext)
     }
   }
 

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/AccessControlListTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/AccessControlListTests.scala
@@ -1,0 +1,85 @@
+package tech.beshu.ror.unit.acl
+
+import cats.data.NonEmptyList
+import monix.eval.Task
+import org.scalatest.Matchers._
+import monix.execution.Scheduler.Implicits.global
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{Inside, WordSpec}
+import tech.beshu.ror.accesscontrol.AccessControl.UserMetadataRequestResult.Allow
+import tech.beshu.ror.accesscontrol.acl.AccessControlList
+import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
+import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
+import tech.beshu.ror.accesscontrol.blocks.rules.Rule
+import tech.beshu.ror.accesscontrol.blocks.rules.Rule.RegularRule
+import tech.beshu.ror.accesscontrol.blocks.{Block, BlockContext, BlockContextUpdater}
+import tech.beshu.ror.accesscontrol.domain.{Group, Header, LoggedUser, User}
+import tech.beshu.ror.accesscontrol.request.RequestContext
+import tech.beshu.ror.utils.TestsUtils._
+import tech.beshu.ror.utils.uniquelist.UniqueList
+
+class AccessControlListTests extends WordSpec with MockFactory with Inside {
+
+  "An AccessControlList" when {
+    "metadata request is called" should {
+      "go through all blocks and collect metadata response content" in {
+        val acl = new AccessControlList(NonEmptyList.of(
+          mockBlock("b1", UserMetadata.empty.withLoggedUser(user("sulc1")).withCurrentGroup(group("admins")).withAvailableGroups(UniqueList.of(group("logserver"), group("ext-onlio"), group("admins"), group("ext-odp"), group("ext-enex"), group("dohled-nd-pce"), group("helpdesk")))),
+          mockBlock("b2", UserMetadata.empty.withLoggedUser(user("sulc1")).withCurrentGroup(group("admins")).withAvailableGroups(UniqueList.of(group("logserver"), group("ext-onlio"), group("admins"), group("ext-odp"), group("ext-enex"), group("dohled-nd-pce"), group("helpdesk")))),
+          mockBlock("b3", UserMetadata.empty.withLoggedUser(user("sulc1")).withCurrentGroup(group("admins")).withAvailableGroups(UniqueList.of(group("logserver"), group("ext-onlio"), group("admins"), group("ext-odp"), group("ext-enex"), group("dohled-nd-pce"), group("helpdesk")))),
+          mockBlock("b4", UserMetadata.empty.withLoggedUser(user("sulc1")).withCurrentGroup(group("admins")).withAvailableGroups(UniqueList.of(group("logserver"), group("ext-onlio"), group("admins"), group("ext-odp"), group("ext-enex"), group("dohled-nd-pce"), group("helpdesk")))),
+          mockBlock("b5", UserMetadata.empty.withLoggedUser(user("sulc1")).withCurrentGroup(group("admins")).withAvailableGroups(UniqueList.of(group("logserver"), group("ext-onlio"), group("admins"), group("ext-odp"), group("ext-enex"), group("dohled-nd-pce"), group("helpdesk")))),
+          mockBlock("b6", UserMetadata.empty.withLoggedUser(user("sulc1")).withCurrentGroup(group("admins")).withAvailableGroups(UniqueList.of(group("logserver"), group("ext-onlio"), group("admins"), group("ext-odp"), group("ext-enex"), group("dohled-nd-pce"), group("helpdesk")))),
+          mockBlock("b7", UserMetadata.empty.withLoggedUser(user("sulc1")).withCurrentGroup(group("admins")).withAvailableGroups(UniqueList.of(group("logserver"), group("ext-onlio"), group("admins"), group("ext-odp"), group("ext-enex"), group("dohled-nd-pce"), group("helpdesk")))),
+        ))
+        val userMetadataRequestResult = acl
+          .handleMetadataRequest(mockMetadataRequestContext("admins"))
+          .runSyncUnsafe()
+          .result
+
+        inside(userMetadataRequestResult) {
+          case Allow(userMetadata, _) =>
+            userMetadata.availableGroups shouldBe UniqueList.of(group("logserver"), group("ext-onlio"), group("admins"), group("ext-odp"), group("ext-enex"), group("dohled-nd-pce"), group("helpdesk"))
+            userMetadata.currentGroup shouldBe Some(group("admins"))
+        }
+      }
+    }
+  }
+
+  private def mockBlock(name: String, userMetadata: UserMetadata) = {
+    new Block(
+      Block.Name(name),
+      Block.Policy.Allow,
+      Block.Verbosity.Info,
+      NonEmptyList.of(
+        new RegularRule {
+          override val name: Rule.Name = Rule.Name("auth")
+
+          override def check[B <: BlockContext : BlockContextUpdater](blockContext: B): Task[Rule.RuleResult[B]] = {
+            Task.now(Rule.RuleResult.Fulfilled(blockContext.withUserMetadata(_ => userMetadata)))
+          }
+        }
+      )
+    )
+  }
+
+  private def user(userName: String) = LoggedUser.DirectlyLoggedUser(User.Id(userName.nonempty))
+
+  private def group(groupName: String) = Group(groupName.nonempty)
+
+  private def mockMetadataRequestContext(preferredGroup: String) = {
+    val rc = mock[MetadataRequestContext]
+    (rc.initialBlockContext _)
+      .expects()
+      .returning(CurrentUserMetadataRequestBlockContext(mock[RequestContext], UserMetadata.empty, Set.empty, Set.empty))
+      .anyNumberOfTimes()
+    (rc.headers _)
+      .expects()
+      .returning(Set(new Header(Header.Name("x-ror-current-group".nonempty), preferredGroup.nonempty)))
+    rc
+  }
+
+  private trait MetadataRequestContext extends RequestContext {
+    override type BLOCK_CONTEXT = CurrentUserMetadataRequestBlockContext
+  }
+}

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/AccessControlListTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/AccessControlListTests.scala
@@ -1,3 +1,19 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
 package tech.beshu.ror.unit.acl
 
 import cats.data.NonEmptyList

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.19.5
-pluginVersion=1.20.0-pre5
+pluginVersion=1.20.0-pre6
 pluginName=readonlyrest


### PR DESCRIPTION
🐞Fix (ES) available groups order in metadata response should match the order in which groups appear in ACL