### PR TITLE
[RORDEV-834] Kibana access 'api_only' was not handled everywhere in the ROR's code

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/MetadataValue.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/MetadataValue.scala
@@ -19,10 +19,10 @@ package tech.beshu.ror.accesscontrol.blocks.metadata
 import cats.Show
 import cats.data.NonEmptyList
 import cats.implicits._
-import tech.beshu.ror.Constants
 import tech.beshu.ror.accesscontrol.domain.KibanaAllowedApiPath.AllowedHttpMethod
 import tech.beshu.ror.accesscontrol.domain.KibanaAllowedApiPath.AllowedHttpMethod.HttpMethod
 import tech.beshu.ror.accesscontrol.domain.{CorrelationId, KibanaAccess}
+
 import scala.collection.JavaConverters._
 
 sealed trait MetadataValue
@@ -113,6 +113,7 @@ object MetadataValue {
     case KibanaAccess.ROStrict => "ro_strict"
     case KibanaAccess.RW => "rw"
     case KibanaAccess.Admin => "admin"
+    case KibanaAccess.ApiOnly => "api_only"
     case KibanaAccess.Unrestricted => "unrestricted"
   }
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/BaseKibanaRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/BaseKibanaRule.scala
@@ -222,7 +222,7 @@ abstract class BaseKibanaRule(val settings: Settings) extends Logging {
 
   private def kibanaCanBeModified = ProcessingContext.create { (r, _) =>
     val result = settings.access match {
-      case RO | ROStrict => false
+      case RO | ROStrict | ApiOnly => false
       case RW | Admin | Unrestricted => true
     }
     logger.debug(s"[${r.id.show}] Can Kibana be modified? $result")

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/ops.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/ops.scala
@@ -231,6 +231,7 @@ object show {
       case KibanaAccess.ROStrict => "ro_strict"
       case KibanaAccess.RW => "rw"
       case KibanaAccess.Admin => "admin"
+      case KibanaAccess.ApiOnly => "api_only"
       case KibanaAccess.Unrestricted => "unrestricted"
     }
     private implicit val userOriginShow: Show[UserOrigin] = Show.show(_.value.value)

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaAccessRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaAccessRuleSettingsTests.scala
@@ -101,6 +101,24 @@ class KibanaAccessRuleSettingsTests extends BaseRuleSettingsDecoderTest[KibanaAc
           }
         )
       }
+      "api_only access is defined" in {
+        assertDecodingSuccess(
+          yaml =
+            """
+              |readonlyrest:
+              |
+              |  access_control_rules:
+              |
+              |  - name: test_block1
+              |    kibana_access: api_only
+              |
+              |""".stripMargin,
+          assertion = rule => {
+            rule.settings.access should be(KibanaAccess.ApiOnly)
+            rule.settings.rorIndex should be(RorConfigurationIndex(IndexName.Full(".readonlyrest")))
+          }
+        )
+      }
       "unrestricted access is defined" in {
         assertDecodingSuccess(
           yaml =

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.47.0
-pluginVersion=1.48.0-pre4
+pluginVersion=1.48.0-pre5
 pluginName=readonlyrest


### PR DESCRIPTION
fixes to: https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/pull/888