### PR TITLE
[RORDEV-687] fixed: currently group in context of `jwt_auth` and `ror_kbn_auth` rule

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -155,6 +155,7 @@ if [[ -z $TRAVIS ]] ||  [[ $ROR_TASK == "package_es8xx" ]]; then
     echo ">>> ($0) additional builds of ES module for specified ES version"
 
     #es82
+    ./gradlew --stacktrace es82x:ror '-PesVersion=8.2.2'
     ./gradlew --stacktrace es82x:ror '-PesVersion=8.2.1'
     ./gradlew --stacktrace es82x:ror '-PesVersion=8.2.0'
 

--- a/bin/upload_es_artifacts.sh
+++ b/bin/upload_es_artifacts.sh
@@ -4,6 +4,7 @@ set -xe
 
 echo ">>> ($0) UPLOADING ES ARTIFACTS ..."
 
+./gradlew --stacktrace --info clean ror-tools:uploadArtifactsFromEsBinaries -PesVersion=8.2.2
 ./gradlew --stacktrace --info clean ror-tools:uploadArtifactsFromEsBinaries -PesVersion=8.2.1
 ./gradlew --stacktrace --info clean ror-tools:uploadArtifactsFromEsBinaries -PesVersion=8.2.0
 ./gradlew --stacktrace --info clean ror-tools:uploadArtifactsFromEsBinaries -PesVersion=8.1.3

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/LdapAuthorizationRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/LdapAuthorizationRule.scala
@@ -82,7 +82,6 @@ object LdapAuthorizationRule {
 
   object GroupsLogic {
     final case class Or(override val groups: UniqueNonEmptyList[Group]) extends GroupsLogic
-
     final case class And(override val groups: UniqueNonEmptyList[Group]) extends GroupsLogic
   }
 

--- a/core/src/test/scala/tech/beshu/ror/mocks/MockRequestContext.scala
+++ b/core/src/test/scala/tech/beshu/ror/mocks/MockRequestContext.scala
@@ -69,6 +69,7 @@ object MockRequestContext {
 
   def notReadOnly[BC <: BlockContext](blockContextCreator: RequestContext => BC): MockSimpleRequestContext[BC] =
     MockSimpleRequestContext(blockContextCreator, isReadOnly = false, customAction = DefaultAction)
+
 }
 
 final case class MockGeneralIndexRequestContext(override val timestamp: Instant,

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/BaseGroupsRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/BaseGroupsRuleTests.scala
@@ -404,7 +404,7 @@ abstract class BaseGroupsRuleTests extends AnyWordSpec with Inside with BlockCon
       if (caseSensitivity) UserIdEq.caseSensitive else UserIdEq.caseInsensitive
     )
     val requestContext = MockRequestContext.metadata.copy(
-      headers = preferredGroup.map(_.value).map(v => new Header(Header.Name.currentGroup, v)).toSet[Header]
+      headers = preferredGroup.map(_.toHeader).toSet
     )
     val blockContext = CurrentUserMetadataRequestBlockContext(
       requestContext,

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/ExternalAuthorizationRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/ExternalAuthorizationRuleTests.scala
@@ -334,7 +334,7 @@ class ExternalAuthorizationRuleTests
                          assertionType: AssertionType): Unit = {
     val rule = new ExternalAuthorizationRule(settings, impersonation, UserIdEq.caseSensitive)
     val requestContext = MockRequestContext.metadata.copy(
-      headers = preferredGroup.map(_.value).map(v => new Header(Header.Name.currentGroup, v)).toSet[Header]
+      headers = preferredGroup.map(_.toHeader).toSet
     )
     val blockContext = CurrentUserMetadataRequestBlockContext(
       requestContext,

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/LdapAuthorizationRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/LdapAuthorizationRuleTests.scala
@@ -272,7 +272,7 @@ class LdapAuthorizationRuleTests
                          assertionType: AssertionType): Unit = {
     val rule = new LdapAuthorizationRule(settings, impersonation, UserIdEq.caseSensitive)
     val requestContext = MockRequestContext.metadata.copy(
-      headers = preferredGroup.map(_.value).map(v => new Header(Header.Name.currentGroup, v)).toSet[Header]
+      headers = preferredGroup.map(_.toHeader).toSet
     )
     val blockContext = loggedUser
       .foldLeft(CurrentUserMetadataRequestBlockContext(requestContext, UserMetadata.from(requestContext), Set.empty, List.empty)) {

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/JwtAuthRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/JwtAuthRuleSettingsTests.scala
@@ -66,7 +66,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(None)
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -94,7 +94,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(None)
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -123,7 +123,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(None)
-            rule.settings.groups should be(UniqueList.of(groupFrom("group1"), groupFrom("group2")))
+            rule.settings.permittedGroups should be(UniqueList.of(groupFrom("group1"), groupFrom("group2")))
           }
         )
       }
@@ -151,7 +151,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(None)
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -180,7 +180,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(None)
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -208,7 +208,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(None)
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -237,7 +237,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(None)
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -265,7 +265,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(Some(ClaimName(JsonPath.compile("user"))))
             rule.settings.jwt.groupsClaim should be(None)
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -293,7 +293,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(Some(ClaimName(JsonPath.compile("groups"))))
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -321,7 +321,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(Some(ClaimName(JsonPath.compile("https://{domain}/claims/roles"))))
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -351,7 +351,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Rsa]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(Some(ClaimName(JsonPath.compile("groups"))))
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -380,7 +380,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Rsa]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(Some(ClaimName(JsonPath.compile("groups"))))
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -411,7 +411,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Rsa]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(Some(ClaimName(JsonPath.compile("groups"))))
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -441,7 +441,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod shouldBe a [SignatureCheckMethod.Ec]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(Some(ClaimName(JsonPath.compile("groups"))))
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -476,7 +476,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod.asInstanceOf[SignatureCheckMethod.NoCheck].service shouldBe a[CacheableExternalAuthenticationServiceDecorator]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(Some(ClaimName(JsonPath.compile("groups"))))
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -514,7 +514,7 @@ class JwtAuthRuleSettingsTests
             rule.settings.jwt.checkMethod.asInstanceOf[SignatureCheckMethod.NoCheck].service shouldBe a[CacheableExternalAuthenticationServiceDecorator]
             rule.settings.jwt.userClaim should be(None)
             rule.settings.jwt.groupsClaim should be(Some(ClaimName(JsonPath.compile("groups"))))
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/RorKbnAuthRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/RorKbnAuthRuleSettingsTests.scala
@@ -57,7 +57,7 @@ class RorKbnAuthRuleSettingsTests
           assertion = rule => {
             rule.settings.rorKbn.id should be(RorKbnDef.Name("kbn1"))
             rule.settings.rorKbn.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -82,7 +82,7 @@ class RorKbnAuthRuleSettingsTests
           assertion = rule => {
             rule.settings.rorKbn.id should be(RorKbnDef.Name("kbn1"))
             rule.settings.rorKbn.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -108,7 +108,7 @@ class RorKbnAuthRuleSettingsTests
           assertion = rule => {
             rule.settings.rorKbn.id should be(RorKbnDef.Name("kbn1"))
             rule.settings.rorKbn.checkMethod shouldBe a [SignatureCheckMethod.Hmac]
-            rule.settings.groups should be(UniqueList.of(groupFrom("group1"), groupFrom("group2")))
+            rule.settings.permittedGroups should be(UniqueList.of(groupFrom("group1"), groupFrom("group2")))
           }
         )
       }
@@ -134,7 +134,7 @@ class RorKbnAuthRuleSettingsTests
           assertion = rule => {
             rule.settings.rorKbn.id should be(RorKbnDef.Name("kbn1"))
             rule.settings.rorKbn.checkMethod shouldBe a [SignatureCheckMethod.Rsa]
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -159,7 +159,7 @@ class RorKbnAuthRuleSettingsTests
           assertion = rule => {
             rule.settings.rorKbn.id should be(RorKbnDef.Name("kbn1"))
             rule.settings.rorKbn.checkMethod shouldBe a [SignatureCheckMethod.Rsa]
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -187,7 +187,7 @@ class RorKbnAuthRuleSettingsTests
           assertion = rule => {
             rule.settings.rorKbn.id should be(RorKbnDef.Name("kbn1"))
             rule.settings.rorKbn.checkMethod shouldBe a [SignatureCheckMethod.Rsa]
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }
@@ -213,7 +213,7 @@ class RorKbnAuthRuleSettingsTests
           assertion = rule => {
             rule.settings.rorKbn.id should be(RorKbnDef.Name("kbn1"))
             rule.settings.rorKbn.checkMethod shouldBe a [SignatureCheckMethod.Ec]
-            rule.settings.groups should be(UniqueList.empty)
+            rule.settings.permittedGroups should be(UniqueList.empty)
           }
         )
       }

--- a/core/src/test/scala/tech/beshu/ror/utils/TestsUtils.scala
+++ b/core/src/test/scala/tech/beshu/ror/utils/TestsUtils.scala
@@ -264,6 +264,10 @@ object TestsUtils {
     case Left(_) => throw new IllegalArgumentException(s"Cannot convert $value to Group")
   }
 
+  implicit class CurrentGroupToHeader(val group: Group) extends AnyVal {
+    def toHeader: Header = new Header(Header.Name.currentGroup, group.value)
+  }
+
   def noGroupMappingFrom(value: String): GroupMappings = GroupMappings.Simple(UniqueNonEmptyList.of(groupFrom(value)))
 
   def apiKeyFrom(value: String): ApiKey = NonEmptyString.from(value) match {

--- a/es716x/src/main/scala/tech/beshu/ror/es/handler/AclAwareRequestFilter.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/handler/AclAwareRequestFilter.scala
@@ -247,7 +247,7 @@ object AclAwareRequestFilter {
                              actionRequest: ActionRequest,
                              listener: ActionListener[ActionResponse],
                              chain: EsChain,
-                             threadContextResponseHeaders: Set[(String, String)]) {
+                             threadContextResponseHeaders: Set[(String, String)]) extends Logging {
     lazy val requestContextId = s"${channel.request().hashCode()}-${actionRequest.hashCode()}#${task.getId}"
     val timestamp: Instant = Instant.now()
 
@@ -269,7 +269,7 @@ object AclAwareRequestFilter {
   }
 
   final class EsChain(chain: ActionFilterChain[ActionRequest, ActionResponse],
-                      threadPool: ThreadPool) {
+                      threadPool: ThreadPool) extends Logging  {
 
     def continue(exContext: EsContext,
                  listener: ActionListener[ActionResponse]): Unit = {
@@ -281,6 +281,7 @@ object AclAwareRequestFilter {
                  action: String,
                  request: ActionRequest,
                  listener: ActionListener[ActionResponse]): Unit = {
+      logger.warn(s"ROR: Action $action")
       threadPool.getThreadContext.addXPackAuthenticationHeader(nodeName)
       chain.proceed(task, action, request, listener)
     }

--- a/es82x/gradle.properties
+++ b/es82x/gradle.properties
@@ -1,1 +1,1 @@
-esVersion=8.2.1
+esVersion=8.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.40.0
-pluginVersion=1.40.0
+pluginVersion=1.41.0-pre1
 pluginName=readonlyrest


### PR DESCRIPTION
🐞Fix (ES|KBN) tenancy selector didn't work well with `jwt_auth` and `ror_kbn_auth` rules