### PR TITLE
[RORDEV-834] `allowed_api_paths` in `kibana` rule

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/Constants.java
+++ b/core/src/main/scala/tech/beshu/ror/Constants.java
@@ -52,17 +52,20 @@ public class Constants {
 
   public static final String AUDIT_LOG_DEFAULT_INDEX_TEMPLATE = "'readonlyrest_audit-'yyyy-MM-dd";
 
-  public static final String HEADER_GROUPS_AVAILABLE      = "x-ror-available-groups";
-  public static final String HEADER_GROUP_CURRENT         = "x-ror-current-group";
-  public static final String HEADER_USER_ROR              = "x-ror-username";
-  public static final String HEADER_KIBANA_HIDDEN_APPS    = "x-ror-kibana-hidden-apps";
-  public static final String HEADER_KIBANA_ACCESS         = "x-ror-kibana_access";
-  public static final String HEADER_KIBANA_INDEX          = "x-ror-kibana_index";
-  public static final String HEADER_KIBANA_TEMPLATE_INDEX = "x-ror-kibana_template_index";
-  public static final String HEADER_USER_ORIGIN           = "x-ror-origin";
-  public static final String HEADER_CORRELATION_ID        = "x-ror-correlation-id";
-  public static final String HEADER_IMPERSONATING         = "x-ror-impersonating";
-  public static final String HEADER_KIBANA_REQUEST_PATH   = "x-ror-kibana-request-path";
+  public static final String HEADER_GROUPS_AVAILABLE                = "x-ror-available-groups";
+  public static final String HEADER_GROUP_CURRENT                   = "x-ror-current-group";
+  public static final String HEADER_USER_ROR                        = "x-ror-username";
+  public static final String HEADER_KIBANA_HIDDEN_APPS              = "x-ror-kibana-hidden-apps";
+  public static final String HEADER_KIBANA_ALLOWED_API_PATHS        = "x-ror-kibana-allowed-api-paths";
+  public static final String HEADER_KIBANA_ACCESS                   = "x-ror-kibana_access";
+  public static final String HEADER_KIBANA_INDEX                    = "x-ror-kibana_index";
+  public static final String HEADER_KIBANA_TEMPLATE_INDEX           = "x-ror-kibana_template_index";
+  public static final String HEADER_USER_ORIGIN                     = "x-ror-origin";
+  public static final String HEADER_CORRELATION_ID                  = "x-ror-correlation-id";
+  public static final String HEADER_IMPERSONATING                   = "x-ror-impersonating";
+  public static final String HEADER_KIBANA_REQUEST_PATH             = "x-ror-kibana-request-path";
+  public static final String HEADER_KIBANA_ALLOWED_API_HTTP_METHOD  = "http_method";
+  public static final String HEADER_KIBANA_ALLOWED_API_PATH_REGEX   = "path_regex";
 
   public static final Set<String> RO_ACTIONS = Sets.newHashSet(
       "indices:admin/exists",

--- a/core/src/main/scala/tech/beshu/ror/Constants.java
+++ b/core/src/main/scala/tech/beshu/ror/Constants.java
@@ -52,21 +52,6 @@ public class Constants {
 
   public static final String AUDIT_LOG_DEFAULT_INDEX_TEMPLATE = "'readonlyrest_audit-'yyyy-MM-dd";
 
-  public static final String HEADER_GROUPS_AVAILABLE                = "x-ror-available-groups";
-  public static final String HEADER_GROUP_CURRENT                   = "x-ror-current-group";
-  public static final String HEADER_USER_ROR                        = "x-ror-username";
-  public static final String HEADER_KIBANA_HIDDEN_APPS              = "x-ror-kibana-hidden-apps";
-  public static final String HEADER_KIBANA_ALLOWED_API_PATHS        = "x-ror-kibana-allowed-api-paths";
-  public static final String HEADER_KIBANA_ACCESS                   = "x-ror-kibana_access";
-  public static final String HEADER_KIBANA_INDEX                    = "x-ror-kibana_index";
-  public static final String HEADER_KIBANA_TEMPLATE_INDEX           = "x-ror-kibana_template_index";
-  public static final String HEADER_USER_ORIGIN                     = "x-ror-origin";
-  public static final String HEADER_CORRELATION_ID                  = "x-ror-correlation-id";
-  public static final String HEADER_IMPERSONATING                   = "x-ror-impersonating";
-  public static final String HEADER_KIBANA_REQUEST_PATH             = "x-ror-kibana-request-path";
-  public static final String HEADER_KIBANA_ALLOWED_API_HTTP_METHOD  = "http_method";
-  public static final String HEADER_KIBANA_ALLOWED_API_PATH_REGEX   = "path_regex";
-
   public static final Set<String> RO_ACTIONS = Sets.newHashSet(
       "indices:admin/exists",
       "indices:admin/mappings/fields/get*",

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/MetadataValue.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/MetadataValue.scala
@@ -54,21 +54,21 @@ object MetadataValue {
   }
 
   private def loggingId(correlationId: CorrelationId) = {
-    Map(Constants.HEADER_CORRELATION_ID -> MetadataString(correlationId.value.value))
+    Map("x-ror-correlation-id" -> MetadataString(correlationId.value.value))
   }
 
   private def userOrigin(userMetadata: UserMetadata) = {
-    userMetadata.userOrigin.map(uo => (Constants.HEADER_USER_ORIGIN, MetadataString(uo.value.value))).toMap
+    userMetadata.userOrigin.map(uo => ("x-ror-origin", MetadataString(uo.value.value))).toMap
   }
 
   private def kibanaAccess(userMetadata: UserMetadata) = {
-    userMetadata.kibanaAccess.map(ka => (Constants.HEADER_KIBANA_ACCESS, MetadataString(ka.show))).toMap
+    userMetadata.kibanaAccess.map(ka => ("x-ror-kibana_access", MetadataString(ka.show))).toMap
   }
 
   private def hiddenKibanaApps(userMetadata: UserMetadata) = {
     NonEmptyList
       .fromList(userMetadata.hiddenKibanaApps.toList)
-      .map(apps => (Constants.HEADER_KIBANA_HIDDEN_APPS, MetadataList(apps.map(_.value.value))))
+      .map(apps => ("x-ror-kibana-hidden-apps", MetadataList(apps.map(_.value.value))))
       .toMap
   }
 
@@ -76,10 +76,10 @@ object MetadataValue {
     NonEmptyList
       .fromList(userMetadata.allowedKibanaApiPaths.toList)
       .map(paths => (
-        Constants.HEADER_KIBANA_ALLOWED_API_PATHS,
+        "x-ror-kibana-allowed-api-paths",
         MetadataListOfMaps(paths.map(p => Map(
-          Constants.HEADER_KIBANA_ALLOWED_API_HTTP_METHOD -> p.httpMethod.show,
-          Constants.HEADER_KIBANA_ALLOWED_API_PATH_REGEX -> p.pathRegex.pattern.pattern()
+          "http_method" -> p.httpMethod.show,
+          "path_regex" -> p.pathRegex.pattern.pattern()
         )))
       ))
       .toMap
@@ -88,24 +88,24 @@ object MetadataValue {
   private def availableGroups(userMetadata: UserMetadata) = {
     NonEmptyList
       .fromList(userMetadata.availableGroups.toList)
-      .map(groups => (Constants.HEADER_GROUPS_AVAILABLE, MetadataList(groups.map(_.value.value))))
+      .map(groups => ("x-ror-available-groups", MetadataList(groups.map(_.value.value))))
       .toMap
   }
 
   private def foundKibanaIndex(userMetadata: UserMetadata) = {
-    userMetadata.kibanaIndex.map(i => (Constants.HEADER_KIBANA_INDEX, MetadataString(i.stringify))).toMap
+    userMetadata.kibanaIndex.map(i => ("x-ror-kibana_index", MetadataString(i.stringify))).toMap
   }
 
   private def foundKibanaTemplateIndex(userMetadata: UserMetadata) = {
-    userMetadata.kibanaTemplateIndex.map(i => (Constants.HEADER_KIBANA_TEMPLATE_INDEX, MetadataString(i.stringify))).toMap
+    userMetadata.kibanaTemplateIndex.map(i => ("x-ror-kibana_template_index", MetadataString(i.stringify))).toMap
   }
 
   private def currentGroup(userMetadata: UserMetadata) = {
-    userMetadata.currentGroup.map(g => (Constants.HEADER_GROUP_CURRENT, MetadataString(g.value.value))).toMap
+    userMetadata.currentGroup.map(g => ("x-ror-current-group", MetadataString(g.value.value))).toMap
   }
 
   private def loggedUser(userMetadata: UserMetadata) = {
-    userMetadata.loggedUser.map(u => (Constants.HEADER_USER_ROR, MetadataString(u.id.value.value))).toMap
+    userMetadata.loggedUser.map(u => ("x-ror-username", MetadataString(u.id.value.value))).toMap
   }
 
   private implicit val kibanaAccessShow: Show[KibanaAccess] = Show {

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/UserMetadata.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/UserMetadata.scala
@@ -18,7 +18,7 @@ package tech.beshu.ror.accesscontrol.blocks.metadata
 
 import cats.implicits._
 import tech.beshu.ror.accesscontrol.domain.GroupLike.GroupName
-import tech.beshu.ror.accesscontrol.domain._
+import tech.beshu.ror.accesscontrol.domain.{KibanaAllowedApiPath, _}
 import tech.beshu.ror.accesscontrol.request.RequestContext
 import tech.beshu.ror.utils.uniquelist.{UniqueList, UniqueNonEmptyList}
 
@@ -28,6 +28,7 @@ final case class UserMetadata private(loggedUser: Option[LoggedUser],
                                       kibanaIndex: Option[IndexName.Kibana],
                                       kibanaTemplateIndex: Option[IndexName.Kibana],
                                       hiddenKibanaApps: Set[KibanaApp],
+                                      allowedKibanaApiPaths: Set[KibanaAllowedApiPath],
                                       kibanaAccess: Option[KibanaAccess],
                                       userOrigin: Option[UserOrigin],
                                       jwtToken: Option[JwtTokenPayload]) {
@@ -49,7 +50,10 @@ final case class UserMetadata private(loggedUser: Option[LoggedUser],
   def withKibanaIndex(index: IndexName.Kibana): UserMetadata = this.copy(kibanaIndex = Some(index))
   def withKibanaTemplateIndex(index: IndexName.Kibana): UserMetadata = this.copy(kibanaTemplateIndex = Some(index))
   def addHiddenKibanaApp(app: KibanaApp): UserMetadata = this.copy(hiddenKibanaApps = this.hiddenKibanaApps + app)
-  def withHiddenKibanaApps(apps: UniqueNonEmptyList[KibanaApp]): UserMetadata = this.copy(hiddenKibanaApps = this.hiddenKibanaApps ++ apps)
+  def withHiddenKibanaApps(apps: UniqueNonEmptyList[KibanaApp]): UserMetadata =
+    this.copy(hiddenKibanaApps = this.hiddenKibanaApps ++ apps)
+  def withAllowedKibanaApiPaths(paths: UniqueNonEmptyList[KibanaAllowedApiPath]): UserMetadata =
+    this.copy(allowedKibanaApiPaths = this.allowedKibanaApiPaths ++ paths)
   def withKibanaAccess(access: KibanaAccess): UserMetadata = this.copy(kibanaAccess = Some(access))
   def withUserOrigin(origin: UserOrigin): UserMetadata = this.copy(userOrigin = Some(origin))
   def withJwtToken(token: JwtTokenPayload): UserMetadata = this.copy(jwtToken = Some(token))
@@ -73,6 +77,7 @@ object UserMetadata {
     kibanaIndex = None,
     kibanaTemplateIndex = None,
     hiddenKibanaApps = Set.empty,
+    allowedKibanaApiPaths = Set.empty,
     kibanaAccess = None,
     userOrigin = None,
     jwtToken = None

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/UserMetadata.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/UserMetadata.scala
@@ -18,7 +18,7 @@ package tech.beshu.ror.accesscontrol.blocks.metadata
 
 import cats.implicits._
 import tech.beshu.ror.accesscontrol.domain.GroupLike.GroupName
-import tech.beshu.ror.accesscontrol.domain.{KibanaAllowedApiPath, _}
+import tech.beshu.ror.accesscontrol.domain._
 import tech.beshu.ror.accesscontrol.request.RequestContext
 import tech.beshu.ror.utils.uniquelist.{UniqueList, UniqueNonEmptyList}
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaUserDataRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaUserDataRule.scala
@@ -24,7 +24,7 @@ import tech.beshu.ror.accesscontrol.blocks.rules.Rule.{RegularRule, RuleName, Ru
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana.KibanaUserDataRule.Settings
 import tech.beshu.ror.accesscontrol.blocks.variables.runtime.RuntimeSingleResolvableVariable
 import tech.beshu.ror.accesscontrol.blocks.{BlockContext, BlockContextUpdater}
-import tech.beshu.ror.accesscontrol.domain.{IndexName, KibanaAccess, KibanaApp, RorConfigurationIndex}
+import tech.beshu.ror.accesscontrol.domain.{IndexName, KibanaAccess, KibanaAllowedApiPath, KibanaApp, RorConfigurationIndex}
 import tech.beshu.ror.utils.uniquelist.UniqueNonEmptyList
 
 class KibanaUserDataRule(override val settings: Settings)
@@ -62,6 +62,10 @@ class KibanaUserDataRule(override val settings: Settings)
       applyToUserMetadata(resolveAppsToHide)(
         _.withHiddenKibanaApps(_)
       )
+    } andThen {
+      applyToUserMetadata(resolveAllowedApiPaths)(
+        _.withAllowedKibanaApiPaths(_)
+      )
     }
   }
 
@@ -78,6 +82,9 @@ class KibanaUserDataRule(override val settings: Settings)
 
   private lazy val resolveAppsToHide =
     UniqueNonEmptyList.fromTraversable(settings.appsToHide)
+
+  private lazy val resolveAllowedApiPaths =
+    UniqueNonEmptyList.fromTraversable(settings.allowedApiPaths)
 
   private def applyToUserMetadata[T](opt: Option[T])
                                     (userMetadataUpdateFunction: (UserMetadata, T) => UserMetadata): UserMetadata => UserMetadata = {
@@ -98,6 +105,7 @@ object KibanaUserDataRule {
                             kibanaIndex: RuntimeSingleResolvableVariable[IndexName.Kibana],
                             kibanaTemplateIndex: Option[RuntimeSingleResolvableVariable[IndexName.Kibana]],
                             appsToHide: Set[KibanaApp],
+                            allowedApiPaths: Set[KibanaAllowedApiPath],
                             override val rorIndex: RorConfigurationIndex)
     extends BaseKibanaRule.Settings(access, rorIndex)
 }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/domain.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/domain.scala
@@ -222,23 +222,20 @@ object domain {
   object Header {
     final case class Name(value: NonEmptyString)
     object Name {
+      val authorization = Name("Authorization")
       val xApiKeyHeaderName = Header.Name("X-Api-Key")
       val xForwardedFor = Name("X-Forwarded-For")
       val xForwardedUser = Name("X-Forwarded-User")
-      val xUserOrigin = Name(Constants.HEADER_USER_ORIGIN)
-      val kibanaHiddenApps = Name(Constants.HEADER_KIBANA_HIDDEN_APPS)
-      val kibanaRequestPath = Name(Constants.HEADER_KIBANA_REQUEST_PATH)
       val cookie = Name("Cookie")
       val setCookie = Name("Set-Cookie")
-      val transientFields = Name(Constants.FIELDS_TRANSIENT)
-      val currentGroup = Name(Constants.HEADER_GROUP_CURRENT)
-      val availableGroups = Name(Constants.HEADER_GROUPS_AVAILABLE)
+      val transientFields = Name("_fields")
       val userAgent = Name("User-Agent")
-      val authorization = Name("Authorization")
-      val rorUser = Name(Constants.HEADER_USER_ROR)
-      val kibanaAccess = Name(Constants.HEADER_KIBANA_ACCESS)
-      val impersonateAs = Name(Constants.HEADER_IMPERSONATING)
-      val correlationId = Name(Constants.HEADER_CORRELATION_ID)
+
+      val xUserOrigin = Name("x-ror-origin")
+      val kibanaRequestPath = Name("x-ror-kibana-request-path")
+      val currentGroup = Name("x-ror-current-group")
+      val impersonateAs = Name("x-ror-impersonating")
+      val correlationId = Name("x-ror-correlation-id")
 
       implicit val eqName: Eq[Name] = Eq.by(_.value.value.toLowerCase(Locale.US))
     }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/common.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/common.scala
@@ -306,10 +306,11 @@ object common extends Logging {
         case "ro" => Right(KibanaAccess.RO)
         case "ro_strict" => Right(KibanaAccess.ROStrict)
         case "rw" => Right(KibanaAccess.RW)
+        case "api_only" =>  Right(KibanaAccess.ApiOnly)
         case "admin" => Right(KibanaAccess.Admin)
         case "unrestricted" => Right(KibanaAccess.Unrestricted)
         case unknown => Left(CoreCreationError.ValueLevelCreationError(Message(
-          s"Unknown kibana access '$unknown'. Available options: 'ro', 'ro_strict', 'rw', 'admin', 'unrestricted'"
+          s"Unknown kibana access '$unknown'. Available options: 'ro', 'ro_strict', 'rw', 'api_only', 'admin', 'unrestricted'"
         )))
       }
       .decoder

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/ops.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/ops.scala
@@ -53,7 +53,7 @@ import tech.beshu.ror.accesscontrol.domain.KibanaAllowedApiPath.AllowedHttpMetho
 import tech.beshu.ror.accesscontrol.domain.ResponseFieldsFiltering.AccessMode.{Blacklist, Whitelist}
 import tech.beshu.ror.accesscontrol.domain.ResponseFieldsFiltering.ResponseFieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain.User.UserIdPattern
-import tech.beshu.ror.accesscontrol.domain.{KibanaAllowedApiPath, _}
+import tech.beshu.ror.accesscontrol.domain._
 import tech.beshu.ror.accesscontrol.factory.BlockValidator.BlockValidationError
 import tech.beshu.ror.accesscontrol.factory.BlockValidator.BlockValidationError.KibanaUserDataRuleTogetherWith
 import tech.beshu.ror.accesscontrol.header.{FromHeaderValue, ToHeaderValue}

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/ops.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/ops.scala
@@ -48,10 +48,12 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.{FieldsRestrictions, Strategy}
 import tech.beshu.ror.accesscontrol.domain.GroupLike.GroupName
 import tech.beshu.ror.accesscontrol.domain.Header.AuthorizationValueError
+import tech.beshu.ror.accesscontrol.domain.KibanaAllowedApiPath.AllowedHttpMethod
+import tech.beshu.ror.accesscontrol.domain.KibanaAllowedApiPath.AllowedHttpMethod.HttpMethod
 import tech.beshu.ror.accesscontrol.domain.ResponseFieldsFiltering.AccessMode.{Blacklist, Whitelist}
 import tech.beshu.ror.accesscontrol.domain.ResponseFieldsFiltering.ResponseFieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain.User.UserIdPattern
-import tech.beshu.ror.accesscontrol.domain._
+import tech.beshu.ror.accesscontrol.domain.{KibanaAllowedApiPath, _}
 import tech.beshu.ror.accesscontrol.factory.BlockValidator.BlockValidationError
 import tech.beshu.ror.accesscontrol.factory.BlockValidator.BlockValidationError.KibanaUserDataRuleTogetherWith
 import tech.beshu.ror.accesscontrol.header.{FromHeaderValue, ToHeaderValue}
@@ -163,6 +165,16 @@ object show {
     implicit val lemonUriShow: Show[LemonUri] = Show.show(_.toString())
     implicit val headerNameShow: Show[Header.Name] = Show.show(_.value.value)
     implicit val kibanaAppShow: Show[KibanaApp] = Show.show(_.value.value)
+    implicit val kibanaAllowedApiPathShow: Show[KibanaAllowedApiPath] = Show.show { p =>
+      val httpMethodStr = p.httpMethod match {
+        case AllowedHttpMethod.Any => "*"
+        case AllowedHttpMethod.Specific(HttpMethod.Get) => "GET"
+        case AllowedHttpMethod.Specific(HttpMethod.Put) => "PUT"
+        case AllowedHttpMethod.Specific(HttpMethod.Post) => "POST"
+        case AllowedHttpMethod.Specific(HttpMethod.Delete) => "DELETE"
+      }
+      s"$httpMethodStr:${p.pathRegex.pattern.pattern()}"
+    }
     implicit val proxyAuthNameShow: Show[ProxyAuth.Name] = Show.show(_.value)
     implicit val clusterIndexNameShow: Show[ClusterIndexName] = Show.show(_.stringify)
     implicit val clusterNameFullShow: Show[ClusterName.Full] = Show.show(_.value.value)
@@ -228,6 +240,7 @@ object show {
         showNamedTraversable("av_groups", u.availableGroups) ::
         showOption("kibana_idx", u.kibanaIndex) ::
         showNamedTraversable("hidden_apps", u.hiddenKibanaApps) ::
+        showNamedTraversable("allowed_api_paths", u.allowedKibanaApiPaths) ::
         showOption("kibana_access", u.kibanaAccess) ::
         showOption("user_origin", u.userOrigin) ::
         Nil flatten) mkString ";"

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/request/RequestContext.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/request/RequestContext.scala
@@ -40,7 +40,7 @@ import tech.beshu.ror.utils.ScalaOps._
 import java.time.Instant
 import scala.language.implicitConversions
 
-trait RequestContext {
+trait RequestContext extends Logging {
 
   type BLOCK_CONTEXT <: BlockContext
 

--- a/core/src/test/scala/tech/beshu/ror/integration/CurrentUserMetadataAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/CurrentUserMetadataAccessControlTests.scala
@@ -29,6 +29,8 @@ import tech.beshu.ror.accesscontrol.AccessControl.ForbiddenCause.OperationNotAll
 import tech.beshu.ror.accesscontrol.AccessControl.UserMetadataRequestResult._
 import tech.beshu.ror.accesscontrol.blocks.definitions.ldap.implementations.UnboundidLdapConnectionPoolProvider
 import tech.beshu.ror.accesscontrol.domain.GroupLike.GroupName
+import tech.beshu.ror.accesscontrol.domain.KibanaAllowedApiPath.AllowedHttpMethod
+import tech.beshu.ror.accesscontrol.domain.KibanaAllowedApiPath.AllowedHttpMethod.HttpMethod
 import tech.beshu.ror.accesscontrol.domain.LoggedUser.DirectlyLoggedUser
 import tech.beshu.ror.accesscontrol.domain._
 import tech.beshu.ror.accesscontrol.factory.{AsyncHttpClientsFactory, HttpClientsFactory}
@@ -91,6 +93,10 @@ class CurrentUserMetadataAccessControlTests
       |      access: ro
       |      kibana_index: "user2_kibana_index"
       |      hide_apps: ["user2_app1", "user2_app2"]
+      |      allowed_api_paths:
+      |        - "^/api/spaces/.*$$"
+      |        - http_method: GET
+      |          path: "/api/spaces?test=12.2"
       |
       |  - name: "User 3"
       |    auth_key: "user3:pass"
@@ -221,6 +227,7 @@ class CurrentUserMetadataAccessControlTests
             userMetadata.availableGroups.toSet should be (Set(GroupName("group3"), GroupName("group1")))
             userMetadata.kibanaIndex should be (None)
             userMetadata.hiddenKibanaApps should be (Set.empty)
+            userMetadata.allowedKibanaApiPaths should be (Set.empty)
             userMetadata.kibanaAccess should be (None)
             userMetadata.userOrigin should be (None)
           }
@@ -236,6 +243,7 @@ class CurrentUserMetadataAccessControlTests
             userMetadata.availableGroups.toSet should be (Set(GroupName("group5"), GroupName("group6")))
             userMetadata.kibanaIndex should be (Some(clusterIndexName("user4_group6_kibana_index")))
             userMetadata.hiddenKibanaApps should be (Set.empty)
+            userMetadata.allowedKibanaApiPaths should be (Set.empty)
             userMetadata.kibanaAccess should be (Some(KibanaAccess.Unrestricted))
             userMetadata.userOrigin should be (None)
           }
@@ -250,6 +258,7 @@ class CurrentUserMetadataAccessControlTests
             userMetadata.availableGroups.toSet should be (Set(GroupName("group5"), GroupName("group6")))
             userMetadata.kibanaIndex should be (Some(clusterIndexName("user4_group5_kibana_index")))
             userMetadata.hiddenKibanaApps should be (Set.empty)
+            userMetadata.allowedKibanaApiPaths should be (Set.empty)
             userMetadata.kibanaAccess should be (Some(KibanaAccess.Unrestricted))
             userMetadata.userOrigin should be (None)
           }
@@ -263,6 +272,10 @@ class CurrentUserMetadataAccessControlTests
             userMetadata.availableGroups.toSet should be (Set(GroupName("group2")))
             userMetadata.kibanaIndex should be (Some(clusterIndexName("user2_kibana_index")))
             userMetadata.hiddenKibanaApps should be (Set(KibanaApp("user2_app1"), KibanaApp("user2_app2")))
+            userMetadata.allowedKibanaApiPaths should be (Set(
+              KibanaAllowedApiPath(AllowedHttpMethod.Any, Regex("^/api/spaces/.*$")),
+              KibanaAllowedApiPath(AllowedHttpMethod.Specific(HttpMethod.Get), Regex("""^/api/spaces\?test\=12\.2$"""))
+            ))
             userMetadata.kibanaAccess should be (Some(KibanaAccess.RO))
             userMetadata.userOrigin should be (None)
           }
@@ -276,6 +289,7 @@ class CurrentUserMetadataAccessControlTests
             userMetadata.availableGroups.toSet should be (UniqueList.empty)
             userMetadata.kibanaIndex should be (Some(clusterIndexName("user3_kibana_index")))
             userMetadata.hiddenKibanaApps should be (Set(KibanaApp("user3_app1"), KibanaApp("user3_app2")))
+            userMetadata.allowedKibanaApiPaths should be (Set.empty)
             userMetadata.kibanaAccess should be (Some(KibanaAccess.Unrestricted))
             userMetadata.userOrigin should be (None)
           }

--- a/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
@@ -162,6 +162,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
             kibanaIndex = Some(localIndexName(".kibana_admins")),
             kibanaTemplateIndex = None,
             hiddenKibanaApps = Set(KibanaApp("Enterprise Search|Overview"), KibanaApp("Observability")),
+            allowedKibanaApiPaths = Set.empty,
             kibanaAccess = Some(KibanaAccess.Admin),
             userOrigin = None,
             jwtToken = None

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/http/UriRegexRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/http/UriRegexRuleTests.scala
@@ -123,13 +123,13 @@ class UriRegexRuleTests extends AnyWordSpec with MockFactory {
     val rule = new UriRegexRule(UriRegexRule.Settings(uriRegex))
     val requestContext = MockRequestContext.metadata.copy(uriPath = uriPath)
     val blockContext = CurrentUserMetadataRequestBlockContext(
-      requestContext,
-      loggedUser match {
+      requestContext = requestContext,
+      userMetadata = loggedUser match {
         case Some(userId) => UserMetadata.empty.withLoggedUser(DirectlyLoggedUser(userId))
         case None => UserMetadata.empty
       },
-      Set.empty,
-      List.empty
+      responseHeaders = Set.empty,
+      responseTransformations = List.empty
     )
     rule.check(blockContext).runSyncStep shouldBe Right {
       if (isMatched) Fulfilled(blockContext)

--- a/docs/api/ror-internal-api-swagger.yaml
+++ b/docs/api/ror-internal-api-swagger.yaml
@@ -421,7 +421,7 @@ components:
           type: array
           description: it defines which Kibana API paths should be allowed by ROR Kibana (it supports regexes)
           items:
-            $ref: '#/components/schemas/KibanaAllowedApiPathLike'
+            $ref: '#/components/schemas/KibanaAllowedApiPath'
         x-ror-origin:
           type: string
           description: the value taken from JWT's x-ror-origin claim
@@ -430,40 +430,24 @@ components:
       type: string
       description: It's a group that the user belongs to. It is used in tenancy selector in ROR Kibana
 
-    KibanaAllowedApiPathLike:
-      oneOf:
-        - $ref: '#/components/schemas/SimpleKibanaAllowedApiPath'
-        - $ref: '#/components/schemas/SimpleKibanaAllowedApiPathRegex'
-        - $ref: '#/components/schemas/ExtendedKibanaAllowedApi'
-
-    SimpleKibanaAllowedApiPath:
-      type: string
-      description: It's a allowed Kibana API path (any HTTP method)
-
-    SimpleKibanaAllowedApiPathRegex:
-      type: string
-      description: It's a allowed Kibana API path regex (any HTTP method)
-
-    ExtendedKibanaAllowedApi:
+    KibanaAllowedApiPath:
       type: object
       required:
         - http_method
-        - path
+        - path_regex
       properties:
         http_method:
           type: string
           enum:
+            - ANY
             - GET
             - PUT
             - POST
             - DELETE
-        path:
-          $ref: '#/components/schemas/SimpleKibanaAllowedApiPath'
-
-    SimpleAllowedApiPathLike:
-      oneOf:
-        - $ref: '#/components/schemas/SimpleKibanaAllowedApiPath'
-        - $ref: '#/components/schemas/SimpleKibanaAllowedApiPathRegex'
+          description: HTTP method can be set to specific one (GET, PUT, POST, DELETE) or be ANY
+        path_regex:
+          type: string
+          description: It's a Java 8 regex (https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html) for Kibana API path (it can include query string and fragments too)
 
     KibanaHiddenAppLike:
       oneOf:
@@ -1016,10 +1000,12 @@ components:
         x-ror-kibana_index: .kibana_7.17_admin
         x-ror-kibana_access: admin
         x-ror-kibana-allowed-api-paths:
-          - /api/index_management/indices
-          - ^\/api\/spaces\/.*$
+          - http_method: ANY
+            path_regex: "^/api/index_management/indices$"
+          - http_method: ANY
+            path_regex: "^\/api\/spaces\/.*$"
           - http_method: GET
-            path: ^\/api\/saved_objects\/.*$
+            path_regex: "^/api/saved_objects/.*$"
 
     NoAclBlockWasMatchedForbiddenResponseExample:
       summary: No ACL block was matched

--- a/docs/api/ror-internal-api-swagger.yaml
+++ b/docs/api/ror-internal-api-swagger.yaml
@@ -432,16 +432,38 @@ components:
 
     KibanaAllowedApiPathLike:
       oneOf:
-        - $ref: '#/components/schemas/KibanaAllowedApiPath'
-        - $ref: '#/components/schemas/KibanaAllowedApiPathRegex'
+        - $ref: '#/components/schemas/SimpleKibanaAllowedApiPath'
+        - $ref: '#/components/schemas/SimpleKibanaAllowedApiPathRegex'
+        - $ref: '#/components/schemas/ExtendedKibanaAllowedApi'
 
-    KibanaAllowedApiPath:
+    SimpleKibanaAllowedApiPath:
       type: string
-      description: It's a allowed Kibana API path
+      description: It's a allowed Kibana API path (any HTTP method)
 
-    KibanaAllowedApiPathRegex:
+    SimpleKibanaAllowedApiPathRegex:
       type: string
-      description: It's a allowed Kibana API path regex
+      description: It's a allowed Kibana API path regex (any HTTP method)
+
+    ExtendedKibanaAllowedApi:
+      type: object
+      required:
+        - http_method
+        - path
+      properties:
+        http_method:
+          type: string
+          enum:
+            - GET
+            - PUT
+            - POST
+            - DELETE
+        path:
+          $ref: '#/components/schemas/SimpleKibanaAllowedApiPath'
+
+    SimpleAllowedApiPathLike:
+      oneOf:
+        - $ref: '#/components/schemas/SimpleKibanaAllowedApiPath'
+        - $ref: '#/components/schemas/SimpleKibanaAllowedApiPathRegex'
 
     KibanaHiddenAppLike:
       oneOf:
@@ -996,6 +1018,9 @@ components:
         x-ror-kibana-allowed-api-paths:
           - /api/index_management/indices
           - ^\/api\/spaces\/.*$
+          - http_method: GET
+            path: ^\/api\/saved_objects\/.*$
+
 
     NoAclBlockWasMatchedForbiddenResponseExample:
       summary: No ACL block was matched

--- a/es60x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -36,13 +36,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es61x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es62x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es62x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es63x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es65x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es65x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,7 +16,6 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
@@ -36,13 +35,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es66x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es67x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es70x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es710x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es711x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es714x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es716x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es72x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,7 +16,6 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
@@ -36,13 +35,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es73x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es74x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es77x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es78x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es79x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es80x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es81x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es82x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es83x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es84x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/es85x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/CurrentUserMetadataEsRequestContext.scala
@@ -16,16 +16,14 @@
  */
 package tech.beshu.ror.es.handler.request.context.types
 
-
 import org.elasticsearch.threadpool.ThreadPool
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.CurrentUserMetadataRequestBlockContext
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
-import tech.beshu.ror.accesscontrol.domain.CorrelationId
 import tech.beshu.ror.es.RorClusterService
+import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult.Modified
 import tech.beshu.ror.es.handler.request.context.{BaseEsRequestContext, EsRequest, ModificationResult}
-import tech.beshu.ror.es.actions.rrmetadata.RRUserMetadataRequest
 
 class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
                                           esContext: EsContext,
@@ -36,13 +34,11 @@ class CurrentUserMetadataEsRequestContext(actionRequest: RRUserMetadataRequest,
 
   override lazy val isReadOnlyRequest: Boolean = true
 
-  override lazy val correlationId: CorrelationId = CorrelationId.random
-
   override val initialBlockContext: CurrentUserMetadataRequestBlockContext = CurrentUserMetadataRequestBlockContext(
-    this,
-    UserMetadata.from(this),
-    Set.empty,
-    List.empty
+    requestContext = this,
+    userMetadata = UserMetadata.from(this),
+    responseHeaders = Set.empty,
+    responseTransformations = List.empty
   )
 
   override protected def modifyRequest(blockContext: CurrentUserMetadataRequestBlockContext): ModificationResult = Modified

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.47.0
-pluginVersion=1.48.0-pre3
+pluginVersion=1.48.0-pre4
 pluginName=readonlyrest

--- a/integration-tests/src/test/resources/current_user_metadata/readonlyrest.yml
+++ b/integration-tests/src/test/resources/current_user_metadata/readonlyrest.yml
@@ -30,6 +30,10 @@ readonlyrest:
         access: ro
         kibana_index: "user2_kibana_index"
         hide_apps: ["user2_app1", "user2_app2"]
+        allowed_api_paths:
+          - "^/api/spaces/.*$"
+          - http_method: GET
+            path: "/api/spaces?test=12.2"
 
     - name: "User 3"
       auth_key: "user3:pass"

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/CurrentUserMetadataSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/CurrentUserMetadataSuite.scala
@@ -16,14 +16,14 @@
  */
 package tech.beshu.ror.integration.suites
 
-import org.junit.Assert.assertEquals
 import org.scalatest.wordspec.AnyWordSpec
 import tech.beshu.ror.integration.suites.base.support.BaseSingleNodeEsClusterTest
 import tech.beshu.ror.integration.utils.ESVersionSupportForAnyWordSpecLike
 import tech.beshu.ror.utils.containers.EsClusterProvider
 import tech.beshu.ror.utils.elasticsearch.RorApiManager
 import tech.beshu.ror.utils.misc.CustomScalaTestMatchers
-import ujson.Str
+
+import java.util.UUID
 
 trait CurrentUserMetadataSuite
   extends AnyWordSpec
@@ -40,56 +40,82 @@ trait CurrentUserMetadataSuite
         "several blocks are matched" in {
           val user1MetadataManager = new RorApiManager(basicAuthClient("user1", "pass"), esVersionUsed)
 
-          val result = user1MetadataManager.fetchMetadata()
+          val correlationId = UUID.randomUUID().toString
+          val result = user1MetadataManager.fetchMetadata(correlationId = Some(correlationId))
 
-          assertEquals(200, result.responseCode)
-          result.responseJson.obj.size should be(4)
-          result.responseJson("x-ror-username").str should be("user1")
-          result.responseJson("x-ror-current-group").str should be("group1")
-          result.responseJson("x-ror-available-groups").arr.toList should be(List(Str("group1")))
-          result.responseJson("x-ror-correlation-id").str should fullyMatch uuidRegex()
+          result.responseCode should be (200)
+          result.responseJson should be (ujson.read(
+            s"""{
+               |  "x-ror-username": "user1",
+               |  "x-ror-current-group": "group1",
+               |  "x-ror-available-groups": [ "group1" ],
+               |  "x-ror-correlation-id": "$correlationId"
+               |}""".stripMargin))
         }
         "several blocks are matched and current group is set" in {
           val user1MetadataManager = new RorApiManager(basicAuthClient("user4", "pass"), esVersionUsed)
 
-          val result = user1MetadataManager.fetchMetadata("group6")
+          val correlationId = UUID.randomUUID().toString
+          val result = user1MetadataManager.fetchMetadata(
+            preferredGroup = Some("group6"),
+            correlationId = Some(correlationId)
+          )
 
-          assertEquals(200, result.responseCode)
-          result.responseJson.obj.size should be(7)
-          result.responseJson("x-ror-username").str should be("user4")
-          result.responseJson("x-ror-current-group").str should be("group6")
-          result.responseJson("x-ror-available-groups").arr.toList should be(List(Str("group5"), Str("group6")))
-          result.responseJson("x-ror-kibana_index").str should be("user4_group6_kibana_index")
-          result.responseJson("x-ror-kibana_template_index").str should be("user4_group6_kibana_template_index")
-          result.responseJson("x-ror-correlation-id").str should fullyMatch uuidRegex()
+          result.responseCode should be (200)
+          result.responseJson should be (ujson.read(
+            s"""{
+               |  "x-ror-username": "user4",
+               |  "x-ror-current-group": "group6",
+               |  "x-ror-available-groups": [ "group5", "group6" ],
+               |  "x-ror-correlation-id": "$correlationId",
+               |  "x-ror-kibana_index": "user4_group6_kibana_index",
+               |  "x-ror-kibana_template_index": "user4_group6_kibana_template_index",
+               |  "x-ror-kibana_access":"unrestricted"
+               |}""".stripMargin))
         }
         "at least one block is matched" in {
           val user2MetadataManager = new RorApiManager(basicAuthClient("user2", "pass"), esVersionUsed)
 
-          val result = user2MetadataManager.fetchMetadata()
+          val correlationId = UUID.randomUUID().toString
+          val result = user2MetadataManager.fetchMetadata(correlationId = Some(correlationId))
 
-          assertEquals(200, result.responseCode)
-          result.responseJson.obj.size should be(7)
-          result.responseJson("x-ror-username").str should be("user2")
-          result.responseJson("x-ror-current-group").str should be("group2")
-          result.responseJson("x-ror-available-groups").arr.toList should be(List(Str("group2")))
-          result.responseJson("x-ror-kibana_index").str should be("user2_kibana_index")
-          result.responseJson("x-ror-kibana-hidden-apps").arr.toList should be(List(Str("user2_app1"), Str("user2_app2")))
-          result.responseJson("x-ror-kibana_access").str should be("ro")
-          result.responseJson("x-ror-correlation-id").str should fullyMatch uuidRegex()
+          result.responseCode should be (200)
+          result.responseJson should be (ujson.read(
+            s"""{
+               |  "x-ror-username": "user2",
+               |  "x-ror-current-group": "group2",
+               |  "x-ror-available-groups": [ "group2" ],
+               |  "x-ror-correlation-id": "$correlationId",
+               |  "x-ror-kibana_index": "user2_kibana_index",
+               |  "x-ror-kibana_access": "ro",
+               |  "x-ror-kibana-hidden-apps": [ "user2_app1", "user2_app2" ],
+               |  "x-ror-kibana-allowed-api-paths":[
+               |    {
+               |      "http_method":"ANY",
+               |      "path_regex":"^/api/spaces/.*$$"
+               |    },
+               |    {
+               |      "http_method":"GET",
+               |      "path_regex":"^/api/spaces\\\\?test\\\\=12\\\\.2$$"
+               |    }
+               |  ]
+               |}""".stripMargin))
         }
         "block with no available groups collected is matched" in {
           val user3MetadataManager = new RorApiManager(basicAuthClient("user3", "pass"), esVersionUsed)
 
-          val result = user3MetadataManager.fetchMetadata()
+          val correlationId = UUID.randomUUID().toString
+          val result = user3MetadataManager.fetchMetadata(correlationId = Some(correlationId))
 
-          assertEquals(200, result.responseCode)
-          result.responseJson.obj.size should be(5)
-          result.responseJson("x-ror-username").str should be("user3")
-          result.responseJson("x-ror-kibana_access").str should be("unrestricted")
-          result.responseJson("x-ror-kibana_index").str should be("user3_kibana_index")
-          result.responseJson("x-ror-kibana-hidden-apps").arr.toList should be(List(Str("user3_app1"), Str("user3_app2")))
-          result.responseJson("x-ror-correlation-id").str should fullyMatch uuidRegex()
+          result.responseCode should be (200)
+          result.responseJson should be (ujson.read(
+            s"""{
+               |  "x-ror-username": "user3",
+               |  "x-ror-correlation-id": "$correlationId",
+               |  "x-ror-kibana_index": "user3_kibana_index",
+               |  "x-ror-kibana_access": "unrestricted",
+               |  "x-ror-kibana-hidden-apps": [ "user3_app1", "user3_app2" ]
+               |}""".stripMargin))
         }
       }
       "return forbidden" when {
@@ -98,21 +124,21 @@ trait CurrentUserMetadataSuite
 
           val result = unknownUserMetadataManager.fetchMetadata()
 
-          assertEquals(401, result.responseCode)
+          result.responseCode should be (401)
         }
         "current group is set but it doesn't exist on available groups list" in {
           val user4MetadataManager = new RorApiManager(basicAuthClient("user4", "pass"), esVersionUsed)
 
-          val result = user4MetadataManager.fetchMetadata("group7")
+          val result = user4MetadataManager.fetchMetadata(preferredGroup = Some("group7"))
 
-          assertEquals(401, result.responseCode)
+          result.responseCode should be (401)
         }
         "block with no available groups collected is matched and current group is set" in {
           val user3MetadataManager = new RorApiManager(basicAuthClient("user3", "pass"), esVersionUsed)
 
-          val result = user3MetadataManager.fetchMetadata("group7")
+          val result = user3MetadataManager.fetchMetadata(preferredGroup = Some("group7"))
 
-          assertEquals(401, result.responseCode)
+          result.responseCode should be (401)
         }
       }
     }

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseAuditingToolsSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseAuditingToolsSuite.scala
@@ -148,21 +148,21 @@ trait BaseAuditingToolsSuite
           def fetchMetadata(correlationId: Option[String] = None) = {
             val userMetadataManager = new RorApiManager(
               client = basicAuthClient("username", "dev"),
-              esVersion = esVersionUsed,
-              additionalHeaders = correlationId.map(("x-ror-correlation-id", _)).toMap
+              esVersion = esVersionUsed
             )
-            userMetadataManager.fetchMetadata()
+            userMetadataManager.fetchMetadata(correlationId = correlationId)
           }
 
-          val response1 = fetchMetadata()
+          val correlationId = UUID.randomUUID().toString
+          val response1 = fetchMetadata(correlationId = Some(correlationId))
           response1.responseCode should be(200)
           val loggingId1 = response1.responseJson("x-ror-correlation-id").str
 
-          val response2 = fetchMetadata(correlationId = Some(loggingId1))
+          val response2 = fetchMetadata(correlationId = Some(correlationId))
           response2.responseCode should be(200)
           val loggingId2 = response2.responseJson("x-ror-correlation-id").str
 
-          loggingId1 shouldNot be(loggingId2)
+          loggingId1 should be(loggingId2)
 
           eventually {
             val auditEntries = adminAuditIndexManager.getEntries.jsons

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/elasticsearch/RorApiManager.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/elasticsearch/RorApiManager.scala
@@ -24,6 +24,7 @@ import org.apache.http.entity.StringEntity
 import tech.beshu.ror.utils.elasticsearch.BaseManager.{JSON, JsonResponse}
 import tech.beshu.ror.utils.httpclient.RestClient
 
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
@@ -34,12 +35,9 @@ class RorApiManager(client: RestClient,
 
   private lazy val documentManager = new DocumentManager(client, esVersion)
 
-  def fetchMetadata(): JsonResponse = {
-    call(createUserMetadataRequest(None), new JsonResponse(_))
-  }
-
-  def fetchMetadata(preferredGroup: String): JsonResponse = {
-    call(createUserMetadataRequest(Some(preferredGroup)), new JsonResponse(_))
+  def fetchMetadata(preferredGroup: Option[String] = None,
+                    correlationId: Option[String] = None): JsonResponse = {
+    call(createUserMetadataRequest(preferredGroup, correlationId), new JsonResponse(_))
   }
 
   def sendAuditEvent(payload: JSON): JsonResponse = {
@@ -117,9 +115,11 @@ class RorApiManager(client: RestClient,
     )
   }
 
-  private def createUserMetadataRequest(preferredGroup: Option[String]) = {
+  private def createUserMetadataRequest(preferredGroup: Option[String],
+                                        correlationId: Option[String]) = {
     val request = new HttpGet(client.from("/_readonlyrest/metadata/current_user"))
     preferredGroup.foreach(request.addHeader("x-ror-current-group", _))
+    correlationId.foreach(request.addHeader("x-ror-correlation-id", _))
     request
   }
 


### PR DESCRIPTION
🚀New (KBN/ES) `kibana` rule supports `allowed_api_paths` for restricting access to [Kibana REST API](https://www.elastic.co/guide/en/kibana/master/api.html)
🚀New (KBN/ES) `kibana` rule supports a new `access` level: `api_only` 