### PR TITLE
[RORDEV-1080] EsAuditSinkService should not close NodeClient, but the bulk processor

### DIFF
--- a/es60x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -51,7 +51,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es61x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -51,7 +51,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es62x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es62x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -49,7 +49,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es63x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -49,7 +49,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es65x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es65x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -49,7 +49,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es66x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -49,7 +49,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es67x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -36,10 +36,10 @@ class EsAuditSinkService(client: Client)
   @nowarn("msg=deprecated")
   private val bulkProcessor =
     BulkProcessor
-        .builder(client, new AuditSinkBulkProcessorListener) // deprecated since es 6.8.5
+      .builder(client, new AuditSinkBulkProcessorListener) // deprecated since es 6.8.5
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -52,7 +52,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es70x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -50,7 +50,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es710x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -37,8 +37,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -52,7 +52,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es711x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -37,8 +37,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -52,7 +52,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es714x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es716x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es717x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es717x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es72x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -50,7 +50,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es73x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -35,8 +35,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -50,7 +50,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es74x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener) // deprecated since es 7.5.0
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es77x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -37,8 +37,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -52,7 +52,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es78x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -37,8 +37,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -52,7 +52,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es79x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -37,8 +37,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -52,7 +52,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es80x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es810x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es810x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -39,8 +39,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(BulkRequestHandler, new AuditSinkBulkProcessorListener, "ror-audit-bulk-processor")
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -54,7 +54,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private object BulkRequestHandler extends BiConsumer[BulkRequest, ActionListener[BulkResponse]] {

--- a/es811x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -39,8 +39,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(BulkRequestHandler, new AuditSinkBulkProcessorListener, "ror-audit-bulk-processor")
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -54,7 +54,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private object BulkRequestHandler extends BiConsumer[BulkRequest, ActionListener[BulkResponse]] {

--- a/es81x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es82x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es83x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es84x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -38,8 +38,8 @@ class EsAuditSinkService(client: Client,
     BulkProcessor
       .builder(client, new AuditSinkBulkProcessorListener, threadPool, threadPool, () => ())
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -53,7 +53,7 @@ class EsAuditSinkService(client: Client,
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {

--- a/es85x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -39,8 +39,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(BulkRequestHandler, new AuditSinkBulkProcessorListener, "ror-audit-bulk-processor")
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -54,7 +54,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private object BulkRequestHandler extends BiConsumer[BulkRequest, ActionListener[BulkResponse]] {

--- a/es87x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -39,8 +39,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(BulkRequestHandler, new AuditSinkBulkProcessorListener, "ror-audit-bulk-processor")
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -54,7 +54,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private object BulkRequestHandler extends BiConsumer[BulkRequest, ActionListener[BulkResponse]] {

--- a/es88x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -39,8 +39,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(BulkRequestHandler, new AuditSinkBulkProcessorListener, "ror-audit-bulk-processor")
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -54,7 +54,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private object BulkRequestHandler extends BiConsumer[BulkRequest, ActionListener[BulkResponse]] {

--- a/es89x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/services/EsAuditSinkService.scala
@@ -39,8 +39,8 @@ class EsAuditSinkService(client: Client)
     BulkProcessor
       .builder(BulkRequestHandler, new AuditSinkBulkProcessorListener, "ror-audit-bulk-processor")
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
-      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB.toInt, ByteSizeUnit.KB))
-      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS.toInt))
+      .setBulkSize(new ByteSizeValue(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
+      .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
       .setConcurrentRequests(1)
       .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
       .build
@@ -54,7 +54,7 @@ class EsAuditSinkService(client: Client)
   }
 
   override def close(): Unit = {
-    client.close()
+    bulkProcessor.close()
   }
 
   private object BulkRequestHandler extends BiConsumer[BulkRequest, ActionListener[BulkResponse]] {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.54.0
-pluginVersion=1.55.0-pre2
+pluginVersion=1.55.0-pre3
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m


### PR DESCRIPTION
[technical change]