### PR TITLE
[RORDEV-392] removed verbose logging

### DIFF
--- a/es55x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es55x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -77,7 +77,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es60x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -77,7 +77,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es61x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -61,7 +61,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -87,7 +87,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es62x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es62x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -61,7 +61,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -87,7 +87,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es63x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -61,7 +61,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -87,7 +87,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es66x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -61,7 +61,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -87,7 +87,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es70x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -61,7 +61,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -87,7 +87,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es710x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -62,7 +62,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -89,7 +89,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es72x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -62,7 +62,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -89,7 +89,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es73x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -62,7 +62,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -89,7 +89,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es74x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -62,7 +62,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -89,7 +89,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es77x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -62,7 +62,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -89,7 +89,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es78x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -62,7 +62,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -89,7 +89,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/es79x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/request/queries/QueryFieldsUsage.scala
@@ -62,7 +62,7 @@ object QueryFieldsUsage extends Logging {
       Option(invokeMethodCached(query, query.getClass, "getFieldName")) match {
         case Some(fieldName: String) => UsingFields(NonEmptyList.one(UsedField(fieldName)))
         case _ =>
-          logger.warn(s"Cannot extract fields for terms set query")
+          logger.debug(s"Cannot extract fields for terms set query")
           CannotExtractFields
       }
     }
@@ -89,7 +89,7 @@ object QueryFieldsUsage extends Logging {
       case builder: TermsSetQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder: WildcardQueryBuilder => resolveFieldsUsageForLeafQuery(builder)
       case builder =>
-        logger.warn(s"Cannot extract fields for query: ${builder.getName}")
+        logger.debug(s"Cannot extract fields for query: ${builder.getName}")
         CannotExtractFields
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.25.1
-pluginVersion=1.25.1
+pluginVersion=1.25.2
 pluginName=readonlyrest


### PR DESCRIPTION
🐞Fix (ES) [removed verbose logging](https://forum.readonlyrest.com/t/elastic-message-cannot-extract-fields-for-query-after-readonlyrest-installation/1749)