### PR TITLE
[RORDEV-335]: allocation explain request fix

### DIFF
--- a/es55x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es55x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es60x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es61x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es62x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es62x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es63x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es66x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es70x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es72x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es73x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es74x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es77x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es78x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/es79x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/request/context/types/ClusterAllocationExplainEsRequestContext.scala
@@ -34,7 +34,8 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
                                                override val threadPool: ThreadPool)
   extends BaseIndicesEsRequestContext(actionRequest, esContext, aclContext, clusterService, threadPool) {
 
-  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] = getIndexFrom(request).toSet
+  override protected def indicesFrom(request: ClusterAllocationExplainRequest): Set[IndexName] =
+    getIndexFrom(request).toSet
 
   override protected def update(request: ClusterAllocationExplainRequest,
                                 indices: NonEmptyList[IndexName]): ModificationResult = {
@@ -45,8 +46,10 @@ class ClusterAllocationExplainEsRequestContext(actionRequest: ClusterAllocationE
         }
         updateIndexIn(request, indices.head)
         Modified
+      case None if indices.exists(_ === IndexName.wildcard) =>
+        Modified
       case None =>
-        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable")
+        logger.error(s"[${id.show}] Cluster allocation explain request without index name is unavailable when block contains `indices` rule")
         ShouldBeInterrupted
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.22.1
-pluginVersion=1.23.0-pre5
+pluginVersion=1.23.0-pre7
 pluginName=readonlyrest

--- a/integration-tests/src/test/resources/cluster_api/readonlyrest.yml
+++ b/integration-tests/src/test/resources/cluster_api/readonlyrest.yml
@@ -26,3 +26,6 @@ readonlyrest:
     - name: "test3"
       indices: ["test3_index"]
       auth_key: dev3:test
+
+    - name: "test4"
+      auth_key: dev4:test

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/ClusterApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/ClusterApiSuite.scala
@@ -47,12 +47,17 @@ trait ClusterApiSuite
   private lazy val dev1ClusterManager = new ClusterManager(esTargets.head.basicAuthClient("dev1", "test"), esVersion = esTargets.head.esVersion)
   private lazy val dev2ClusterManager = new ClusterManager(esTargets.head.basicAuthClient("dev2", "test"), esVersion = esTargets.head.esVersion)
   private lazy val dev3ClusterManager = new ClusterManager(esTargets.head.basicAuthClient("dev3", "test"), esVersion = esTargets.head.esVersion)
+  private lazy val dev4ClusterManager = new ClusterManager(esTargets.head.basicAuthClient("dev4", "test"), esVersion = esTargets.head.esVersion)
 
   "Cluster allocation explain API" should {
     "allow to be used" when {
       "user has access to given index" in {
         val result = dev1ClusterManager.allocationExplain("test1_index")
         result.responseCode should be(200)
+      }
+      "no index is passed and block without no `indices` rule was matched" in {
+        val result = dev4ClusterManager.allocationExplain()
+        result.responseCode should not be (403)
       }
     }
     "not allow to be used (pretend that index doesn't exist)" when {


### PR DESCRIPTION
🐞Fix (ES) /_cluster/allocation/explain request should not be forbidden if matched block doesn't have `indices` rules