### PR TITLE
[RORDEV-1095] docker images improvements

### DIFF
--- a/docker-image/init-readonlyrest.yml
+++ b/docker-image/init-readonlyrest.yml
@@ -8,5 +8,4 @@ readonlyrest:
 
     - name: "ADMIN"
       type: allow
-      verbosity: error
       auth_key: admin:${env:ADMIN_USER_PASS}

--- a/docker-image/ror-entrypoint-es6x.sh
+++ b/docker-image/ror-entrypoint-es6x.sh
@@ -3,9 +3,20 @@
 INVOKE_ROR_TOOLS="$JAVA_HOME/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar"
 
 if $INVOKE_ROR_TOOLS verify | grep -q "Elasticsearch is NOT patched"; then
-  $INVOKE_ROR_TOOLS patch
+
+  if [ -n "$I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING" ] && [[ "${I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING,,}" == *"yes"* ]]; then
+    $INVOKE_ROR_TOOLS patch
+  else
+    echo "Elasticsearch needs to be patched to work with ReadonlyREST. You can read about patching in our documentation:" \
+         "https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch. In this Docker image, the patching step" \
+         "is done automatically, but you must agree to have it done for you. You can do this by setting" \
+         "I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes environment when running the container."
+    exit 1
+  fi
+
 else
   echo "Elasticsearch is already patched. We can continue ..."
 fi
+
 
 gosu elasticsearch /usr/local/bin/docker-entrypoint.sh "$@"

--- a/docker-image/ror-entrypoint-es6x.sh
+++ b/docker-image/ror-entrypoint-es6x.sh
@@ -10,7 +10,7 @@ if $INVOKE_ROR_TOOLS verify | grep -q "Elasticsearch is NOT patched"; then
     echo "Elasticsearch needs to be patched to work with ReadonlyREST. You can read about patching in our documentation:" \
          "https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch. In this Docker image, the patching step" \
          "is done automatically, but you must agree to have it done for you. You can do this by setting" \
-         "I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes environment when running the container."
+         "I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes environment variable when running the container."
     exit 1
   fi
 

--- a/docker-image/ror-entrypoint-es6x.sh
+++ b/docker-image/ror-entrypoint-es6x.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+INVOKE_ROR_TOOLS="$JAVA_HOME/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar"
+
+if $INVOKE_ROR_TOOLS verify | grep -q "Elasticsearch is NOT patched"; then
+  $INVOKE_ROR_TOOLS patch
+else
+  echo "Elasticsearch is already patched. We can continue ..."
+fi
+
+gosu elasticsearch /usr/local/bin/docker-entrypoint.sh "$@"

--- a/docker-image/ror-entrypoint.sh
+++ b/docker-image/ror-entrypoint.sh
@@ -3,7 +3,17 @@
 INVOKE_ROR_TOOLS="/usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar"
 
 if $INVOKE_ROR_TOOLS verify | grep -q "Elasticsearch is NOT patched"; then
-  $INVOKE_ROR_TOOLS patch
+
+  if [ -n "$I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING" ] && [[ "${I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING,,}" == *"yes"* ]]; then
+    $INVOKE_ROR_TOOLS patch
+  else
+    echo "Elasticsearch needs to be patched to work with ReadonlyREST. You can read about patching in our documentation:" \
+         "https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch. In this Docker image, the patching step" \
+         "is done automatically, but you must agree to have it done for you. You can do this by setting" \
+         "I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes environment when running the container."
+    exit 1
+  fi
+
 else
   echo "Elasticsearch is already patched. We can continue ..."
 fi

--- a/docker-image/ror-entrypoint.sh
+++ b/docker-image/ror-entrypoint.sh
@@ -10,7 +10,7 @@ if $INVOKE_ROR_TOOLS verify | grep -q "Elasticsearch is NOT patched"; then
     echo "Elasticsearch needs to be patched to work with ReadonlyREST. You can read about patching in our documentation:" \
          "https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch. In this Docker image, the patching step" \
          "is done automatically, but you must agree to have it done for you. You can do this by setting" \
-         "I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes environment when running the container."
+         "I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes environment variable when running the container."
     exit 1
   fi
 

--- a/docker-image/ror-entrypoint.sh
+++ b/docker-image/ror-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+INVOKE_ROR_TOOLS="/usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar"
+
+if $INVOKE_ROR_TOOLS verify | grep -q "Elasticsearch is NOT patched"; then
+  $INVOKE_ROR_TOOLS patch
+else
+  echo "Elasticsearch is already patched. We can continue ..."
+fi
+
+gosu elasticsearch /usr/local/bin/docker-entrypoint.sh "$@"

--- a/es60x/build.gradle
+++ b/es60x/build.gradle
@@ -132,7 +132,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es61x/build.gradle
+++ b/es61x/build.gradle
@@ -132,7 +132,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es62x/build.gradle
+++ b/es62x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es63x/Dockerfile
+++ b/es63x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ror-entrypoint.sh"]

--- a/es63x/Dockerfile
+++ b/es63x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint-es6x.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN $JAVA_HOME/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es63x/build.gradle
+++ b/es63x/build.gradle
@@ -141,7 +141,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es65x/Dockerfile
+++ b/es65x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ror-entrypoint.sh"]

--- a/es65x/Dockerfile
+++ b/es65x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint-es6x.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN $JAVA_HOME/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es65x/build.gradle
+++ b/es65x/build.gradle
@@ -131,7 +131,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es66x/Dockerfile
+++ b/es66x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ror-entrypoint.sh"]

--- a/es66x/Dockerfile
+++ b/es66x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint-es6x.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN $JAVA_HOME/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es66x/build.gradle
+++ b/es66x/build.gradle
@@ -131,7 +131,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es67x/Dockerfile
+++ b/es67x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ror-entrypoint.sh"]

--- a/es67x/Dockerfile
+++ b/es67x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint-es6x.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN $JAVA_HOME/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es67x/build.gradle
+++ b/es67x/build.gradle
@@ -137,7 +137,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es70x/Dockerfile
+++ b/es70x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ror-entrypoint.sh"]

--- a/es70x/Dockerfile
+++ b/es70x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es70x/build.gradle
+++ b/es70x/build.gradle
@@ -131,7 +131,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es710x/Dockerfile
+++ b/es710x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es710x/Dockerfile
+++ b/es710x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es710x/build.gradle
+++ b/es710x/build.gradle
@@ -132,7 +132,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es711x/Dockerfile
+++ b/es711x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es711x/Dockerfile
+++ b/es711x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es711x/build.gradle
+++ b/es711x/build.gradle
@@ -137,7 +137,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es714x/Dockerfile
+++ b/es714x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es714x/Dockerfile
+++ b/es714x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es714x/build.gradle
+++ b/es714x/build.gradle
@@ -131,7 +131,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es716x/Dockerfile
+++ b/es716x/Dockerfile
@@ -26,4 +26,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es716x/Dockerfile
+++ b/es716x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es716x/build.gradle
+++ b/es716x/build.gradle
@@ -132,7 +132,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es717x/Dockerfile
+++ b/es717x/Dockerfile
@@ -26,4 +26,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es717x/Dockerfile
+++ b/es717x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es717x/build.gradle
+++ b/es717x/build.gradle
@@ -132,7 +132,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es72x/Dockerfile
+++ b/es72x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ror-entrypoint.sh"]

--- a/es72x/Dockerfile
+++ b/es72x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es72x/build.gradle
+++ b/es72x/build.gradle
@@ -131,7 +131,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es73x/Dockerfile
+++ b/es73x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ror-entrypoint.sh"]

--- a/es73x/Dockerfile
+++ b/es73x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es73x/build.gradle
+++ b/es73x/build.gradle
@@ -131,7 +131,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es74x/Dockerfile
+++ b/es74x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ror-entrypoint.sh"]

--- a/es74x/Dockerfile
+++ b/es74x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es74x/build.gradle
+++ b/es74x/build.gradle
@@ -138,7 +138,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es77x/Dockerfile
+++ b/es77x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es77x/Dockerfile
+++ b/es77x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es77x/build.gradle
+++ b/es77x/build.gradle
@@ -132,7 +132,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es78x/Dockerfile
+++ b/es78x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es78x/Dockerfile
+++ b/es78x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es78x/build.gradle
+++ b/es78x/build.gradle
@@ -132,7 +132,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es79x/Dockerfile
+++ b/es79x/Dockerfile
@@ -11,9 +11,8 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
 USER elasticsearch
@@ -26,4 +25,4 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tm
 
 USER root
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es79x/Dockerfile
+++ b/es79x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es79x/build.gradle
+++ b/es79x/build.gradle
@@ -132,7 +132,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es80x/Dockerfile
+++ b/es80x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es80x/build.gradle
+++ b/es80x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es810x/Dockerfile
+++ b/es810x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es810x/build.gradle
+++ b/es810x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es811x/Dockerfile
+++ b/es811x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es811x/build.gradle
+++ b/es811x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es812x/Dockerfile
+++ b/es812x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es812x/build.gradle
+++ b/es812x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es81x/Dockerfile
+++ b/es81x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es81x/build.gradle
+++ b/es81x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es82x/Dockerfile
+++ b/es82x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es82x/build.gradle
+++ b/es82x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es83x/Dockerfile
+++ b/es83x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es83x/build.gradle
+++ b/es83x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es84x/Dockerfile
+++ b/es84x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es84x/build.gradle
+++ b/es84x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es85x/Dockerfile
+++ b/es85x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es85x/build.gradle
+++ b/es85x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es87x/Dockerfile
+++ b/es87x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es87x/build.gradle
+++ b/es87x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es88x/Dockerfile
+++ b/es88x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es88x/build.gradle
+++ b/es88x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }

--- a/es89x/Dockerfile
+++ b/es89x/Dockerfile
@@ -9,12 +9,21 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
+USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/* && \
+    gosu nobody true
+
+USER elasticsearch
+
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
+COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
 
 USER root
-RUN /usr/share/elasticsearch/jdk/bin/java -jar /usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar patch
 
-USER 1000:0
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es89x/build.gradle
+++ b/es89x/build.gradle
@@ -133,7 +133,7 @@ tasks.register('prepareDockerImageFiles', Copy) {
 
     from layout.projectDirectory.file("Dockerfile")
     from layout.buildDirectory.file("distributions/" + pluginFullName + ".zip")
-    from rootProject.file("docker-image/init-readonlyrest.yml")
+    from rootProject.files("docker-image")
 
     into layout.buildDirectory.dir("docker-image")
 }


### PR DESCRIPTION
```bash
> docker run -p 19200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m"  beshultd/elasticsearch-readonlyrest:8.12.0-ror-1.55.0
Elasticsearch needs to be patched to work with ReadonlyREST. You can read about patching in our documentation: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch. In this Docker image, the patching step is done automatically, but you must agree to have it done for you. You can do this by setting I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes environment when running the container.
```

```bash
> docker run -p 19200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e "I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes" beshultd/elasticsearch-readonlyrest:8.12.0-ror-1.55.0
Checking if Elasticsearch is patched ...
Creating backup ...
Patching ...
Elasticsearch is patched! ReadonlyREST is ready to use
^C^CCompileCommand: exclude org/apache/lucene/util/MSBRadixSorter.computeCommonPrefixLengthAndBuildHistogram bool exclude = true
CompileCommand: exclude org/apache/lucene/util/RadixSelector.computeCommonPrefixLengthAndBuildHistogram bool exclude = true
Feb 02, 2024 9:29:13 PM sun.util.locale.provider.LocaleProviderAdapter <clinit>
WARNING: COMPAT locale provider will be removed in a future release
...
```
