### PR TITLE
[RORDEV-907] Kibana 8.8.0 related `kibana` rule adaptations

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/BaseKibanaRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/BaseKibanaRule.scala
@@ -136,9 +136,8 @@ abstract class BaseKibanaRule(val settings: Settings) extends Logging {
   }
 
   private def isTargetingKibana = ProcessingContext.create { (requestContext, kibanaIndexName) =>
-    val result = if (requestContext.initialBlockContext.indices.size == 1) {
-      val requestedIndex = requestContext.initialBlockContext.indices.head
-      requestedIndex.isRelatedToKibanaIndex(kibanaIndexName)
+    val result = if (requestContext.initialBlockContext.indices.nonEmpty) {
+      requestContext.initialBlockContext.indices.forall(_.isRelatedToKibanaIndex(kibanaIndexName))
     } else {
       false
     }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/BaseKibanaAccessBasedTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/BaseKibanaAccessBasedTests.scala
@@ -287,6 +287,20 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           )
         }
       }
+      "are .kibana_8.8.0 and .kibana_analytics_8.8.0 at the same time" in {
+        assertMatchRuleUsingIndicesRequest(
+          settingsOf(RW),
+          Action("indices:data/write/bulk"),
+          requestedIndices = Set(clusterIndexName(".kibana"), clusterIndexName(".kibana_analytics_8.8.0")),
+          uriPath = Some(UriPath("/_bulk"))
+        ) {
+          assertBlockContext(
+            kibanaIndex = Some(kibanaIndexName(".kibana")),
+            kibanaAccess = Some(RW),
+            indices = Set(clusterIndexName(".kibana"), clusterIndexName(".kibana_analytics_8.8.0")),
+          )
+        }
+      }
     }
     "Kibana related data stream is used" which {
       "is kibana_sample_data_logs" in {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.49.0
-pluginVersion=1.49.1-pre3
+pluginVersion=1.49.1-pre4
 pluginName=readonlyrest


### PR DESCRIPTION
fix: in Kibana 8.8.0 we need to match kibana request that is related to two kibana indices at the same time