### PR TITLE
[RORDEV-306] proxy superuser support

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/boot/ReadonlyRest.scala
+++ b/core/src/main/scala/tech/beshu/ror/boot/ReadonlyRest.scala
@@ -253,7 +253,7 @@ class RorInstance private(boot: ReadonlyRest,
   import RorInstance.ScheduledReloadError.{EngineReloadError, ReloadingInProgress}
   import RorInstance._
 
-  logger.info("Readonly REST plugin core was loaded ...")
+  logger.info("ReadonlyREST core was loaded ...")
   mode match {
     case Mode.WithPeriodicIndexCheck =>
       RorProperties.rorIndexSettingReloadInterval match {

--- a/core/src/main/scala/tech/beshu/ror/configuration/RorProperties.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/RorProperties.scala
@@ -69,7 +69,7 @@ object RorProperties extends Logging {
 
   def rorProxyEsHost(implicit provider: PropertiesProvider): String =
     getProperty(keys.esHost, str => Success(str), defaults.esHost)
-
+  
   def rorProxyEsPort(implicit provider: PropertiesProvider): Int =
     getProperty(keys.esPort, str => Try(Integer.valueOf(str)), defaults.esPort)
 

--- a/proxy/src/main/scala/tech/beshu/ror/proxy/Boot.scala
+++ b/proxy/src/main/scala/tech/beshu/ror/proxy/Boot.scala
@@ -67,7 +67,9 @@ trait RorProxyApp extends IOApp
     val user = ProxyEnvSettings.rorSuperuserName
     val secret = ProxyEnvSettings.rorSuperUserSecret
     (user, secret) match {
-      case (Some(u), Some(s)) => Some(Credentials(u, s))
+      case (Some(u), Some(s)) =>
+        logger.info(s"Configured superuser '${u.show}'")
+        Some(Credentials(u, s))
       case (None, None)       => None
       case (Some(u), None)    => throw new IllegalArgumentException(s"Superuser name '${u.show}' defined, but no secret passed")
       case (None, Some(_))    => throw new IllegalArgumentException(s"Superuser password defined, but no user name passed")

--- a/proxy/src/main/scala/tech/beshu/ror/proxy/ProxyEnvSettings.scala
+++ b/proxy/src/main/scala/tech/beshu/ror/proxy/ProxyEnvSettings.scala
@@ -1,3 +1,6 @@
+/*
+ *     Beshu Limited all rights reserved
+ */
 package tech.beshu.ror.proxy
 
 import eu.timepit.refined.auto._

--- a/proxy/src/main/scala/tech/beshu/ror/proxy/ProxyEnvSettings.scala
+++ b/proxy/src/main/scala/tech/beshu/ror/proxy/ProxyEnvSettings.scala
@@ -1,0 +1,24 @@
+package tech.beshu.ror.proxy
+
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.string.NonEmptyString
+import tech.beshu.ror.accesscontrol.domain.{PlainTextSecret, User}
+import tech.beshu.ror.providers.EnvVarProvider.EnvVarName
+import tech.beshu.ror.providers.EnvVarsProvider
+
+object ProxyEnvSettings {
+
+  def rorSuperuserName(implicit provider: EnvVarsProvider): Option[User.Id] = {
+    provider
+      .getEnv(EnvVarName("ROR_SUPERUSER_NAME"))
+      .flatMap(NonEmptyString.from(_).toOption)
+      .map(User.Id.apply)
+  }
+
+  def rorSuperUserSecret(implicit provider: EnvVarsProvider): Option[PlainTextSecret] = {
+    provider
+      .getEnv(EnvVarName("ROR_SUPERUSER_SECRET"))
+      .flatMap(NonEmptyString.from(_).toOption)
+      .map(PlainTextSecret.apply)
+  }
+}


### PR DESCRIPTION
ROR Proxy supports SUPERUSER basic authentication - it means that each downstream request (from proxy to underlying ES) will be enriched with authentication header. Superuser name and secret can be defined by setting following environment variables: `ROR_SUPERUSER_NAME` & `ROR_SUPERUSER_SECRET` 