### PR TITLE
[RORDEV-560] CVE-2021-21409 & CVE-2021-27568 fixes

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,7 +30,7 @@ buildscript {
     }
 
     dependencies {
-        classpath group: 'org.owasp',                                    name: 'dependency-check-gradle',  version: '6.2.2'
+        classpath group: 'org.owasp',                                    name: 'dependency-check-gradle',  version: '6.4.1.1'
         classpath group: 'com.star-zero.gradle',                         name: 'githook',                  version: '1.2.1'
         classpath group: 'gradle.plugin.com.github.maiflai',             name: 'gradle-scalatest',         version: '0.24'
         classpath group: 'gradle.plugin.com.hierynomus.gradle.plugins',  name: 'license-gradle-plugin',    version: '0.15.0'
@@ -53,15 +53,15 @@ apply plugin: 'maven'
 apply plugin: 'org.owasp.dependencycheck'
 
 dependencyCheck {
-    /*
-       Severity	Base Score
-       None     0
-       Low      0.1-3.9
-       Medium   4.0-6.9
-       High     7.0-8.9
-       Critical 9.0-10.0
-     */
-    failBuildOnCVSS = 4
+//    /*
+//       Severity	Base Score
+//       None     0
+//       Low      0.1-3.9
+//       Medium   4.0-6.9
+//       High     7.0-8.9
+//       Critical 9.0-10.0
+//     */
+    failBuildOnCVSS = 3
     scanConfigurations = ['runtime']
     suppressionFiles = ["${project.rootDir}/supressions_cve.xml"]
 }
@@ -128,7 +128,7 @@ dependencies {
     compile group: 'org.scala-lang.modules',                name: 'scala-java8-compat_2.12',                version: '0.9.0'
     compile group: 'io.lemonlabs',                          name: 'scala-uri_2.12',                         version: '1.4.1'
     compile group: 'org.typelevel',                         name: 'squants_2.12',                           version: '1.4.0'
-    compile group: 'com.unboundid',                         name: 'unboundid-ldapsdk',                      version: '4.0.9'
+    compile group: 'com.unboundid',                         name: 'unboundid-ldapsdk',                      version: '4.0.14'
     compile group: 'com.lihaoyi',                           name: 'upickle_2.12',                           version: '0.7.1'
 
     testCompile project(':tests-utils')
@@ -143,11 +143,11 @@ dependencies {
     testCompile group: 'com.dimafeng',                      name: 'testcontainers-scala_2.12',              version: '0.39.0'
 
     constraints{
-        compile group: 'io.netty',                          name: 'netty-codec-http2',                      version: '4.1.61.Final'
-        compile group: 'io.netty',                          name: 'netty-handler-proxy',                    version: '4.1.61.Final'
-        compile group: 'io.netty',                          name: 'netty-transport-native-unix-common',     version: '4.1.61.Final'
-        compile group: 'io.netty',                          name: 'netty-transport-native-epoll',           version: '4.1.61.Final'
-        compile group: 'io.netty',                          name: 'netty-transport-native-kqueue',          version: '4.1.61.Final'
+        compile group: 'io.netty',                          name: 'netty-codec-http2',                      version: '4.1.69.Final'
+        compile group: 'io.netty',                          name: 'netty-handler-proxy',                    version: '4.1.69.Final'
+        compile group: 'io.netty',                          name: 'netty-transport-native-unix-common',     version: '4.1.69.Final'
+        compile group: 'io.netty',                          name: 'netty-transport-native-epoll',           version: '4.1.69.Final'
+        compile group: 'io.netty',                          name: 'netty-transport-native-kqueue',          version: '4.1.69.Final'
         compile group: 'com.google.guava',                  name: 'guava',                                  version: '30.0-jre'
         compile group: 'io.spray',                          name: 'spray-json_2.12',                        version: '1.3.5'
         compile group: 'org.scala-lang',                    name: 'scala-reflect',                          version: '2.12.10'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.35.0
-pluginVersion=1.35.0
+pluginVersion=1.35.1
 pluginName=readonlyrest

--- a/ror-shadowed-libs/build.gradle
+++ b/ror-shadowed-libs/build.gradle
@@ -24,8 +24,8 @@ buildscript {
     }
 
     dependencies {
-        classpath group: 'org.owasp',                                    name: 'dependency-check-gradle',  version: '6.1.6'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
+        classpath group: 'org.owasp',                            name: 'dependency-check-gradle',  version: '6.4.1.1'
+        classpath group: 'com.github.jengelman.gradle.plugins',  name: 'shadow',                   version: '4.0.4'
     }
 }
 
@@ -39,6 +39,19 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'org.owasp.dependencycheck'
+
+dependencyCheck {
+    /*
+       Severity	Base Score
+       None     0
+       Low      0.1-3.9
+       Medium   4.0-6.9
+       High     7.0-8.9
+       Critical 9.0-10.0
+     */
+    failBuildOnCVSS = 3
+    suppressionFiles = ["${project.rootDir}/supressions_cve.xml"]
+}
 
 configurations {
     shadowCompile
@@ -54,12 +67,7 @@ dependencies {
     shadowCompile group: 'com.fasterxml.jackson.dataformat',      name: 'jackson-dataformat-yaml',                version: '2.12.4'
     shadowCompile group: 'com.fasterxml.jackson.core',            name: 'jackson-databind',                       version: '2.12.4'
     shadowCompile group: 'org.yaml',                              name: 'snakeyaml',                              version: '1.29'
-    shadowCompile group: 'com.jayway.jsonpath',                   name: 'json-path',                              version: '2.2.0'
-    shadowCompile(group: 'net.minidev',                           name: 'json-smart'){
-        version {
-            strictly '2.4.7'
-        }
-    }
+    shadowCompile group: 'com.jayway.jsonpath',                   name: 'json-path',                              version: '2.6.0'
 }
 
 shadowJar {


### PR DESCRIPTION
🚨Security Fix (ES) [CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409) & [CVE-2021-27568](https://nvd.nist.gov/vuln/detail/CVE-2021-27568)