### PR TITLE
[RORDEV-1092] Internode SSL `certificate_verification: true` was causing problems with nodes discovery

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -260,8 +260,6 @@ stages:
               ROR_TASK: integration_es717x
             IT_es710x:
               ROR_TASK: integration_es710x
-            IT_es74x:
-              ROR_TASK: integration_es74x
             IT_es70x:
               ROR_TASK: integration_es70x
             IT_es67x:

--- a/core/src/main/scala/tech/beshu/ror/configuration/EsConfig.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/EsConfig.scala
@@ -77,7 +77,7 @@ object EsConfig {
       .subflatMap { fipsConfiguration =>
         fipsConfiguration.fipsMode match {
           case FipsMode.SslOnly if xpackSettings.securityEnabled =>
-            Left(RorSettingsInactiveWhenXpackSecurityIsEnabled(SettingsType.Fibs))
+            Left(RorSettingsInactiveWhenXpackSecurityIsEnabled(SettingsType.Fips))
           case FipsMode.NonFips | FipsMode.SslOnly =>
             Right(fipsConfiguration)
         }
@@ -98,7 +98,7 @@ object EsConfig {
       sealed trait SettingsType
       object SettingsType {
         case object Ssl extends SettingsType
-        case object Fibs extends SettingsType
+        case object Fips extends SettingsType
       }
     }
   }

--- a/core/src/main/scala/tech/beshu/ror/configuration/SslConfiguration.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/SslConfiguration.scala
@@ -123,7 +123,8 @@ object SslConfiguration {
                                              allowedProtocols: Set[SslConfiguration.Protocol],
                                              allowedCiphers: Set[SslConfiguration.Cipher],
                                              clientAuthenticationEnabled: Boolean,
-                                             certificateVerificationEnabled: Boolean)
+                                             certificateVerificationEnabled: Boolean,
+                                             hostnameVerificationEnabled: Boolean)
     extends SslConfiguration
 }
 
@@ -143,6 +144,7 @@ private object SslDecoders extends Logging {
     val allowedCiphers = "allowed_ciphers"
     val allowedProtocols = "allowed_protocols"
     val certificateVerification = "certificate_verification"
+    val hostnameVerification = "hostname_verification"
     val clientAuthentication = "client_authentication"
     val verification = "verification"
     val enable = "enable"
@@ -248,6 +250,7 @@ private object SslDecoders extends Logging {
     whenEnabled(c) {
       for {
         certificateVerification <- c.downField(consts.certificateVerification).as[Option[Boolean]]
+        hostnameVerification <- c.downField(consts.hostnameVerification).as[Option[Boolean]]
         verification <- c.downField(consts.verification).as[Option[Boolean]]
         sslCommonProperties <- sslCommonPropertiesDecoder(basePath, c)
       } yield
@@ -257,7 +260,8 @@ private object SslDecoders extends Logging {
           allowedProtocols = sslCommonProperties.allowedProtocols,
           allowedCiphers = sslCommonProperties.allowedCiphers,
           clientAuthenticationEnabled = sslCommonProperties.clientAuthentication.getOrElse(false),
-          certificateVerificationEnabled = certificateVerification.orElse(verification).getOrElse(false)
+          certificateVerificationEnabled = certificateVerification.orElse(verification).getOrElse(false),
+          hostnameVerificationEnabled = hostnameVerification.getOrElse(false)
         )
     }
   }

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/ConfigLoadingInterpreter.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/ConfigLoadingInterpreter.scala
@@ -53,7 +53,7 @@ object ConfigLoadingInterpreter extends Logging {
               CannotUseRorConfigurationWhenXpackSecurityIsEnabled(
                 aType match {
                   case SettingsType.Ssl => "SSL configuration"
-                  case SettingsType.Fibs => "FIBS configuration"
+                  case SettingsType.Fips => "FIBS configuration"
                 }
               )
           })

--- a/core/src/test/resources/boot_tests/internode_ssl_settings_in_elasticsearch_config/elasticsearch.yml
+++ b/core/src/test/resources/boot_tests/internode_ssl_settings_in_elasticsearch_config/elasticsearch.yml
@@ -9,3 +9,4 @@ readonlyrest:
     keystore_pass: readonlyrest1
     key_pass: readonlyrest2
     verification: true
+    hostname_verification: true

--- a/core/src/test/resources/boot_tests/internode_ssl_settings_in_readonlyrest_config/readonlyrest.yml
+++ b/core/src/test/resources/boot_tests/internode_ssl_settings_in_readonlyrest_config/readonlyrest.yml
@@ -8,6 +8,7 @@ readonlyrest:
     truststore_file:  "ror-truststore.jks"
     truststore_pass: readonlyrest3
     certificate_verification: true
+    hostname_verification: true
 
   access_control_rules:
 

--- a/core/src/test/resources/boot_tests/internode_ssl_settings_pem_files/elasticsearch.yml
+++ b/core/src/test/resources/boot_tests/internode_ssl_settings_pem_files/elasticsearch.yml
@@ -9,3 +9,4 @@ readonlyrest:
     server_certificate_key_file: "server_certificate_key.pem"
     client_trusted_certificate_file: "client_certificate.pem"
     verification: true
+    hostname_verification: false

--- a/core/src/test/scala/tech/beshu/ror/unit/configuration/SslConfigurationTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/configuration/SslConfigurationTest.scala
@@ -144,7 +144,7 @@ class SslConfigurationTest
     "be loaded from elasticsearch config file" in {
       val ssl = RorSsl.load(getResourcePath("/boot_tests/internode_ssl_settings_in_elasticsearch_config/")).runSyncUnsafe().toOption.get
       inside(ssl.interNodeSsl) {
-        case Some(InternodeSslConfiguration(KeystoreBasedConfiguration(keystoreFile, Some(keystorePassword), None, Some(keyPass)), truststoreConfiguration, allowedProtocols, allowedCiphers, clientAuthenticationEnabled, certificateVerificationEnabled)) =>
+        case Some(InternodeSslConfiguration(KeystoreBasedConfiguration(keystoreFile, Some(keystorePassword), None, Some(keyPass)), truststoreConfiguration, allowedProtocols, allowedCiphers, clientAuthenticationEnabled, certificateVerificationEnabled, hostnameVerificationEnabled)) =>
           keystoreFile.value.getName should be("ror-keystore.jks")
           keystorePassword should be(KeystorePassword("readonlyrest1"))
           keyPass should be(KeyPass("readonlyrest2"))
@@ -153,13 +153,14 @@ class SslConfigurationTest
           allowedCiphers should be(Set.empty)
           clientAuthenticationEnabled should be(false)
           certificateVerificationEnabled should be(true)
+          hostnameVerificationEnabled should be (true)
       }
       ssl.externalSsl should be(None)
     }
     "be loaded from elasticsearch config file when pem files are used" in {
       val ssl = RorSsl.load(getResourcePath("/boot_tests/internode_ssl_settings_pem_files/")).runSyncUnsafe().toOption.get
       inside(ssl.interNodeSsl) {
-        case Some(InternodeSslConfiguration(FileBasedConfiguration(serverCertificateKeyFile, serverCertificateFile), Some(ClientCertificateConfiguration.FileBasedConfiguration(clientTrustedCertificateFile)), allowedProtocols, allowedCiphers, clientAuthenticationEnabled, certificateVerificationEnabled)) =>
+        case Some(InternodeSslConfiguration(FileBasedConfiguration(serverCertificateKeyFile, serverCertificateFile), Some(ClientCertificateConfiguration.FileBasedConfiguration(clientTrustedCertificateFile)), allowedProtocols, allowedCiphers, clientAuthenticationEnabled, certificateVerificationEnabled, hostnameVerificationEnabled)) =>
           serverCertificateKeyFile.value.getName should be("server_certificate_key.pem")
           serverCertificateFile.value.getName should be("server_certificate.pem")
           clientTrustedCertificateFile.value.getName should be("client_certificate.pem")
@@ -167,13 +168,14 @@ class SslConfigurationTest
           allowedCiphers should be(Set.empty)
           clientAuthenticationEnabled should be(false)
           certificateVerificationEnabled should be(true)
+          hostnameVerificationEnabled should be (false)
       }
     }
     "be loaded from readonlyrest config file" when {
       "elasticsearch config file doesn't contain ROR ssl section" in {
         val ssl = RorSsl.load(getResourcePath("/boot_tests/internode_ssl_settings_in_readonlyrest_config/")).runSyncUnsafe().toOption.get
         inside(ssl.interNodeSsl) {
-          case Some(InternodeSslConfiguration(KeystoreBasedConfiguration(keystoreFile, Some(keystorePassword), None, Some(keyPass)), Some(ClientCertificateConfiguration.TruststoreBasedConfiguration(truststoreFile, Some(truststorePassword))), allowedProtocols, allowedCiphers, clientAuthenticationEnabled, certificateVerificationEnabled)) =>
+          case Some(InternodeSslConfiguration(KeystoreBasedConfiguration(keystoreFile, Some(keystorePassword), None, Some(keyPass)), Some(ClientCertificateConfiguration.TruststoreBasedConfiguration(truststoreFile, Some(truststorePassword))), allowedProtocols, allowedCiphers, clientAuthenticationEnabled, certificateVerificationEnabled, hostnameVerificationEnabled)) =>
             keystoreFile.value.getName should be("ror-keystore.jks")
             keystorePassword should be(KeystorePassword("readonlyrest1"))
             keyPass should be(KeyPass("readonlyrest2"))
@@ -183,6 +185,7 @@ class SslConfigurationTest
             allowedCiphers should be(Set.empty)
             clientAuthenticationEnabled should be(false)
             certificateVerificationEnabled should be(true)
+            hostnameVerificationEnabled should be (true)
         }
         ssl.externalSsl should be(None)
       }

--- a/es60x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -40,7 +40,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                                         fipsCompliant: Boolean)
   extends Netty4Transport(settings, threadPool, networkService, bigArrays, namedWriteableRegistry, circuitBreakerService) {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer: ChannelHandler = new ClientChannelInitializer {
@@ -53,7 +53,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = None,
             fipsCompliant = fipsCompliant

--- a/es60x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es60x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -27,8 +27,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
                                         threadPool: ThreadPool,
@@ -52,10 +53,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = None,
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es61x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -40,7 +40,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                                         fipsCompliant: Boolean)
   extends Netty4Transport(settings, threadPool, networkService, bigArrays, namedWriteableRegistry, circuitBreakerService) {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer: ChannelHandler = new ClientChannelInitializer {
@@ -53,7 +53,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = None,
             fipsCompliant = fipsCompliant

--- a/es61x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es61x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -27,8 +27,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
                                         threadPool: ThreadPool,
@@ -52,10 +53,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = None,
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es62x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es62x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -40,7 +40,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                                         fipsCompliant: Boolean)
   extends Netty4Transport(settings, threadPool, networkService, bigArrays, namedWriteableRegistry, circuitBreakerService) {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer: ChannelHandler = new ClientChannelInitializer {
@@ -53,7 +53,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = None,
             fipsCompliant = fipsCompliant

--- a/es62x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es62x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -27,8 +27,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
                                         threadPool: ThreadPool,
@@ -52,10 +53,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = None,
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es63x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -40,7 +40,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                                         fipsCompliant: Boolean)
   extends Netty4Transport(settings, threadPool, networkService, bigArrays, namedWriteableRegistry, circuitBreakerService) {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer: ChannelHandler = new ClientChannelInitializer {
@@ -53,7 +53,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = None,
             fipsCompliant = fipsCompliant

--- a/es63x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es63x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -27,8 +27,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
                                         threadPool: ThreadPool,
@@ -52,10 +53,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = None,
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es65x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es65x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -42,7 +42,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                                         fipsCompliant: Boolean)
   extends Netty4Transport(settings, threadPool, networkService, bigArrays, namedWriteableRegistry, circuitBreakerService) {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -55,7 +55,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es65x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es65x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -28,8 +28,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -54,10 +55,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es66x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -57,10 +58,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es66x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es66x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -45,7 +45,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -58,7 +58,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es67x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -57,10 +58,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es67x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -45,7 +45,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -58,7 +58,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es70x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -57,10 +58,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es70x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -45,7 +45,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -58,7 +58,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es710x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -60,7 +60,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es710x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.SharedGroupFactory
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -59,10 +60,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es711x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -60,7 +60,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es711x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.SharedGroupFactory
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -59,10 +60,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es714x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -60,7 +60,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es714x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.SharedGroupFactory
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -59,10 +60,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es716x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -60,7 +60,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es716x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.SharedGroupFactory
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -59,10 +60,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es717x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es717x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -60,7 +60,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es717x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es717x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.SharedGroupFactory
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -59,10 +60,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es72x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -57,10 +58,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es72x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -45,7 +45,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -58,7 +58,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es73x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -57,10 +58,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es73x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -45,7 +45,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -58,7 +58,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es74x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -57,10 +58,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es74x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -45,7 +45,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -58,7 +58,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es77x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -57,10 +58,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es77x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -45,7 +45,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -58,7 +58,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es78x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -57,10 +58,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es78x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -45,7 +45,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -58,7 +58,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es79x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -60,7 +60,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es79x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.SharedGroupFactory
 import org.elasticsearch.transport.netty4.Netty4Transport
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -59,10 +60,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es80x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -46,7 +46,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -59,7 +59,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es80x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -58,10 +59,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es810x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es810x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.ConnectionProfile
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -60,10 +61,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es810x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es810x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, TransportVersion.current(), threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode,
@@ -61,7 +61,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es811x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.ConnectionProfile
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -60,10 +61,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es811x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, TransportVersion.current(), threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode,
@@ -61,7 +61,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es812x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.ConnectionProfile
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -47,7 +48,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, TransportVersion.current(), threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode,
@@ -60,10 +61,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es81x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -46,7 +46,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -59,7 +59,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es81x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -58,10 +59,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es82x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -46,7 +46,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -59,7 +59,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es82x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -58,10 +59,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es83x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -46,7 +46,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -59,7 +59,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es83x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -58,10 +59,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es84x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -46,7 +46,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -59,7 +59,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es84x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -58,10 +59,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es85x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -46,7 +46,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, Version.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode): ChannelHandler = new ClientChannelInitializer {
@@ -59,7 +59,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es85x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -30,8 +30,9 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -58,10 +59,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es87x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.ConnectionProfile
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -60,10 +61,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es87x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, TransportVersion.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode,
@@ -61,7 +61,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es88x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.ConnectionProfile
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -60,10 +61,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es88x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, TransportVersion.CURRENT, threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode,
@@ -61,7 +61,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/es89x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -31,8 +31,9 @@ import org.elasticsearch.transport.ConnectionProfile
 import org.elasticsearch.transport.netty4.{Netty4Transport, SharedGroupFactory}
 import tech.beshu.ror.configuration.SslConfiguration.InternodeSslConfiguration
 import tech.beshu.ror.utils.SSLCertHelper
+import tech.beshu.ror.utils.SSLCertHelper.HostAndPort
 
-import java.net.SocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import javax.net.ssl.SNIHostName
 
 class SSLNetty4InternodeServerTransport(settings: Settings,
@@ -60,10 +61,13 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              remoteAddress: SocketAddress,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
+          val inet = remoteAddress.asInstanceOf[InetSocketAddress]
           val sslEngine = SSLCertHelper.prepareSSLEngine(
             sslContext = clientSslContext,
+            hostAndPort = HostAndPort(inet.getHostString, inet.getPort),
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
+            enableHostnameVerification = ssl.hostnameVerificationEnabled,
             fipsCompliant = fipsCompliant
           )
           ctx.pipeline().replace(this, "internode_ssl_client", new SslHandler(sslEngine))

--- a/es89x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/ssl/SSLNetty4InternodeServerTransport.scala
@@ -47,7 +47,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
   extends Netty4Transport(settings, TransportVersion.current(), threadPool, networkService, pageCacheRecycler, namedWriteableRegistry, circuitBreakerService, sharedGroupFactory)
     with Logging {
 
-  private val clientSslCtx = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
+  private val clientSslContext = SSLCertHelper.prepareClientSSLContext(ssl, fipsCompliant, ssl.certificateVerificationEnabled)
   private val serverSslContext = SSLCertHelper.prepareServerSSLContext(ssl, fipsCompliant, clientAuthenticationEnabled = false)
 
   override def getClientChannelInitializer(node: DiscoveryNode,
@@ -61,7 +61,7 @@ class SSLNetty4InternodeServerTransport(settings: Settings,
                              localAddress: SocketAddress,
                              promise: ChannelPromise): Unit = {
           val sslEngine = SSLCertHelper.prepareSSLEngine(
-            sslContext = clientSslCtx,
+            sslContext = clientSslContext,
             channelHandlerContext = ctx,
             serverName = Option(node.getAttributes.get("server_name")).map(new SNIHostName(_)),
             fipsCompliant = fipsCompliant

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.55.0
-pluginVersion=1.56.0-pre4
+pluginVersion=1.56.0-pre5
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/resources/xpack_cluster_with_ror_nodes_and_internode_ssl/readonlyrest_es60x-es65x.yml
+++ b/integration-tests/src/test/resources/xpack_cluster_with_ror_nodes_and_internode_ssl/readonlyrest_es60x-es65x.yml
@@ -14,6 +14,7 @@ readonlyrest:
     key_pass: readonlyrest
     truststore_file: "elastic-certificates.p12"
     truststore_pass: readonlyrest
+    certificate_verification: true
 
   access_control_rules:
 

--- a/integration-tests/src/test/resources/xpack_cluster_with_ror_nodes_and_internode_ssl/readonlyrest_keystore.yml
+++ b/integration-tests/src/test/resources/xpack_cluster_with_ror_nodes_and_internode_ssl/readonlyrest_keystore.yml
@@ -14,6 +14,7 @@ readonlyrest:
     key_pass: readonlyrest
     truststore_file: "elastic-certificates.p12"
     truststore_pass: readonlyrest
+    certificate_verification: true
 
   access_control_rules:
 

--- a/integration-tests/src/test/resources/xpack_cluster_with_ror_nodes_and_internode_ssl/readonlyrest_pem.yml
+++ b/integration-tests/src/test/resources/xpack_cluster_with_ror_nodes_and_internode_ssl/readonlyrest_pem.yml
@@ -10,6 +10,7 @@ readonlyrest:
     server_certificate_key_file: elastic-certificates-pkey.pem
     server_certificate_file: elastic-certificates-cert.pem
     client_trusted_certificate_file: elastic-certificates-cert.pem
+    certificate_verification: true
 
   access_control_rules:
 

--- a/integration-tests/src/test/resources/xpack_cluster_with_ror_nodes_and_internode_ssl/readonlyrest_update.yml
+++ b/integration-tests/src/test/resources/xpack_cluster_with_ror_nodes_and_internode_ssl/readonlyrest_update.yml
@@ -14,6 +14,7 @@ readonlyrest:
     key_pass: readonlyrest
     truststore_file: "elastic-certificates.p12"
     truststore_pass: readonlyrest
+    certificate_verification: true
 
   access_control_rules:
 

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/XpackClusterWithRorNodesAndInternodeSslSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/XpackClusterWithRorNodesAndInternodeSslSuite.scala
@@ -24,9 +24,9 @@ import org.scalatest.wordspec.AnyWordSpec
 import tech.beshu.ror.integration.suites.base.support.{BaseEsClusterIntegrationTest, SingleClientSupport}
 import tech.beshu.ror.integration.utils.{ESVersionSupportForAnyWordSpecLike, PluginTestSupport}
 import tech.beshu.ror.utils.containers.EsClusterSettings.NodeType
-import tech.beshu.ror.utils.containers.SecurityType.RorSecurity
+import tech.beshu.ror.utils.containers.SecurityType.{RorSecurity, XPackSecurity}
 import tech.beshu.ror.utils.containers._
-import tech.beshu.ror.utils.containers.images.ReadonlyRestPlugin
+import tech.beshu.ror.utils.containers.images.{ReadonlyRestPlugin, XpackSecurityPlugin}
 import tech.beshu.ror.utils.containers.images.ReadonlyRestPlugin.Config.{InternodeSsl, RestSsl}
 import tech.beshu.ror.utils.containers.images.domain.{Enabled, SourceFile}
 import tech.beshu.ror.utils.elasticsearch._
@@ -77,15 +77,15 @@ trait XpackClusterWithRorNodesAndInternodeSslSuite
               restSsl = Enabled.Yes(RestSsl.Ror(SourceFile.RorFile)),
               internodeSsl = Enabled.Yes(InternodeSsl.Ror(SourceFile.RorFile))
             )),
-            numberOfInstances = 3
+            numberOfInstances = 1
           ),
-//          NodeType(
-//            securityType = XPackSecurity(XpackSecurityPlugin.Config.Attributes.default.copy(
-//              restSslEnabled = true,
-//              internodeSslEnabled = true
-//            )),
-//            numberOfInstances = 2
-//          )
+          NodeType(
+            securityType = XPackSecurity(XpackSecurityPlugin.Config.Attributes.default.copy(
+              restSslEnabled = true,
+              internodeSslEnabled = true
+            )),
+            numberOfInstances = 2
+          )
         )
       )
     }

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/XpackClusterWithRorNodesAndInternodeSslSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/XpackClusterWithRorNodesAndInternodeSslSuite.scala
@@ -24,11 +24,11 @@ import org.scalatest.wordspec.AnyWordSpec
 import tech.beshu.ror.integration.suites.base.support.{BaseEsClusterIntegrationTest, SingleClientSupport}
 import tech.beshu.ror.integration.utils.{ESVersionSupportForAnyWordSpecLike, PluginTestSupport}
 import tech.beshu.ror.utils.containers.EsClusterSettings.NodeType
-import tech.beshu.ror.utils.containers.SecurityType.{RorSecurity, XPackSecurity}
+import tech.beshu.ror.utils.containers.SecurityType.RorSecurity
 import tech.beshu.ror.utils.containers._
-import tech.beshu.ror.utils.containers.images.ReadonlyRestPlugin.Config.InternodeSsl
+import tech.beshu.ror.utils.containers.images.ReadonlyRestPlugin
+import tech.beshu.ror.utils.containers.images.ReadonlyRestPlugin.Config.{InternodeSsl, RestSsl}
 import tech.beshu.ror.utils.containers.images.domain.{Enabled, SourceFile}
-import tech.beshu.ror.utils.containers.images.{ReadonlyRestPlugin, XpackSecurityPlugin}
 import tech.beshu.ror.utils.elasticsearch._
 import tech.beshu.ror.utils.misc.CustomScalaTestMatchers
 import tech.beshu.ror.utils.misc.Resources.getResourceContent
@@ -63,7 +63,8 @@ trait XpackClusterWithRorNodesAndInternodeSslSuite
         numberOfInstances = 3,
         securityType = RorSecurity(ReadonlyRestPlugin.Config.Attributes.default.copy(
           rorConfigFileName = rorConfigFileName,
-          internodeSsl = Enabled.Yes(InternodeSsl.Ror(SourceFile.EsFile))
+          restSsl = Enabled.Yes(RestSsl.Ror(SourceFile.RorFile)),
+          internodeSsl = Enabled.Yes(InternodeSsl.Ror(SourceFile.RorFile))
         ))
       )
     } else {
@@ -73,17 +74,18 @@ trait XpackClusterWithRorNodesAndInternodeSslSuite
           NodeType(
             securityType = RorSecurity(ReadonlyRestPlugin.Config.Attributes.default.copy(
               rorConfigFileName = rorConfigFileName,
-              internodeSsl = Enabled.Yes(InternodeSsl.Ror(SourceFile.EsFile))
+              restSsl = Enabled.Yes(RestSsl.Ror(SourceFile.RorFile)),
+              internodeSsl = Enabled.Yes(InternodeSsl.Ror(SourceFile.RorFile))
             )),
-            numberOfInstances = 1
+            numberOfInstances = 3
           ),
-          NodeType(
-            securityType = XPackSecurity(XpackSecurityPlugin.Config.Attributes.default.copy(
-              restSslEnabled = true,
-              internodeSslEnabled = true
-            )),
-            numberOfInstances = 2
-          )
+//          NodeType(
+//            securityType = XPackSecurity(XpackSecurityPlugin.Config.Attributes.default.copy(
+//              restSslEnabled = true,
+//              internodeSslEnabled = true
+//            )),
+//            numberOfInstances = 2
+//          )
         )
       )
     }

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestPlugin.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestPlugin.scala
@@ -214,6 +214,9 @@ class ReadonlyRestPlugin(esVersion: String,
             .add("readonlyrest.ssl_internode.keystore_file: ror-keystore.jks")
             .add("readonlyrest.ssl_internode.keystore_pass: readonlyrest")
             .add("readonlyrest.ssl_internode.key_pass: readonlyrest")
+            .add("readonlyrest.truststore_file: ror-keystore.jks")
+            .add("readonlyrest.truststore_pass: readonlyrest")
+            .add("readonlyrest.certificate_verification: true")
         case Enabled.Yes(InternodeSsl.RorFips(SourceFile.EsFile)) =>
           builder
             .add("transport.type: ror_ssl_internode")
@@ -221,7 +224,7 @@ class ReadonlyRestPlugin(esVersion: String,
             .add("readonlyrest.ssl_internode.keystore_file: ror-keystore.bcfks")
             .add("readonlyrest.ssl_internode.keystore_pass: readonlyrest")
             .add("readonlyrest.ssl_internode.key_pass: readonlyrest")
-            .add("truststore_file: ror-truststore.bcfks")
+            .add("truststore_file: ror-truststore.bcfks") // todo:
             .add("truststore_pass: readonlyrest")
             .add("certificate_verification: true")
         case Enabled.Yes(InternodeSsl.Ror(SourceFile.RorFile)) =>

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/XpackSecurityPlugin.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/XpackSecurityPlugin.scala
@@ -79,7 +79,7 @@ class XpackSecurityPlugin(esVersion: String,
       if (config.attributes.internodeSslEnabled) {
         builder
           .add("xpack.security.transport.ssl.enabled: true")
-          .add("xpack.security.transport.ssl.verification_mode: none")
+          .add("xpack.security.transport.ssl.verification_mode: certificate")
           .add("xpack.security.transport.ssl.client_authentication: none")
           .add("xpack.security.transport.ssl.keystore.path: elastic-certificates.p12")
           .add("xpack.security.transport.ssl.truststore.path: elastic-certificates.p12")


### PR DESCRIPTION
🐞Fix (ES) [Internode SSL `certificate_verification: true` was causing problems with nodes discovery](https://forum.readonlyrest.com/t/upgrade-elasticsearch-8-2-to-8-x-leads-to-ssl-problems/2480)