### PR TITLE
[RORDEV-687] `jwt_rule`, `ror_kbn_auth` and local groups mapping fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,10 +91,10 @@ stages:
               ROR_TASK: license
             UNIT:
               ROR_TASK: core_tests
-
             IT_PROXY:
               ROR_TASK: integration_proxy
       - job:
+        condition: and(or(eq(variables.isDevelop, true), eq(variables.isMaster, true)))
         container: maven:3.8.1-openjdk-17-slim
         steps:
           - checkout: self
@@ -127,6 +127,38 @@ stages:
             IT_es80x:
               ROR_TASK: integration_es80x
       - job:
+        condition: and(and(ne(variables.isDevelop, true), ne(variables.isMaster, true)))
+        container: maven:3.8.1-openjdk-17-slim
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: false
+            persistCredentials: true
+          - script: |
+              # Translate back env vars to avoid cyclical reference :/
+              export aws_access_key_id=$var_aws_access_key_id
+              export aws_secret_access_key=$var_aws_secret_access_key 
+              
+              echo "[TEST] executing ROR_TASK = $ROR_TASK"
+              bin/build.sh
+            env:
+              var_aws_access_key_id: $(aws_access_key_id)
+              var_aws_secret_access_key: $(aws_secret_access_key)
+          - task: PublishTestResults@2
+            condition: failed()
+            inputs:
+              testRunTitle: "$(ROR_TASK) results"
+              testResultsFiles: "**/TEST*xml"
+              mergeTestResults: true
+        strategy:
+          maxParallel: 99
+          matrix:
+            IT_es82x:
+              ROR_TASK: integration_es82x
+            IT_es80x:
+              ROR_TASK: integration_es80x
+      - job:
+        condition: and(or(eq(variables.isDevelop, true), eq(variables.isMaster, true)))
         steps:
           - checkout: self
             fetchDepth: 1
@@ -185,6 +217,42 @@ stages:
               ROR_TASK: integration_es62x
             IT_es61x:
               ROR_TASK: integration_es61x
+            IT_es60x:
+              ROR_TASK: integration_es60x
+      - job:
+        condition: and(and(ne(variables.isDevelop, true), ne(variables.isMaster, true)))
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: false
+            persistCredentials: true
+          - script: |
+              # Translate back env vars to avoid cyclical reference :/
+              export aws_access_key_id=$var_aws_access_key_id
+              export aws_secret_access_key=$var_aws_secret_access_key 
+              
+              echo "[TEST] executing ROR_TASK = $ROR_TASK"
+              bin/build.sh
+            env:
+              var_aws_access_key_id: $(aws_access_key_id)
+              var_aws_secret_access_key: $(aws_secret_access_key)
+          - task: PublishTestResults@2
+            condition: failed()
+            inputs:
+              testRunTitle: "$(ROR_TASK) results"
+              testResultsFiles: "**/TEST*xml"
+              mergeTestResults: true
+        strategy:
+          maxParallel: 99
+          matrix:
+            IT_es716x:
+              ROR_TASK: integration_es716x
+            IT_es710x:
+              ROR_TASK: integration_es710x
+            IT_es70x:
+              ROR_TASK: integration_es70x
+            IT_es67x:
+              ROR_TASK: integration_es67x
             IT_es60x:
               ROR_TASK: integration_es60x
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ stages:
             IT_PROXY:
               ROR_TASK: integration_proxy
       - job:
-        condition: and(or(eq(variables.isDevelop, true), eq(variables.isMaster, true)))
+        condition: or(eq(variables.isDevelop, true), eq(variables.isMaster, true))
         container: maven:3.8.1-openjdk-17-slim
         steps:
           - checkout: self
@@ -127,7 +127,7 @@ stages:
             IT_es80x:
               ROR_TASK: integration_es80x
       - job:
-        condition: and(and(ne(variables.isDevelop, true), ne(variables.isMaster, true)))
+        condition: and(ne(variables.isDevelop, true), ne(variables.isMaster, true))
         container: maven:3.8.1-openjdk-17-slim
         steps:
           - checkout: self
@@ -158,7 +158,7 @@ stages:
             IT_es80x:
               ROR_TASK: integration_es80x
       - job:
-        condition: and(or(eq(variables.isDevelop, true), eq(variables.isMaster, true)))
+        condition: or(eq(variables.isDevelop, true), eq(variables.isMaster, true))
         steps:
           - checkout: self
             fetchDepth: 1
@@ -220,7 +220,7 @@ stages:
             IT_es60x:
               ROR_TASK: integration_es60x
       - job:
-        condition: and(and(ne(variables.isDevelop, true), ne(variables.isMaster, true)))
+        condition: and(ne(variables.isDevelop, true), ne(variables.isMaster, true))
         steps:
           - checkout: self
             fetchDepth: 1

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/acl/AccessControlList.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/acl/AccessControlList.scala
@@ -34,7 +34,6 @@ import tech.beshu.ror.accesscontrol.domain.{Group, Header}
 import tech.beshu.ror.accesscontrol.factory.GlobalSettings
 import tech.beshu.ror.accesscontrol.orders.forbiddenCauseOrder
 import tech.beshu.ror.accesscontrol.request.RequestContext
-import tech.beshu.ror.accesscontrol.request.RequestContextOps._
 import tech.beshu.ror.utils.uniquelist.UniqueList
 
 class AccessControlList(val blocks: NonEmptyList[Block],
@@ -89,7 +88,7 @@ class AccessControlList(val blocks: NonEmptyList[Block],
         val history = blockResults.map(_._2).toVector
         val result = matchedAllowedBlocks(blockResults.map(_._1)) match {
           case Right(matchedResults) =>
-            userMetadataFrom(matchedResults, context.currentGroup.toOption) match {
+            userMetadataFrom(matchedResults, context.initialBlockContext.userMetadata.currentGroup) match {
               case Some((userMetadata, matchedBlock)) => UserMetadataRequestResult.Allow(userMetadata, matchedBlock)
               case None => UserMetadataRequestResult.Forbidden(nonEmptySetOfMismatchedCausesFromHistory(history))
             }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/Block.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/Block.scala
@@ -25,6 +25,7 @@ import tech.beshu.ror.Constants.{ANSI_CYAN, ANSI_RESET, ANSI_YELLOW}
 import tech.beshu.ror.accesscontrol.blocks.Block.ExecutionResult.{Matched, Mismatched}
 import tech.beshu.ror.accesscontrol.blocks.Block.HistoryItem.RuleHistoryItem
 import tech.beshu.ror.accesscontrol.blocks.Block._
+import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
 import tech.beshu.ror.accesscontrol.blocks.rules.base.Rule
 import tech.beshu.ror.accesscontrol.blocks.rules.base.Rule.RuleResult
 import tech.beshu.ror.accesscontrol.blocks.variables.runtime.VariableContext.VariableUsage
@@ -77,7 +78,7 @@ class Block(val name: Name,
           val block: Block = this
           logger.debug(s"${ANSI_CYAN}matched ${block.show} { found: ${blockContext.show} }$ANSI_RESET")
         case Success((_: Mismatched[B], history)) =>
-          implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show[B](None, None, Vector(history))
+          implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show[B](UserMetadata.empty, Vector(history))
           logger.debug(s"$ANSI_YELLOW[${name.show}] the request matches no rules in this block: ${requestContext.show} $ANSI_RESET")
       }
   }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/UserMetadata.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/UserMetadata.scala
@@ -17,8 +17,9 @@
 package tech.beshu.ror.accesscontrol.blocks.metadata
 
 import cats.data.NonEmptySet
+import cats.implicits._
 import tech.beshu.ror.accesscontrol.domain._
-import tech.beshu.ror.accesscontrol.request.{RequestContext, RequestContextOps}
+import tech.beshu.ror.accesscontrol.request.RequestContext
 import tech.beshu.ror.utils.uniquelist.{UniqueList, UniqueNonEmptyList}
 
 final case class UserMetadata private(loggedUser: Option[LoggedUser],
@@ -57,9 +58,11 @@ final case class UserMetadata private(loggedUser: Option[LoggedUser],
 
 object UserMetadata {
   def from(request: RequestContext): UserMetadata = {
-    new RequestContextOps(request).currentGroup.toOption match {
-      case Some(group) => UserMetadata.empty.withCurrentGroup(group)
+    request
+      .headers
+      .find(_.name === Header.Name.currentGroup) match {
       case None => UserMetadata.empty
+      case Some(Header(_, value)) => UserMetadata.empty.withCurrentGroup(Group(value))
     }
   }
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/JwtAuthRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/JwtAuthRule.scala
@@ -67,10 +67,10 @@ final class JwtAuthRule(val settings: JwtAuthRule.Settings,
     Task
       .unit
       .flatMap { _ =>
-        blockContext.requestContext.currentGroup match {
-          case RequestGroup.`N/A` =>
+        blockContext.userMetadata.currentGroup match {
+          case None =>
             authorizeUsingJwtToken(blockContext)
-          case RequestGroup.AGroup(group) =>
+          case Some(group) =>
             settings.permittedGroups.toList match {
               case Nil =>
                 authorizeUsingJwtToken(blockContext)
@@ -219,12 +219,12 @@ final class JwtAuthRule(val settings: JwtAuthRule.Settings,
 
   private def checkIfCanContinueWithGroups[B <: BlockContext : BlockContextUpdater](blockContext: B,
                                                                                     groups: UniqueList[Group]) = {
-    blockContext.requestContext.currentGroup match {
-      case RequestGroup.`N/A` =>
+    blockContext.userMetadata.currentGroup match {
+      case None =>
         Right(blockContext)
-      case RequestGroup.AGroup(group) if groups.contains(group) =>
+      case Some(group) if groups.contains(group) =>
         Right(blockContext)
-      case RequestGroup.AGroup(_) =>
+      case Some(_) =>
         Left(())
     }
   }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/RorKbnAuthRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/RorKbnAuthRule.scala
@@ -63,10 +63,10 @@ final class RorKbnAuthRule(val settings: Settings,
 
   override protected[rules] def authorize[B <: BlockContext : BlockContextUpdater](blockContext: B): Task[RuleResult[B]] =
     Task {
-      blockContext.requestContext.currentGroup match {
-        case RequestGroup.`N/A` =>
+      blockContext.userMetadata.currentGroup match {
+        case None =>
           authorizeUsingJwtToken(blockContext)
-        case RequestGroup.AGroup(group) =>
+        case Some(group) =>
           settings.permittedGroups.toList match {
             case Nil =>
               authorizeUsingJwtToken(blockContext)
@@ -154,12 +154,12 @@ final class RorKbnAuthRule(val settings: Settings,
 
   private def checkIfCanContinueWithGroups[B <: BlockContext : BlockContextUpdater](blockContext: B,
                                                                                     groups: UniqueList[Group]) = {
-    blockContext.requestContext.currentGroup match {
-      case RequestGroup.`N/A` =>
+    blockContext.userMetadata.currentGroup match {
+      case None =>
         Right(blockContext)
-      case RequestGroup.AGroup(group) if groups.contains(group) =>
+      case Some(group) if groups.contains(group) =>
         Right(blockContext)
-      case RequestGroup.AGroup(_) =>
+      case Some(_) =>
         Left(())
     }
   }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/logging/AccessControlLoggingDecorator.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/logging/AccessControlLoggingDecorator.scala
@@ -26,6 +26,7 @@ import tech.beshu.ror.accesscontrol.AccessControl
 import tech.beshu.ror.accesscontrol.AccessControl.{RegularRequestResult, UserMetadataRequestResult, WithHistory}
 import tech.beshu.ror.accesscontrol.blocks.Block.Verbosity
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
+import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
 import tech.beshu.ror.accesscontrol.blocks.{Block, BlockContext, BlockContextUpdater}
 import tech.beshu.ror.accesscontrol.domain.Header
 import tech.beshu.ror.accesscontrol.logging.ResponseContext._
@@ -135,27 +136,25 @@ object AccessControlLoggingDecorator {
     Show.show[ResponseContext[B]] {
       case allowedBy: AllowedBy[B] =>
         implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(
-          allowedBy.blockContext.userMetadata.loggedUser, allowedBy.blockContext.userMetadata.kibanaIndex, allowedBy.history
+          allowedBy.blockContext.userMetadata, allowedBy.history
         )
         s"""${Constants.ANSI_CYAN}ALLOWED by ${allowedBy.block.show} req=${allowedBy.requestContext.show}${Constants.ANSI_RESET}"""
       case allow: Allow[B] =>
-        implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(
-          allow.userMetadata.loggedUser, allow.userMetadata.kibanaIndex, allow.history
-        )
+        implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(allow.userMetadata, allow.history)
         s"""${Constants.ANSI_CYAN}ALLOWED by ${allow.block.show} req=${allow.requestContext.show}${Constants.ANSI_RESET}"""
       case forbiddenBy: ForbiddenBy[B] =>
         implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(
-          forbiddenBy.blockContext.userMetadata.loggedUser, forbiddenBy.blockContext.userMetadata.kibanaIndex, forbiddenBy.history
+          forbiddenBy.blockContext.userMetadata, forbiddenBy.history
         )
         s"""${Constants.ANSI_PURPLE}FORBIDDEN by ${forbiddenBy.block.show} req=${forbiddenBy.requestContext.show}${Constants.ANSI_RESET}"""
       case forbidden: Forbidden[B] =>
-        implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(None, None, forbidden.history)
+        implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(UserMetadata.empty, forbidden.history)
         s"""${Constants.ANSI_PURPLE}FORBIDDEN by default req=${forbidden.requestContext.show}${Constants.ANSI_RESET}"""
       case requestedIndexNotExist: RequestedIndexNotExist[B] =>
-        implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(None, None, requestedIndexNotExist.history)
+        implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(UserMetadata.empty, requestedIndexNotExist.history)
         s"""${Constants.ANSI_PURPLE}INDEX NOT FOUND req=${requestedIndexNotExist.requestContext.show}${Constants.ANSI_RESET}"""
       case errored: Errored[B] =>
-        implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(None, None, Vector.empty)
+        implicit val requestShow: Show[RequestContext.Aux[B]] = RequestContext.show(UserMetadata.empty, Vector.empty)
         s"""${Constants.ANSI_YELLOW}ERRORED by error req=${errored.requestContext.show}${Constants.ANSI_RESET}"""
     }
   }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/request/RequestContext.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/request/RequestContext.scala
@@ -17,7 +17,6 @@
 package tech.beshu.ror.accesscontrol.request
 
 import java.time.Instant
-
 import cats.Show
 import cats.implicits._
 import com.softwaremill.sttp.Method
@@ -28,6 +27,7 @@ import org.apache.logging.log4j.scala.Logging
 import org.json.JSONObject
 import squants.information.{Bytes, Information}
 import tech.beshu.ror.RequestId
+import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
 import tech.beshu.ror.accesscontrol.blocks.{Block, BlockContext}
 import tech.beshu.ror.accesscontrol.domain.LoggedUser.{DirectlyLoggedUser, ImpersonatedUser}
 import tech.beshu.ror.accesscontrol.domain._
@@ -35,7 +35,6 @@ import tech.beshu.ror.accesscontrol.request.RequestContext.Id
 import tech.beshu.ror.accesscontrol.request.RequestContextOps._
 import tech.beshu.ror.accesscontrol.show.logs._
 import tech.beshu.ror.utils.ScalaOps._
-import tech.beshu.ror.utils.uniquelist.UniqueNonEmptyList
 
 import scala.language.implicitConversions
 
@@ -113,13 +112,12 @@ object RequestContext extends Logging {
     implicit val show: Show[Id] = Show.show(_.value)
   }
 
-  def show[B <: BlockContext](loggedUser: Option[LoggedUser],
-                              kibanaIndex: Option[ClusterIndexName],
+  def show[B <: BlockContext](userMetadata: UserMetadata,
                               history: Vector[Block.History[B]])
                              (implicit headerShow: Show[Header]): Show[RequestContext.Aux[B]] =
     Show.show { r =>
       def stringifyUser = {
-        loggedUser match {
+        userMetadata.loggedUser match {
           case Some(DirectlyLoggedUser(user)) => s"${user.show}"
           case Some(ImpersonatedUser(user, impersonatedBy)) => s"${impersonatedBy.show} (as ${user.show})"
           case None => r.basicAuth.map(_.credentials.user.value).map(name => s"${name.value} (attempted)").getOrElse("[no info about user]")
@@ -141,10 +139,10 @@ object RequestContext extends Logging {
       s"""{
          | ID:${r.id.show},
          | TYP:${r.`type`.show},
-         | CGR:${r.currentGroup.show},
+         | CGR:${userMetadata.currentGroup.show},
          | USR:$stringifyUser,
          | BRS:${r.headers.exists(_.name === Header.Name.userAgent)},
-         | KDX:${kibanaIndex.map(_.show).getOrElse("null")},
+         | KDX:${userMetadata.kibanaIndex.map(_.show).getOrElse("null")},
          | ACT:${r.action.show},
          | OA:${r.remoteAddress.map(_.show).getOrElse("null")},
          | XFF:${r.headers.find(_.name === Header.Name.xForwardedFor).map(_.value.show).getOrElse("null")},
@@ -175,22 +173,6 @@ class RequestContextOps(val requestContext: RequestContext) extends AnyVal {
           .flatMap(_.split(",").headOption)
           .flatMap(Address.from)
       }
-  }
-
-  def currentGroup: RequestGroup = {
-    findHeader(Header.Name.currentGroup) match {
-      case None => RequestGroup.`N/A`
-      case Some(Header(_, value)) => RequestGroup.AGroup(Group(value))
-    }
-  }
-
-  def isCurrentGroupEligible(groups: UniqueNonEmptyList[Group]): Boolean = {
-    currentGroup match {
-      case RequestGroup.AGroup(preferredGroup) =>
-        requestContext.uriPath.isCurrentUserMetadataPath || groups.contains(preferredGroup)
-      case RequestGroup.`N/A` =>
-        true
-    }
   }
 
   def basicAuth: Option[BasicAuth] = {

--- a/core/src/test/scala/tech/beshu/ror/integration/CurrentUserMetadataAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/CurrentUserMetadataAccessControlTests.scala
@@ -271,8 +271,7 @@ class CurrentUserMetadataAccessControlTests
             }
 
             val request2 = MockRequestContext.metadata.copy(
-              headers = Set(header("X-Forwarded-User", "user5")),
-              currentGroup = Some(groupFrom("service1_group2"))
+              headers = Set(header("X-Forwarded-User", "user5"), currentGroupHeader("service1_group2"))
             )
             val result2 = acl.handleMetadataRequest(request2).runSyncUnsafe()
 
@@ -291,8 +290,7 @@ class CurrentUserMetadataAccessControlTests
             }
 
             val request2 = MockRequestContext.metadata.copy(
-              headers = Set(basicAuthHeader("user6:user2")),
-              currentGroup = Some(groupFrom("ldap2_group2"))
+              headers = Set(basicAuthHeader("user6:user2"), currentGroupHeader("ldap2_group2"))
             )
             val result2 = acl.handleMetadataRequest(request2).runSyncUnsafe()
 

--- a/core/src/test/scala/tech/beshu/ror/integration/GroupsRuleAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/GroupsRuleAccessControlTests.scala
@@ -197,7 +197,7 @@ class GroupsRuleAccessControlTests
           val request = MockRequestContext.indices.copy(
             headers = Set(
               basicAuthHeader("morgan:user1"),
-              header("x-ror-current-group", "admin")
+              currentGroupHeader( "admin")
             ),
             filteredIndices = Set(clusterIndexName(".kibana")),
             allIndicesAndAliases = Set(FullLocalIndexWithAliases(fullIndexName(".kibana"), Set.empty))

--- a/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
@@ -170,7 +170,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
         val request = MockRequestContext.indices.copy(
           headers = Set(
             basicAuthHeader("admin:dev"),
-            Header(("x-ror-current-group", "Administrators"))
+            currentGroupHeader("Administrators")
           ),
           uriPath = UriPath("/.kibana_admins/_create/index-pattern:3b2fa1b0-bcb2-11eb-a20e-8daf1d07a2b2"),
           method = Method("PUT"),

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/AccessControlListTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/AccessControlListTests.scala
@@ -104,14 +104,12 @@ class AccessControlListTests extends AnyWordSpec with MockFactory with Inside {
   private def group(groupName: String) = Group(NonEmptyString.unsafeFrom(groupName))
 
   private def mockMetadataRequestContext(preferredGroup: String) = {
+    val userMetadata = UserMetadata.empty.withCurrentGroup(groupFrom(preferredGroup))
     val rc = mock[MetadataRequestContext]
     (rc.initialBlockContext _)
       .expects()
-      .returning(CurrentUserMetadataRequestBlockContext(rc, UserMetadata.empty, Set.empty, List.empty))
+      .returning(CurrentUserMetadataRequestBlockContext(rc, userMetadata, Set.empty, List.empty))
       .anyNumberOfTimes()
-    (rc.headers _)
-      .expects()
-      .returning(Set(new Header(Header.Name("x-ror-current-group"), NonEmptyString.unsafeFrom(preferredGroup))))
     (rc.action _)
       .expects()
       .returning(Action.rorUserMetadataAction)

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/BaseGroupsRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/BaseGroupsRuleTests.scala
@@ -23,7 +23,7 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers._
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AnyWordSpecLike
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.BlockContextUpdater.CurrentUserMetadataRequestBlockContextUpdater
 import tech.beshu.ror.accesscontrol.blocks.definitions.UserDef
@@ -54,7 +54,7 @@ import tech.beshu.ror.utils.uniquelist.{UniqueList, UniqueNonEmptyList}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-abstract class BaseGroupsRuleTests extends AnyWordSpec with Inside with BlockContextAssertion {
+trait BaseGroupsRuleTests extends AnyWordSpecLike with Inside with BlockContextAssertion {
 
   implicit val provider: EnvVarsProvider = OsEnvVarsProvider
 

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/FieldsRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/FieldsRuleTests.scala
@@ -232,7 +232,7 @@ class FieldsRuleTests extends AnyWordSpec with MockFactory with Inside {
 
         (requestContext.uriPath _).expects().returning(UriPath("/_search"))
         (requestContext.isReadOnlyRequest _).expects().returning(true)
-        (requestContext.action _).expects().returning(MockRequestContext.DefaultAction)
+        (requestContext.action _).expects().returning(MockRequestContext.defaultAction)
 
         inside(rule.check(incomingBlockContext).runSyncStep) {
           case Right(Fulfilled(outBlockContext)) =>

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/FilterRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/FilterRuleTests.scala
@@ -123,7 +123,7 @@ class FilterRuleTests extends AnyWordSpec with MockFactory {
       "request is ROR admin request" in {
         val rawFilter = "{\"bool\":{\"must\":[{\"term\":{\"Country\":{\"value\":\"UK\"}}}]}}"
         val rule = new FilterRule(FilterRule.Settings(filterValueFrom(rawFilter)))
-        val requestContext = MockRequestContext.indices.copy(action = MockRequestContext.AdminAction)
+        val requestContext = MockRequestContext.indices.copy(action = MockRequestContext.adminAction)
         val blockContext = FilterableRequestBlockContext(requestContext, UserMetadata.empty, Set.empty, List.empty, Set.empty, Set.empty, None)
 
         rule.check(blockContext).runSyncStep shouldBe Right(RuleResult.Rejected())

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/GroupsOrRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/GroupsOrRuleTests.scala
@@ -31,7 +31,7 @@ import tech.beshu.ror.utils.uniquelist.{UniqueList, UniqueNonEmptyList}
 
 import scala.language.postfixOps
 
-class GroupsRuleTests extends BaseGroupsRuleTests {
+class GroupsOrRuleTests extends BaseGroupsRuleTests {
 
   override def createRule(settings: GroupsRuleSettings, caseSensitivity: UserIdCaseMappingEquality): BaseGroupsRule = {
     new GroupsOrRule(settings, caseSensitivity)

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/variables/RuntimeResolvableVariablesTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/variables/RuntimeResolvableVariablesTests.scala
@@ -147,7 +147,7 @@ class RuntimeResolvableVariablesTests extends AnyWordSpec with MockFactory {
       }
 
       "current group variable is used and initial group is present" in {
-        val requestContext = MockRequestContext.metadata.copy(headers = Set(headerFrom("x-ror-current-group" -> "g1")))
+        val requestContext = MockRequestContext.metadata.copy(headers = Set(currentGroupHeader("g1")))
         val variable = forceCreateSingleVariable("@{acl:current_group}")
           .resolve(currentUserMetadataRequestBlockContextFrom(requestContext = requestContext))
         variable shouldBe Right("g1")

--- a/core/src/test/scala/tech/beshu/ror/utils/TestsUtils.scala
+++ b/core/src/test/scala/tech/beshu/ror/utils/TestsUtils.scala
@@ -69,6 +69,9 @@ object TestsUtils {
       NonEmptyString.unsafeFrom(value)
     )
 
+  def currentGroupHeader(value: String): Header =
+    header("x-ror-current-group", value)
+
   def clusterIndexName(str: NonEmptyString): ClusterIndexName = ClusterIndexName.unsafeFromString(str.value)
 
   def localIndexName(str: NonEmptyString): ClusterIndexName.Local = ClusterIndexName.Local.fromString(str.value.value).get

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.40.0
-pluginVersion=1.41.0-pre2
+pluginVersion=1.41.0-pre3
 pluginName=readonlyrest


### PR DESCRIPTION
🐞Fix (ES|KBN) tenancy selector didn't work well with jwt_auth and ror_kbn_auth rules