### PR TITLE
[RORDEV-931] fix: getting data streams API

### DIFF
--- a/es710x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/datastreams/GetDataStreamEsRequestContext.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/datastreams/GetDataStreamEsRequestContext.scala
@@ -56,7 +56,7 @@ private[datastreams] class GetDataStreamEsRequestContext(actionRequest: ActionRe
         case r: ActionResponse if isGetDataStreamActionResponse(r) =>
           blockContext.backingIndices match {
             case BackingIndices.IndicesInvolved(_, allAllowedIndices) =>
-              Task.now(updateActionResponse(r, allAllowedIndices))
+              Task.now(updateActionResponse(r, extendAllowedIndicesSet(allAllowedIndices)))
             case BackingIndices.IndicesNotInvolved =>
               Task.now(r)
           }
@@ -67,7 +67,10 @@ private[datastreams] class GetDataStreamEsRequestContext(actionRequest: ActionRe
       logger.error(s"[${id.show}] Cannot update ${actionRequest.getClass.getCanonicalName} request. We're using reflection to modify the request data streams and it fails. Please, report the issue.")
       ModificationResult.ShouldBeInterrupted
     }
+  }
 
+  private def extendAllowedIndicesSet(allowedIndices: Iterable[ClusterIndexName]) = {
+    allowedIndices.toList.map(_.formatAsLegacyDataStreamBackingIndexName).toSet ++ allowedIndices.toSet
   }
 
   private def modifyActionRequest(blockContext: BlockContext.DataStreamRequestBlockContext): Boolean = {
@@ -82,9 +85,8 @@ private[datastreams] class GetDataStreamEsRequestContext(actionRequest: ActionRe
     r.getClass.getCanonicalName == "org.elasticsearch.xpack.core.action.GetDataStreamAction.Response"
   }
 
-
   private def updateActionResponse(response: ActionResponse,
-                                   allAllowedIndices: Set[ClusterIndexName]): ActionResponse = {
+                                   allAllowedIndices: Iterable[ClusterIndexName]): ActionResponse = {
     val allowedIndicesMatcher = MatcherWithWildcardsScalaAdapter.create(allAllowedIndices)
     val filteredDataStreams =
       invokeMethod(response, response.getClass, "getDataStreams")

--- a/es81x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
@@ -33,7 +33,7 @@ class DataStreamsStatsEsRequestContext(actionRequest: DataStreamsStatsAction.Req
                                        override val threadPool: ThreadPool)
   extends BaseDataStreamsEsRequestContext(actionRequest, esContext, clusterService, threadPool) {
 
-  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices =  BackingIndices.IndicesNotInvolved
+  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices = BackingIndices.IndicesNotInvolved
 
   override def dataStreamsFrom(request: DataStreamsStatsAction.Request): Set[domain.DataStreamName] =
     actionRequest.indices().asSafeList.flatMap(DataStreamName.fromString).toSet

--- a/es82x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
@@ -33,7 +33,7 @@ class DataStreamsStatsEsRequestContext(actionRequest: DataStreamsStatsAction.Req
                                        override val threadPool: ThreadPool)
   extends BaseDataStreamsEsRequestContext(actionRequest, esContext, clusterService, threadPool) {
 
-  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices =  BackingIndices.IndicesNotInvolved
+  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices = BackingIndices.IndicesNotInvolved
 
   override def dataStreamsFrom(request: DataStreamsStatsAction.Request): Set[domain.DataStreamName] =
     actionRequest.indices().asSafeList.flatMap(DataStreamName.fromString).toSet

--- a/es83x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
@@ -33,7 +33,7 @@ class DataStreamsStatsEsRequestContext(actionRequest: DataStreamsStatsAction.Req
                                        override val threadPool: ThreadPool)
   extends BaseDataStreamsEsRequestContext(actionRequest, esContext, clusterService, threadPool) {
 
-  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices =  BackingIndices.IndicesNotInvolved
+  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices = BackingIndices.IndicesNotInvolved
 
   override def dataStreamsFrom(request: DataStreamsStatsAction.Request): Set[domain.DataStreamName] =
     actionRequest.indices().asSafeList.flatMap(DataStreamName.fromString).toSet

--- a/es84x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
@@ -33,7 +33,7 @@ class DataStreamsStatsEsRequestContext(actionRequest: DataStreamsStatsAction.Req
                                        override val threadPool: ThreadPool)
   extends BaseDataStreamsEsRequestContext(actionRequest, esContext, clusterService, threadPool) {
 
-  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices =  BackingIndices.IndicesNotInvolved
+  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices = BackingIndices.IndicesNotInvolved
 
   override def dataStreamsFrom(request: DataStreamsStatsAction.Request): Set[domain.DataStreamName] =
     actionRequest.indices().asSafeList.flatMap(DataStreamName.fromString).toSet

--- a/es85x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
@@ -33,7 +33,7 @@ class DataStreamsStatsEsRequestContext(actionRequest: DataStreamsStatsAction.Req
                                        override val threadPool: ThreadPool)
   extends BaseDataStreamsEsRequestContext(actionRequest, esContext, clusterService, threadPool) {
 
-  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices =  BackingIndices.IndicesNotInvolved
+  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices = BackingIndices.IndicesNotInvolved
 
   override def dataStreamsFrom(request: DataStreamsStatsAction.Request): Set[domain.DataStreamName] =
     actionRequest.indices().asSafeList.flatMap(DataStreamName.fromString).toSet

--- a/es87x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
@@ -33,7 +33,7 @@ class DataStreamsStatsEsRequestContext(actionRequest: DataStreamsStatsAction.Req
                                        override val threadPool: ThreadPool)
   extends BaseDataStreamsEsRequestContext(actionRequest, esContext, clusterService, threadPool) {
 
-  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices =  BackingIndices.IndicesNotInvolved
+  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices = BackingIndices.IndicesNotInvolved
 
   override def dataStreamsFrom(request: DataStreamsStatsAction.Request): Set[domain.DataStreamName] =
     actionRequest.indices().asSafeList.flatMap(DataStreamName.fromString).toSet

--- a/es88x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
@@ -33,7 +33,7 @@ class DataStreamsStatsEsRequestContext(actionRequest: DataStreamsStatsAction.Req
                                        override val threadPool: ThreadPool)
   extends BaseDataStreamsEsRequestContext(actionRequest, esContext, clusterService, threadPool) {
 
-  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices =  BackingIndices.IndicesNotInvolved
+  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices = BackingIndices.IndicesNotInvolved
 
   override def dataStreamsFrom(request: DataStreamsStatsAction.Request): Set[domain.DataStreamName] =
     actionRequest.indices().asSafeList.flatMap(DataStreamName.fromString).toSet

--- a/es89x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/DataStreamsStatsEsRequestContext.scala
@@ -33,7 +33,7 @@ class DataStreamsStatsEsRequestContext(actionRequest: DataStreamsStatsAction.Req
                                        override val threadPool: ThreadPool)
   extends BaseDataStreamsEsRequestContext(actionRequest, esContext, clusterService, threadPool) {
 
-  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices =  BackingIndices.IndicesNotInvolved
+  override def backingIndicesFrom(request: DataStreamsStatsAction.Request): BackingIndices = BackingIndices.IndicesNotInvolved
 
   override def dataStreamsFrom(request: DataStreamsStatsAction.Request): Set[domain.DataStreamName] =
     actionRequest.indices().asSafeList.flatMap(DataStreamName.fromString).toSet

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 publishedPluginVersion=1.50.0
-pluginVersion=1.51.0-pre2
+pluginVersion=1.51.0-pre3
 pluginName=readonlyrest

--- a/integration-tests/src/test/resources/data_stream_api/readonlyrest.yml
+++ b/integration-tests/src/test/resources/data_stream_api/readonlyrest.yml
@@ -61,3 +61,7 @@ readonlyrest:
       indices:
         - 'data-stream-d*' #-ev
         - 'data-stream-t*' #-est
+
+    - name: "User11 access streams"
+      auth_key: "user11:pass"
+      indices: ["user11_index1", "user11_index2*"]


### PR DESCRIPTION
🐞Fix (ES) [getting data streams when not full names of backing indices are declared in the `indices` rule](https://forum.readonlyrest.com/t/forbidden-for-creating-component-templates/2372/7)