### PR TITLE
[RORDEV-851] building ES ROR in docker - improvements 

### DIFF
--- a/bin/build-ror-plugin.sh
+++ b/bin/build-ror-plugin.sh
@@ -15,19 +15,22 @@ vergte() {
 }
 export -f vergte
 
-ES_VERSION=$1
-
-ES_MODULE=$(ls | \
-  grep -Ei '^es[0-9]+x$' | \
-  sed "s/^es\([0-9]\)\([0-9]*\)x$/\1.\2.0 $ES_VERSION es\1\2x/" | \
-  sort -Vr | \
-  awk '{ if (system("vergte " $2 " " $1) == 0) { print $3 } }' | \
-  head -1)
-
-echo "Building ROR for ES_VERSION: $ES_VERSION (using ES_MODULE: $ES_MODULE):"
-
-./gradlew clean --stacktrace $ES_MODULE:ror '-PesVersion='$ES_VERSION
-
 mkdir -p builds
 rm -r builds/*
-cp $ES_MODULE/build/distributions/readonlyrest-*es$ES_VERSION.zip* builds
+
+for arg in "$@"; do
+  ES_VERSION=$arg
+
+  ES_MODULE=$(ls | \
+    grep -Ei '^es[0-9]+x$' | \
+    sed "s/^es\([0-9]\)\([0-9]*\)x$/\1.\2.0 $ES_VERSION es\1\2x/" | \
+    sort -Vr | \
+    awk '{ if (system("vergte " $2 " " $1) == 0) { print $3 } }' | \
+    head -1)
+
+  echo "Building ROR for ES_VERSION: $ES_VERSION (using ES_MODULE: $ES_MODULE):"
+
+  ./gradlew clean --stacktrace $ES_MODULE:ror '-PesVersion='$ES_VERSION
+
+  cp $ES_MODULE/build/distributions/readonlyrest-*es$ES_VERSION.zip* builds
+done

--- a/docker-envs/build-ror-in-docker/build.sh
+++ b/docker-envs/build-ror-in-docker/build.sh
@@ -3,7 +3,7 @@
 cd "$(dirname $0)"
 
 if [[ $# -eq 0 ]] ; then
-    echo "Please pass to the script an ES version you'd like to build ROR for"
+    echo "Please pass to the script ES versions you'd like to build ROR for"
     exit 1
 fi
 

--- a/docker-envs/build-ror-in-docker/build.sh
+++ b/docker-envs/build-ror-in-docker/build.sh
@@ -5,8 +5,8 @@ if [[ $# -eq 0 ]] ; then
     exit 1
 fi
 
-ES_VERSION=$1
+ES_VERSIONS=$*
 
-docker build --no-cache --progress=plain -t ror-builder-tmp ../../
-docker run --rm -v $(pwd)/builds:/ror/builds ror-builder-tmp $ES_VERSION
+docker buildx build --no-cache --progress=plain --load -t ror-builder-tmp ../../
+docker run --rm -v $(pwd)/builds:/ror/builds ror-builder-tmp $ES_VERSIONS
 docker rmi -f ror-builder-tmp

--- a/docker-envs/build-ror-in-docker/build.sh
+++ b/docker-envs/build-ror-in-docker/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+cd "$(dirname $0)"
+
 if [[ $# -eq 0 ]] ; then
     echo "Please pass to the script an ES version you'd like to build ROR for"
     exit 1


### PR DESCRIPTION
You can build many ROR deliverables at once:

e.g.
```bash
docker-envs/build-ror-in-docker/build.sh 8.10.1 8.10.0
```