### PR TITLE
add regex for short URL creation on ES 7.8.1

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/KibanaAccessRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/KibanaAccessRule.scala
@@ -135,7 +135,7 @@ class KibanaAccessRule(val settings: Settings)
 
   private def kibanaIndexPattern(kibanaIndex: IndexName) = {
     Try(Pattern.compile(
-      "^/@kibana_index/(url|config/.*/_create|index-pattern|doc/index-pattern.*|doc/url.*)/.*|^/_template/.*|^/@kibana_index/doc/telemetry.*|^/@kibana_index/(_update/index-pattern.*|_update/url.*)"
+      "^/@kibana_index/(url|config/.*/_create|index-pattern|doc/index-pattern.*|doc/url.*)/.*|^/_template/.*|^/@kibana_index/doc/telemetry.*|^/@kibana_index/(_update/index-pattern.*|_update/url.*)|^/@kibana_index/_create/(url:.*)"
         .replace("@kibana_index", kibanaIndex.value.value)
     )).toOption
   }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/KibanaAccessRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/KibanaAccessRuleTests.scala
@@ -186,6 +186,13 @@ class KibanaAccessRuleTests extends WordSpec with Inside with BlockContextAssert
         uriPath = UriPath("/.custom_kibana/_update/url1234")
       )
     }
+    "non strict operations (11)" in {
+      testNonStrictOperations(
+        customKibanaIndex = IndexName(".custom_kibana".nonempty),
+        action = Action("indices:data/write/update"),
+        uriPath = UriPath("/.custom_kibana/_create/url:710d2a92ef849fc282bcb8a216f39046")
+      )
+    }
     "RW can change cluster settings" in {
       assertNotMatchRule(settingsOf(RO, IndexName(".kibana".nonempty)), Action("cluster:admin/settings/update"), Set.empty, Some(UriPath("/_cluster/settings")))
       assertMatchRule(settingsOf(RW, IndexName(".kibana".nonempty)), Action("cluster:admin/settings/update"), Set.empty, Some(UriPath("/_cluster/settings"))) {

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/KibanaAccessRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/KibanaAccessRuleTests.scala
@@ -189,7 +189,7 @@ class KibanaAccessRuleTests extends WordSpec with Inside with BlockContextAssert
     "non strict operations (11)" in {
       testNonStrictOperations(
         customKibanaIndex = IndexName(".custom_kibana".nonempty),
-        action = Action("indices:data/write/update"),
+        action = Action("indices:data/write/index"),
         uriPath = UriPath("/.custom_kibana/_create/url:710d2a92ef849fc282bcb8a216f39046")
       )
     }


### PR DESCRIPTION
fix #685 Saved Search short url creation has changed in Kibana/Elastic 7.8.1, this pull request add a new pattern to allow RO users to create short url.  