### PR TITLE
[RORDEV-902] kibana access `rw` and `admin` should allow to manage component templates

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -143,11 +143,11 @@ dependencies {
     testImplementation  group: 'com.dimafeng',               name: 'testcontainers-scala_2.13',  version: '0.40.16'
 
     constraints {
-        api group: 'io.netty',              name: 'netty-codec-http2',                  version: '4.1.86.Final'
-        api group: 'io.netty',              name: 'netty-handler-proxy',                version: '4.1.86.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-unix-common', version: '4.1.86.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-epoll',       version: '4.1.86.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-kqueue',      version: '4.1.86.Final'
+        api group: 'io.netty',              name: 'netty-codec-http2',                  version: '4.1.94.Final'
+        api group: 'io.netty',              name: 'netty-handler-proxy',                version: '4.1.94.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-unix-common', version: '4.1.94.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-epoll',       version: '4.1.94.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-kqueue',      version: '4.1.94.Final'
         api group: 'com.google.guava',      name: 'guava',                              version: '32.0.1-jre'
         api group: 'io.spray',              name: 'spray-json_2.13',                    version: '1.3.5'
         api group: 'org.scala-lang',        name: 'scala-reflect',                      version: '2.13.10'

--- a/core/src/main/scala/tech/beshu/ror/Constants.java
+++ b/core/src/main/scala/tech/beshu/ror/Constants.java
@@ -89,6 +89,7 @@ public class Constants {
       "indices:data/write/update*",
       "indices:data/write/bulk*",
       "indices:admin/template/*",
+      "cluster:admin/component_template/*",
       "cluster:admin/settings/*",
       "indices:admin/aliases/*"
   );
@@ -111,15 +112,17 @@ public class Constants {
       "cluster:admin/repository/delete",
       "indices:data/write/update/byquery",
       "indices:admin/data_stream/delete",
+      "cluster:admin/component_template/get",
       "cluster:admin/component_template/delete",
+      "cluster:admin/component_template/put",
       "cluster:monitor/ccr/follow_info",
       "indices:admin/delete",
       "indices:admin/index_template/get",
       "indices:admin/index_template/delete",
       "indices:admin/index_template/put",
+      "indices:admin/index_template/simulate",
       "cluster:admin/slm/put",
       "cluster:admin/slm/execute",
-      "cluster:admin/slm/delete",
-      "indices:admin/index_template/simulate"
+      "cluster:admin/slm/delete"
   );
 }

--- a/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
@@ -95,25 +95,89 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
 
   "An ACL" when {
     "kibana index and kibana access rules are used" should {
-      "allow to proceed" in {
-        val request = MockRequestContext.indices.copy(
-          headers = Set(basicAuthHeader("john:dev")),
-          action = Action("indices:monitor/*"),
-          filteredIndices = Set(clusterIndexName(".readonlyrest"))
-        )
+      "allow to proceed" when {
+        "indices monitor request is called" in {
+          val request = MockRequestContext.indices.copy(
+            headers = Set(basicAuthHeader("john:dev")),
+            action = Action("indices:monitor/*"),
+            filteredIndices = Set(clusterIndexName(".readonlyrest"))
+          )
 
-        val result = acl.handleRegularRequest(request).runSyncUnsafe()
+          val result = acl.handleRegularRequest(request).runSyncUnsafe()
 
-        result.history should have size 1
-        inside(result.result) { case RegularRequestResult.Allow(blockContext, block) =>
-          block.name should be(Block.Name("Template Tenancy"))
-          assertBlockContext(
-            loggedUser = Some(DirectlyLoggedUser(User.Id("john"))),
-            kibanaIndex = Some(kibanaIndexName(".kibana_template")),
-            kibanaAccess = Some(KibanaAccess.Admin),
-            indices = Set(clusterIndexName(".readonlyrest")),
-          ) {
-            blockContext
+          result.history should have size 1
+          inside(result.result) { case RegularRequestResult.Allow(blockContext, block) =>
+            block.name should be(Block.Name("Template Tenancy"))
+            assertBlockContext(
+              loggedUser = Some(DirectlyLoggedUser(User.Id("john"))),
+              kibanaIndex = Some(kibanaIndexName(".kibana_template")),
+              kibanaAccess = Some(KibanaAccess.Admin),
+              indices = Set(clusterIndexName(".readonlyrest")),
+            ) {
+              blockContext
+            }
+          }
+        }
+        "component template creation request is called (in case of `admin` kibana access)" in {
+          val request = MockRequestContext.nonIndices.copy(
+            headers = Set(basicAuthHeader("john:dev")),
+            action = Action("cluster:admin/component_template/put"),
+            uriPath = UriPath("/_component_template/test")
+          )
+
+          val result = acl.handleRegularRequest(request).runSyncUnsafe()
+
+          inside(result.result) { case RegularRequestResult.Allow(blockContext, block) =>
+            block.name should be(Block.Name("Template Tenancy"))
+            assertBlockContext(
+              loggedUser = Some(DirectlyLoggedUser(User.Id("john"))),
+              kibanaIndex = Some(kibanaIndexName(".kibana_template")),
+              kibanaAccess = Some(KibanaAccess.Admin),
+            ) {
+              blockContext
+            }
+          }
+        }
+        "component template creation request is called (in case of `rw` kibana access)" in {
+          val request = MockRequestContext.nonIndices.copy(
+            headers = Set(basicAuthHeader("testuser_ro_master_rw_custom:XXXX")),
+            action = Action("cluster:admin/component_template/put"),
+            uriPath = UriPath("/_component_template/test")
+          )
+
+          val result = acl.handleRegularRequest(request).runSyncUnsafe()
+
+          inside(result.result) { case RegularRequestResult.Allow(blockContext, block) =>
+            block.name should be(Block.Name("Read-Write access with RoR custom kibana index"))
+            assertBlockContext(
+              loggedUser = Some(DirectlyLoggedUser(User.Id("testuser_ro_master_rw_custom"))),
+              kibanaIndex = Some(kibanaIndexName(".kibana_ror_custom")),
+              kibanaAccess = Some(KibanaAccess.RW),
+              currentGroup = Some(GroupName("RW_ror_custom")),
+              availableGroups = UniqueList.of(GroupName("RW_ror_custom")),
+            ) {
+              blockContext
+            }
+          }
+        }
+        "index template creation request is called (in case of `admin` kibana access)" in {
+          val request = MockRequestContext.nonIndices.copy(
+            headers = Set(basicAuthHeader("john:dev")),
+            action = Action("cluster:admin/component_template/put"),
+            uriPath = UriPath("/_component_template/test")
+          )
+
+          val result = acl.handleRegularRequest(request).runSyncUnsafe()
+
+          inside(result.result) { case RegularRequestResult.Allow(blockContext, block) =>
+            block.name should be(Block.Name("Template Tenancy"))
+            assertBlockContext(
+              loggedUser = Some(DirectlyLoggedUser(User.Id("john"))),
+              kibanaIndex = Some(kibanaIndexName(".kibana_template")),
+              kibanaAccess = Some(KibanaAccess.Admin),
+            ) {
+              blockContext
+            }
           }
         }
       }

--- a/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
@@ -105,7 +105,6 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
 
           val result = acl.handleRegularRequest(request).runSyncUnsafe()
 
-          result.history should have size 1
           inside(result.result) { case RegularRequestResult.Allow(blockContext, block) =>
             block.name should be(Block.Name("Template Tenancy"))
             assertBlockContext(
@@ -194,7 +193,6 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
 
         val result = acl.handleRegularRequest(request).runSyncUnsafe()
 
-        result.history should have size 2
         inside(result.result) { case RegularRequestResult.Allow(blockContext, block) =>
           block.name should be(Block.Name("Read-Write access with RoR custom kibana index"))
           assertBlockContext(
@@ -248,7 +246,6 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
 
         val result = acl.handleRegularRequest(request).runSyncUnsafe()
 
-        result.history should have size 4
         inside(result.result) { case RegularRequestResult.Allow(blockContext, block) =>
           block.name should be(Block.Name("ADMIN_GRP"))
           assertBlockContext(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.49.0
-pluginVersion=1.49.1-pre5
+pluginVersion=1.49.1-pre6
 pluginName=readonlyrest


### PR DESCRIPTION
🐞Fix (ES) kibana access `rw` and `admin` should allow to manage component templates
🚨Security Fix (ES) [CVE-2023-34462](https://github.com/advisories/GHSA-6mjq-h674-j845)
