### PR TITLE
[RORDEV-398] upgraded: fasterXML jackson-databind lib - CVE-2020-35490 & CVE-2020-35491

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -137,7 +137,7 @@ dependencies {
         compile group: 'io.netty',                          name: 'netty-transport-native-unix-common',     version: '4.1.53.Final'
         compile group: 'io.netty',                          name: 'netty-transport-native-epoll',           version: '4.1.53.Final'
         compile group: 'io.netty',                          name: 'netty-transport-native-kqueue',          version: '4.1.53.Final'
-        compile group: 'com.fasterxml.jackson.core',        name: 'jackson-databind',                       version: '2.9.10.7'
+        compile group: 'com.fasterxml.jackson.core',        name: 'jackson-databind',                       version: '2.9.10.8'
         compile group: 'com.google.guava',                  name: 'guava',                                  version: '30.0-jre'
         compile group: 'io.spray',                          name: 'spray-json_2.12',                        version: '1.3.5'
         compile group: 'org.scala-lang',                    name: 'scala-reflect',                          version: '2.12.10'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.25.2
-pluginVersion=1.25.2
+pluginVersion=1.25.3
 pluginName=readonlyrest

--- a/ror-shadowed-libs/build.gradle
+++ b/ror-shadowed-libs/build.gradle
@@ -50,7 +50,7 @@ compileJava {
 
 dependencies {
     shadowCompile group: 'com.fasterxml.jackson.dataformat',      name: 'jackson-dataformat-yaml',                version: '2.9.10'
-    shadowCompile group: 'com.fasterxml.jackson.core',            name: 'jackson-databind',                       version: '2.9.10.7'
+    shadowCompile group: 'com.fasterxml.jackson.core',            name: 'jackson-databind',                       version: '2.9.10.8'
     shadowCompile group: 'com.jayway.jsonpath',                   name: 'json-path',                              version: '2.2.0'
     // because of https://bitbucket.org/asomov/snakeyaml/issues/462/memory-leak
     shadowCompile group: 'org.yaml',                              name: 'snakeyaml',                              version: '1.17'


### PR DESCRIPTION
🚨Security Fix (ES) [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) & [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35491)