### PR TITLE
RORDEV-774 Fix ro users visibility issues

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/Constants.java
+++ b/core/src/main/scala/tech/beshu/ror/Constants.java
@@ -78,7 +78,7 @@ public class Constants {
       "indices:monitor/settings/get",
       "indices:data/read/xpack/rollup/get/*",
       "indices:monitor/stats",
-      "indices:data/write/bulk*"
+      "indices:data/write/bulk*" // To read kibana UI Discover, Dashboard, and Canvas pages, we need to allow POST /bulk calls performed by kibana
   );
 
   public static final Set<String> CLUSTER_ACTIONS = Sets.newHashSet(

--- a/core/src/main/scala/tech/beshu/ror/Constants.java
+++ b/core/src/main/scala/tech/beshu/ror/Constants.java
@@ -77,7 +77,8 @@ public class Constants {
       "indices:admin/*/explain",
       "indices:monitor/settings/get",
       "indices:data/read/xpack/rollup/get/*",
-      "indices:monitor/stats"
+      "indices:monitor/stats",
+      "indices:data/write/bulk*"
   );
 
   public static final Set<String> CLUSTER_ACTIONS = Sets.newHashSet(
@@ -99,7 +100,6 @@ public class Constants {
       "indices:data/write/delete*",
       "indices:data/write/index",
       "indices:data/write/update*",
-      "indices:data/write/bulk*",
       "indices:admin/template/*",
       "cluster:admin/settings/*",
       "indices:admin/aliases/*"

--- a/core/src/main/scala/tech/beshu/ror/Constants.java
+++ b/core/src/main/scala/tech/beshu/ror/Constants.java
@@ -78,7 +78,7 @@ public class Constants {
       "indices:monitor/settings/get",
       "indices:data/read/xpack/rollup/get/*",
       "indices:monitor/stats",
-      "indices:data/write/bulk*" // To read kibana UI Discover, Dashboard, and Canvas pages, we need to allow POST /bulk calls performed by kibana
+      "indices:data/write/bulk*" // To read kibana UI Discover, Dashboard, and Canvas pages, we need to allow POST /_bulk calls performed by kibana, which call a custom script running which increments kibana context resolveCounter value. See script example https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-update
   );
 
   public static final Set<String> CLUSTER_ACTIONS = Sets.newHashSet(


### PR DESCRIPTION
- Moving `"indices:data/write/bulk*"` to the `RO_ACTIONS` resolved various of issues with RO Kibana access user:
    - https://readonlyrest.atlassian.net/browse/RORDEV-774
    - https://readonlyrest.atlassian.net/browse/RORDEV-740
    - And also discover page visibility


I attached es plugin build with the fix to [this](https://readonlyrest.atlassian.net/browse/RORDEV-740) task
