### PR TITLE
[RORDEV-665] Update TTL of  the test settings engine

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/boot/RorInstance.scala
+++ b/core/src/main/scala/tech/beshu/ror/boot/RorInstance.scala
@@ -111,11 +111,6 @@ class RorInstance private(boot: ReadonlyRest,
     anTestConfigEngine.currentTestConfig()
   }
 
-  def currentTestEngineRorConfig()
-                                (implicit requestId: RequestId): Task[TestEngineRorConfig] = {
-    anTestConfigEngine.currentRorConfig()
-  }
-
   def forceReloadTestConfigEngine(config: RawRorConfig,
                                   ttl: FiniteDuration)
                                  (implicit requestId: RequestId): Task[Either[RawConfigReloadError, Unit]] = {
@@ -215,14 +210,12 @@ object RorInstance {
   sealed trait TestConfig
   object TestConfig {
     case object NotSet extends TestConfig
-    final case class Present(config: RawRorConfig, configuredTtl: FiniteDuration, validTo: Instant) extends TestConfig
-    final case class Invalidated(recent: RawRorConfig) extends TestConfig
-  }
-
-  sealed trait TestEngineRorConfig
-  object TestEngineRorConfig {
-    case object NotSet extends TestEngineRorConfig
-    final case class Present(config: RorConfig) extends TestEngineRorConfig
+    final case class Present(config: RorConfig,
+                             rawConfig: RawRorConfig,
+                             configuredTtl: FiniteDuration,
+                             validTo: Instant) extends TestConfig
+    final case class Invalidated(recent: RawRorConfig,
+                                 configuredTtl: FiniteDuration) extends TestConfig
   }
 
   def createWithPeriodicIndexCheck(boot: ReadonlyRest,

--- a/core/src/main/scala/tech/beshu/ror/boot/engines/TestConfigBasedReloadableEngine.scala
+++ b/core/src/main/scala/tech/beshu/ror/boot/engines/TestConfigBasedReloadableEngine.scala
@@ -24,7 +24,7 @@ import tech.beshu.ror.RequestId
 import tech.beshu.ror.accesscontrol.domain.RorConfigurationIndex
 import tech.beshu.ror.boot.ReadonlyRest
 import tech.beshu.ror.boot.ReadonlyRest.StartingFailure
-import tech.beshu.ror.boot.RorInstance.{RawConfigReloadError, TestConfig, TestEngineRorConfig}
+import tech.beshu.ror.boot.RorInstance.{RawConfigReloadError, TestConfig}
 import tech.beshu.ror.boot.engines.BaseReloadableEngine.EngineState
 import tech.beshu.ror.boot.engines.ConfigHash._
 import tech.beshu.ror.configuration.RawRorConfig
@@ -45,24 +45,15 @@ private[boot] class TestConfigBasedReloadableEngine(boot: ReadonlyRest,
                        (implicit requestId: RequestId): Task[TestConfig] = {
     Task.delay {
       currentEngineState match {
-        case EngineState.NotStartedYet(None) | EngineState.Stopped =>
+        case EngineState.NotStartedYet(None, _) | EngineState.Stopped =>
           TestConfig.NotSet
-        case EngineState.NotStartedYet(Some(recentConfig)) =>
-          TestConfig.Invalidated(recentConfig)
+        case EngineState.NotStartedYet(Some(recentConfig), recentExpirationConfig) =>
+          val expiration = recentExpirationConfig.getOrElse(throw new IllegalStateException("Test Config based engine should have an expiration config defined"))
+          TestConfig.Invalidated(recentConfig, expiration.ttl)
         case EngineState.Working(engineWithConfig, _) =>
           val expiration = engineWithConfig.expirationConfig.getOrElse(throw new IllegalStateException("Test Config based engine should have an expiration config defined"))
-          TestConfig.Present(engineWithConfig.config, expiration.ttl, expiration.validTo)
+          TestConfig.Present(engineWithConfig.engine.core.rorConfig, engineWithConfig.config, expiration.ttl, expiration.validTo)
       }
-    }
-  }
-
-  def currentRorConfig()
-                      (implicit requestId: RequestId): Task[TestEngineRorConfig] = {
-    Task.delay {
-      engine
-        .map(_.core.rorConfig)
-        .map(TestEngineRorConfig.Present.apply)
-        .getOrElse(TestEngineRorConfig.NotSet)
     }
   }
 

--- a/docs/api/ror-internal-api-swagger.yaml
+++ b/docs/api/ror-internal-api-swagger.yaml
@@ -199,6 +199,8 @@ paths:
                   $ref: "#/components/examples/OnlySomeAuthServicesConfiguredResponseExample"
                 TestSettingsNotConfiguredAuthServicesResponseExample:
                   $ref: "#/components/examples/TestSettingsNotConfiguredAuthServicesResponseExample"
+                TestSettingsInvalidatedAuthServicesResponseExample:
+                  $ref: "#/components/examples/TestSettingsInvalidatedAuthServicesResponseExample"
         403:
           description: The request was forbidden by ROR's ACL
           content:
@@ -252,6 +254,8 @@ paths:
                   $ref: "#/components/examples/AuthMocksUpdatedResponseExample"
                 TestSettingsNotConfiguredAuthServicesResponseExample:
                   $ref: "#/components/examples/TestSettingsNotConfiguredAuthServicesResponseExample"
+                TestSettingsInvalidatedAuthServicesResponseExample:
+                  $ref: "#/components/examples/TestSettingsInvalidatedAuthServicesResponseExample"
                 UnknownAuthServicesDetectedResponseExample:
                   $ref: "#/components/examples/UnknownAuthServicesDetectedResponseExample"
         403:
@@ -360,6 +364,8 @@ components:
       required:
         - status
         - message
+        - settings
+        - ttl
       properties:
         status:
           type: string
@@ -371,6 +377,8 @@ components:
         settings:
           type: string
           description: Recently configured Test Settings that are not longer valid, because they were invalidated
+        ttl:
+          $ref: '#/components/schemas/RorSettingsTtl'
 
     CurrentTestSettingsResponse:
       type: object
@@ -527,11 +535,13 @@ components:
       oneOf:
         - $ref: '#/components/schemas/CurrentAuthMocksResponse'
         - $ref: '#/components/schemas/AuthMockTestSettingsNotConfiguredResponse'
+        - $ref: '#/components/schemas/AuthMockTestSettingsInvalidatedResponse'
       discriminator:
         propertyName: status
         mapping:
           TEST_SETTINGS_PRESENT: '#/components/schemas/CurrentAuthMocksResponse'
           TEST_SETTINGS_NOT_CONFIGURED: '#/components/schemas/AuthMockTestSettingsNotConfiguredResponse'
+          TEST_SETTINGS_INVALIDATED: '#/components/schemas/AuthMockTestSettingsInvalidatedResponse'
 
     CurrentAuthMocksResponse:
       type: object
@@ -558,6 +568,20 @@ components:
           type: string
           enum:
             - TEST_SETTINGS_NOT_CONFIGURED
+        message:
+          type: string
+          description: Human readable message
+
+    AuthMockTestSettingsInvalidatedResponse:
+      type: object
+      required:
+        - status
+        - message
+      properties:
+        status:
+          type: string
+          enum:
+            - TEST_SETTINGS_INVALIDATED
         message:
           type: string
           description: Human readable message
@@ -590,12 +614,14 @@ components:
       oneOf:
         - $ref: '#/components/schemas/AuthMocksUpdatedResponse'
         - $ref: '#/components/schemas/AuthMockTestSettingsNotConfiguredResponse'
+        - $ref: '#/components/schemas/AuthMockTestSettingsInvalidatedResponse'
         - $ref: '#/components/schemas/UnknownAuthServicesDetectedResponse'
       discriminator:
         propertyName: status
         mapping:
           OK: '#/components/schemas/AuthMocksUpdatedResponse'
           TEST_SETTINGS_NOT_CONFIGURED: '#/components/schemas/AuthMockTestSettingsNotConfiguredResponse'
+          TEST_SETTINGS_INVALIDATED: '#/components/schemas/AuthMockTestSettingsInvalidatedResponse'
           UNKNOWN_AUTH_SERVICES_DETECTED: '#/components/schemas/UnknownAuthServicesDetectedResponse'
 
     AuthMocksUpdatedResponse:
@@ -882,6 +908,7 @@ components:
         message: ROR Test settings are invalidated
         recent_settings: |
           readonlyrest:\\r\\n    access_control_rules:\\r\\n\\r\\n    - name: | \\""Require HTTP Basic | Auth\\""\\r\\n      type: allow\\r\\n      indices: | [\\""test\\""]\\r\\n\\r\\n    - name: | \\""other\\""\\r\\n      auth_key: \\""admin:test\\""
+        ttl: 30 m
 
     TestSettingsUpdatedResponseExample:
       summary: ROR Test settings was updated and configured with success
@@ -1103,6 +1130,12 @@ components:
       value:
         status: TEST_SETTINGS_NOT_CONFIGURED
         message: ROR Test settings are not configured. To use Auth Services Mock ROR has to have Test settings active.
+
+    TestSettingsInvalidatedAuthServicesResponseExample:
+      summary: ROR Test settings are invalidated
+      value:
+        status: TEST_SETTINGS_INVALIDATED
+        message: ROR Test settings are invalidated. To use Auth Services Mock ROR has to have Test settings active.
 
     UnknownAuthServicesDetectedResponseExample:
       summary: Unknown Auth Services detected

--- a/es60x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es60x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es61x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es61x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es62x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es62x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es62x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es62x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es63x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es63x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es65x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es65x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es65x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es65x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es66x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es66x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es67x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es67x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es70x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es70x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es710x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -35,10 +35,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es710x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -45,6 +45,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -96,6 +97,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es711x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -35,10 +35,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es711x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -45,6 +45,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -96,6 +97,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es714x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -35,10 +35,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es714x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -45,6 +45,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -96,6 +97,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es716x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -36,10 +36,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es716x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -46,6 +46,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -97,6 +98,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es72x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -39,10 +39,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es72x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es73x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -35,10 +35,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es73x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -49,6 +49,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -100,6 +101,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es74x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -35,10 +35,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es74x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -45,6 +45,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -96,6 +97,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es77x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -35,10 +35,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es77x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -45,6 +45,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -96,6 +97,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es78x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -35,10 +35,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es78x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -45,6 +45,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -96,6 +97,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es79x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -35,10 +35,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es79x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -45,6 +45,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -96,6 +97,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es80x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -36,10 +36,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es80x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -46,6 +46,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -97,6 +98,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/es81x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/actions/rrauthmock/RRAuthMockResponse.scala
@@ -36,10 +36,12 @@ class RRAuthMockResponse(response: AuthMockApi.AuthMockResponse)
       case mock: AuthMockResponse.ProvideAuthMock => mock match {
         case ProvideAuthMock.CurrentAuthMocks(services) => currentServicesJson(builder, services)
         case ProvideAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
       }
       case mock: AuthMockResponse.UpdateAuthMock => mock match {
         case UpdateAuthMock.Success(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.NotConfigured(message) => addResponseJson(builder, response.status, message)
+        case UpdateAuthMock.Invalidated(message) => addResponseJson(builder, response.status, message)
         case UpdateAuthMock.UnknownAuthServicesDetected(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {

--- a/es81x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/actions/rrtestconfig/RRTestConfigResponse.scala
@@ -46,6 +46,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
       case provideUsersResponse: ProvideLocalUsers => provideUsersResponse match {
         case res: ProvideLocalUsers.SuccessResponse => provideLocalUsersJson(builder, res)
         case ProvideLocalUsers.TestSettingsNotConfigured(message) => addResponseJson(builder, response.status, message)
+        case ProvideLocalUsers.TestSettingsInvalidated(message) => addResponseJson(builder, response.status, message)
       }
       case failure: Failure => failure match {
         case Failure.BadRequest(message) => addResponseJson(builder, response.status, message)
@@ -97,6 +98,7 @@ class RRTestConfigResponse(response: TestConfigApi.TestConfigResponse)
     builder.field("status", response.status)
     builder.field("message", response.message)
     builder.field("settings", response.settings.raw)
+    builder.field("ttl", response.ttl.toString())
     builder.endObject
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.39.0
-pluginVersion=1.40.0-pre5
+pluginVersion=1.40.0-epic578-pre2
 pluginName=readonlyrest


### PR DESCRIPTION
* Update TTL of  the test settings engine
* TEST_SETTINGS_INVALIDATED cases for /authmock and /localusers
* `ttl` field added to TEST_SETTINGS_INVALIDATED case for /config/test