### PR TITLE
[RORDEV-1128] additional validations: `kibana` rule should not be used with some other rules in the same block

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/BaseKibanaRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/BaseKibanaRule.scala
@@ -21,6 +21,7 @@ import cats.data.ReaderT
 import cats.implicits._
 import org.apache.logging.log4j.scala.Logging
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule
+import tech.beshu.ror.accesscontrol.blocks.rules.Rule.RegularRule
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana.BaseKibanaRule.Settings
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana.KibanaActionMatchers._
 import tech.beshu.ror.accesscontrol.domain.ClusterIndexName.Local.devNullKibana
@@ -32,8 +33,12 @@ import tech.beshu.ror.accesscontrol.request.RequestContext
 import java.util.regex.Pattern
 import scala.util.Try
 
-abstract class BaseKibanaRule(val settings: Settings) extends Logging {
+trait KibanaRelatedRule {
   this: Rule =>
+}
+
+abstract class BaseKibanaRule(val settings: Settings)
+  extends RegularRule with KibanaRelatedRule with Logging {
 
   import BaseKibanaRule._
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaAccessRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaAccessRule.scala
@@ -19,13 +19,13 @@ package tech.beshu.ror.accesscontrol.blocks.rules.kibana
 import monix.eval.Task
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule.RuleResult.{Fulfilled, Rejected}
-import tech.beshu.ror.accesscontrol.blocks.rules.Rule.{RegularRule, RuleName, RuleResult}
+import tech.beshu.ror.accesscontrol.blocks.rules.Rule.{RuleName, RuleResult}
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana.KibanaAccessRule.Settings
 import tech.beshu.ror.accesscontrol.blocks.{BlockContext, BlockContextUpdater}
 import tech.beshu.ror.accesscontrol.domain._
 
 class KibanaAccessRule(override val settings: Settings)
-  extends BaseKibanaRule(settings) with RegularRule {
+  extends BaseKibanaRule(settings) {
 
   override val name: Rule.Name = KibanaAccessRule.Name.name
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaHideAppsRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaHideAppsRule.scala
@@ -17,7 +17,6 @@
 package tech.beshu.ror.accesscontrol.blocks.rules.kibana
 
 import monix.eval.Task
-import org.apache.logging.log4j.scala.Logging
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule.{MatchingAlwaysRule, RuleName}
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana.KibanaHideAppsRule.Settings
@@ -26,7 +25,7 @@ import tech.beshu.ror.accesscontrol.domain.KibanaApp
 import tech.beshu.ror.utils.uniquelist.UniqueNonEmptyList
 
 class KibanaHideAppsRule(val settings: Settings)
-  extends MatchingAlwaysRule with Logging {
+  extends MatchingAlwaysRule with KibanaRelatedRule {
 
   override val name: Rule.Name = KibanaHideAppsRule.Name.name
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaIndexRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaIndexRule.scala
@@ -25,7 +25,7 @@ import tech.beshu.ror.accesscontrol.blocks.{BlockContext, BlockContextUpdater}
 import tech.beshu.ror.accesscontrol.domain.KibanaIndexName
 
 class KibanaIndexRule(val settings: Settings)
-  extends MatchingAlwaysRule {
+  extends MatchingAlwaysRule with KibanaRelatedRule {
 
   override val name: Rule.Name = KibanaIndexRule.Name.name
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaTemplateIndexRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaTemplateIndexRule.scala
@@ -25,7 +25,7 @@ import tech.beshu.ror.accesscontrol.blocks.{BlockContext, BlockContextUpdater}
 import tech.beshu.ror.accesscontrol.domain.KibanaIndexName
 
 class KibanaTemplateIndexRule(val settings: Settings)
-  extends MatchingAlwaysRule {
+  extends MatchingAlwaysRule with KibanaRelatedRule {
 
   override val name: Rule.Name = KibanaTemplateIndexRule.Name.name
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaUserDataRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaUserDataRule.scala
@@ -21,18 +21,18 @@ import monix.eval.Task
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule.RuleResult.{Fulfilled, Rejected}
-import tech.beshu.ror.accesscontrol.blocks.rules.Rule.{RegularRule, RuleName, RuleResult}
+import tech.beshu.ror.accesscontrol.blocks.rules.Rule.{RuleName, RuleResult}
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana.KibanaUserDataRule.Settings
 import tech.beshu.ror.accesscontrol.blocks.variables.runtime.ResolvableJsonRepresentationOps._
 import tech.beshu.ror.accesscontrol.blocks.variables.runtime.RuntimeSingleResolvableVariable
 import tech.beshu.ror.accesscontrol.blocks.{BlockContext, BlockContextUpdater}
 import tech.beshu.ror.accesscontrol.domain.Json.ResolvableJsonRepresentation
-import tech.beshu.ror.accesscontrol.domain.{KibanaAccess, KibanaAllowedApiPath, KibanaApp, KibanaIndexName, RorConfigurationIndex}
+import tech.beshu.ror.accesscontrol.domain._
 import tech.beshu.ror.accesscontrol.show.logs._
 import tech.beshu.ror.utils.uniquelist.UniqueNonEmptyList
 
 class KibanaUserDataRule(override val settings: Settings)
-  extends BaseKibanaRule(settings) with RegularRule {
+  extends BaseKibanaRule(settings)  {
 
   override val name: Rule.Name = KibanaUserDataRule.Name.name
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/ops.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/ops.scala
@@ -40,7 +40,7 @@ import tech.beshu.ror.accesscontrol.blocks.variables.startup.StartupResolvableVa
 import tech.beshu.ror.accesscontrol.blocks._
 import tech.beshu.ror.accesscontrol.blocks.definitions.ldap.implementations.UserGroupsSearchFilterConfig.UserGroupsSearchMode.{GroupIdAttribute, GroupSearchFilter, GroupsFromUserAttribute, UniqueMemberAttribute}
 import tech.beshu.ror.accesscontrol.blocks.rules.Rule
-import tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.ActionsRule
+import tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.{ActionsRule, FieldsRule, FilterRule, ResponseFieldsRule}
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana._
 import tech.beshu.ror.accesscontrol.blocks.variables.runtime.RuntimeResolvableVariable.Unresolvable
 import tech.beshu.ror.accesscontrol.domain.AccessRequirement.{MustBeAbsent, MustBePresent}
@@ -56,7 +56,7 @@ import tech.beshu.ror.accesscontrol.domain.ResponseFieldsFiltering.AccessMode.{B
 import tech.beshu.ror.accesscontrol.domain.ResponseFieldsFiltering.ResponseFieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain._
 import tech.beshu.ror.accesscontrol.factory.BlockValidator.BlockValidationError
-import tech.beshu.ror.accesscontrol.factory.BlockValidator.BlockValidationError.KibanaUserDataRuleTogetherWith
+import tech.beshu.ror.accesscontrol.factory.BlockValidator.BlockValidationError.{KibanaRuleTogetherWith, KibanaUserDataRuleTogetherWith}
 import tech.beshu.ror.accesscontrol.header.{FromHeaderValue, ToHeaderValue}
 import tech.beshu.ror.com.jayway.jsonpath.JsonPath
 import tech.beshu.ror.providers.EnvVarProvider.EnvVarName
@@ -374,10 +374,16 @@ object show {
         s"The '${block.show}' block contains an authorization rule, but not an authentication rule. This does not mean anything if you don't also set some authentication rule."
       case BlockValidationError.OnlyOneAuthenticationRuleAllowed(authRules) =>
         s"The '${block.show}' block should contain only one authentication rule, but contains: [${authRules.map(_.name.show).mkString_(",")}]"
-      case BlockValidationError.KibanaRuleTogetherWithActionsRule =>
-        s"The '${block.show}' block contains '${KibanaUserDataRule.Name.name.show}' rule (or deprecated '${KibanaAccessRule.Name.name.show}' rule) and '${ActionsRule.Name.name.show}' rule. These two cannot be used together in one block."
       case BlockValidationError.RuleDoesNotMeetRequirement(complianceResult) =>
         s"The '${block.show}' block doesn't meet requirements for defined variables. ${complianceResult.show}"
+      case error: BlockValidationError.KibanaRuleTogetherWith =>
+        val conflictingRule = error match {
+          case KibanaRuleTogetherWith.ActionsRule => ActionsRule.Name.name
+          case KibanaRuleTogetherWith.FilterRule => FilterRule.Name.name
+          case KibanaRuleTogetherWith.FieldsRule => FieldsRule.Name.name
+          case KibanaRuleTogetherWith.ResponseFieldsRule => ResponseFieldsRule.Name.name
+        }
+        s"The '${block.show}' block contains '${KibanaUserDataRule.Name.name.show}' rule (or any deprecated kibana-related rule) and '${conflictingRule.show}' rule. These two cannot be used together in one block."
       case error: BlockValidationError.KibanaUserDataRuleTogetherWith =>
         val conflictingRule = error match {
           case KibanaUserDataRuleTogetherWith.KibanaAccessRule => KibanaAccessRule.Name.name

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/JwtAuthRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/JwtAuthRuleSettingsTests.scala
@@ -109,7 +109,6 @@ class JwtAuthRuleSettingsTests
             yaml =
               s"""
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -143,7 +142,6 @@ class JwtAuthRuleSettingsTests
             yaml =
               s"""
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/RorKbnAuthRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/RorKbnAuthRuleSettingsTests.scala
@@ -130,7 +130,6 @@ class RorKbnAuthRuleSettingsTests
             yaml =
               s"""
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/elasticsearch/FieldsRuleSettingsTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/elasticsearch/FieldsRuleSettingsTest.scala
@@ -37,7 +37,6 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -56,7 +55,6 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -77,7 +75,6 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -96,7 +93,6 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -117,7 +113,6 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -204,7 +199,6 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -224,7 +218,6 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -244,7 +237,6 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/elasticsearch/ResponseFieldsRuleSettingsTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/elasticsearch/ResponseFieldsRuleSettingsTest.scala
@@ -36,7 +36,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -54,7 +53,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -74,7 +72,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -92,7 +89,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -112,7 +108,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -132,7 +127,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -177,7 +171,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -197,7 +190,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -218,7 +210,6 @@ class ResponseFieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[Respons
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaHideAppsRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaHideAppsRuleSettingsTests.scala
@@ -20,8 +20,8 @@ import eu.timepit.refined.auto._
 import org.scalatest.matchers.should.Matchers._
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana.KibanaHideAppsRule
 import tech.beshu.ror.accesscontrol.domain.KibanaApp.FullNameKibanaApp
-import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.Reason.MalformedValue
-import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.RulesLevelCreationError
+import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.Reason.{MalformedValue, Message}
+import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.{BlocksLevelCreationError, RulesLevelCreationError}
 import tech.beshu.ror.unit.acl.factory.decoders.rules.BaseRuleSettingsDecoderTest
 import tech.beshu.ror.utils.TestsUtils.kibanaAppRegex
 import tech.beshu.ror.utils.uniquelist.UniqueNonEmptyList
@@ -132,6 +132,88 @@ class KibanaHideAppsRuleSettingsTests extends BaseRuleSettingsDecoderTest[Kibana
                 |""".stripMargin)))
           }
         )
+      }
+      "it's defined with other rule in the block" when {
+        "the rule is 'actions' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_hide_apps: "app1"
+                |    actions: ["indices:data/write/*"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'actions' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'filter' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_hide_apps: "app1"
+                |    filter: "{\"bool\": {\"must\": [{\"term\": {\"title\": {\"value\": \"a1\"}}}]}}"
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'filter' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'fields' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_hide_apps: "app1"
+                |    fields: ["_source","user1"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'fields' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'response_fields' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_hide_apps: "app1"
+                |    response_fields: ["hits.hits"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'response_fields' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
       }
     }
   }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaIndexRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaIndexRuleSettingsTests.scala
@@ -20,8 +20,8 @@ import eu.timepit.refined.auto._
 import org.scalatest.matchers.should.Matchers._
 import tech.beshu.ror.accesscontrol.blocks.rules.kibana.KibanaIndexRule
 import tech.beshu.ror.accesscontrol.blocks.variables.runtime.RuntimeSingleResolvableVariable.{AlreadyResolved, ToBeResolved}
-import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.Reason.MalformedValue
-import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.RulesLevelCreationError
+import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.Reason.{MalformedValue, Message}
+import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.{BlocksLevelCreationError, RulesLevelCreationError}
 import tech.beshu.ror.unit.acl.factory.decoders.rules.BaseRuleSettingsDecoderTest
 import tech.beshu.ror.utils.TestsUtils._
 
@@ -85,6 +85,88 @@ class KibanaIndexRuleSettingsTests extends BaseRuleSettingsDecoderTest[KibanaInd
                 |""".stripMargin)))
           }
         )
+      }
+      "it's defined with other rule in the block" when {
+        "the rule is 'actions' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_index: some_kibana_index
+                |    actions: ["indices:data/write/*"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'actions' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'filter' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_index: some_kibana_index
+                |    filter: "{\"bool\": {\"must\": [{\"term\": {\"title\": {\"value\": \"a1\"}}}]}}"
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'filter' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'fields' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_index: some_kibana_index
+                |    fields: ["_source","user1"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'fields' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'response_fields' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_index: some_kibana_index
+                |    response_fields: ["hits.hits"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'response_fields' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
       }
     }
   }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaUserDataRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaUserDataRuleSettingsTests.scala
@@ -31,7 +31,7 @@ import tech.beshu.ror.accesscontrol.domain.KibanaAllowedApiPath.AllowedHttpMetho
 import tech.beshu.ror.accesscontrol.domain.KibanaApp.FullNameKibanaApp
 import tech.beshu.ror.accesscontrol.domain._
 import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.Reason.{MalformedValue, Message}
-import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.RulesLevelCreationError
+import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCreationError.{BlocksLevelCreationError, RulesLevelCreationError}
 import tech.beshu.ror.unit.acl.factory.decoders.rules.BaseRuleSettingsDecoderTest
 import tech.beshu.ror.utils.TestsUtils._
 
@@ -46,7 +46,6 @@ class KibanaUserDataRuleSettingsTests
           yaml =
             """
               |readonlyrest:
-              |
               |  access_control_rules:
               |
               |  - name: test_block1
@@ -70,7 +69,6 @@ class KibanaUserDataRuleSettingsTests
           yaml =
             """
               |readonlyrest:
-              |
               |  access_control_rules:
               |
               |  - name: test_block1
@@ -101,7 +99,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -125,7 +122,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -149,7 +145,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -173,7 +168,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -197,7 +191,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -220,7 +213,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -246,7 +238,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -271,7 +262,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -299,7 +289,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -326,7 +315,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -353,7 +341,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -383,7 +370,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -415,7 +401,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -452,7 +437,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -547,7 +531,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -579,7 +562,6 @@ class KibanaUserDataRuleSettingsTests
             yaml =
               """
                 |readonlyrest:
-                |
                 |  access_control_rules:
                 |
                 |  - name: test_block1
@@ -673,9 +655,189 @@ class KibanaUserDataRuleSettingsTests
           }
         )
       }
+      "old style kibana rules are mixed with new style kibana rule" when {
+        "kibana_access and kibana rules are mixed" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_access: ro
+                |    kibana:
+                |      access: ro
+                |      index: .kibana_custom
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                """The 'test_block' block contains 'kibana' rule and 'kibana_access' rule. The second one is deprecated. The first one offers all the second one is able to provide."""
+              )))
+            }
+          )
+        }
+        "kibana_index and kibana rules are mixed" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_index: .kibana_custom
+                |    kibana:
+                |      access: ro
+                |      index: .kibana_custom
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                """The 'test_block' block contains 'kibana' rule and 'kibana_index' rule. The second one is deprecated. The first one offers all the second one is able to provide."""
+              )))
+            }
+          )
+        }
+        "kibana_hide_apps and kibana rules are mixed" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_hide_apps: ["app1"]
+                |    kibana:
+                |      access: ro
+                |      index: .kibana_custom
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                """The 'test_block' block contains 'kibana' rule and 'kibana_hide_apps' rule. The second one is deprecated. The first one offers all the second one is able to provide."""
+              )))
+            }
+          )
+        }
+        "kibana_template_index and kibana rules are mixed" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana_template_index: ".kibana_template_index"
+                |    kibana:
+                |      access: ro
+                |      index: .kibana_custom
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                """The 'test_block' block contains 'kibana' rule and 'kibana_template_index' rule. The second one is deprecated. The first one offers all the second one is able to provide."""
+              )))
+            }
+          )
+        }
+      }
+      "it's defined with other rule in the block" when {
+        "the rule is 'actions' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana:
+                |      access: ro
+                |      index: .kibana_custom
+                |    actions: ["indices:data/write/*"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'actions' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'filter' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana:
+                |      access: ro
+                |      index: .kibana_custom
+                |    filter: "{\"bool\": {\"must\": [{\"term\": {\"title\": {\"value\": \"a1\"}}}]}}"
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'filter' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'fields' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana:
+                |      access: ro
+                |      index: .kibana_custom
+                |    fields: ["_source","user1"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'fields' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+        "the rule is 'response_fields' rule" in {
+          assertDecodingFailure(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block
+                |    kibana:
+                |      access: ro
+                |      index: .kibana_custom
+                |    response_fields: ["hits.hits"]
+                |
+                |""".stripMargin,
+            assertion = errors => {
+              errors should have size 1
+              errors.head should be(BlocksLevelCreationError(Message(
+                "The 'test_block' block contains 'kibana' rule (or any deprecated kibana-related rule) and 'response_fields' rule. These two cannot be used together in one block."
+              )))
+            }
+          )
+        }
+      }
     }
   }
 
-  private val variableCreator: RuntimeResolvableVariableCreator =
+  private lazy val variableCreator: RuntimeResolvableVariableCreator =
     new RuntimeResolvableVariableCreator(TransformationCompiler.withAliases(SupportedVariablesFunctions.default, Seq.empty))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.56.0
-pluginVersion=1.56.0
+pluginVersion=1.57.0-pre1
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/resources/duplicated_response_headers_issue/readonlyrest.yml
+++ b/integration-tests/src/test/resources/duplicated_response_headers_issue/readonlyrest.yml
@@ -38,10 +38,6 @@ readonlyrest:
         groups: ["011"]
       indices: ["negotiation-*", "trade-*", "transation-*"]
       filter: '{"bool": { "must": { "match": { "firmid": "011" }}}}'
-      kibana:
-        access: rw
-        index: ".kibana_@{user}"
-        hide_apps: ["readonlyrest_kbn", "kibana:dev_tools", "/^(?!(Analytic\\|Management).*$).*$/"]
 
     - name: "011"
       external_authentication: "ExternalAuthService"
@@ -60,10 +56,6 @@ readonlyrest:
         groups: ["013"]
       indices: ["negotiation-*", "trade-*", "transation-*"]
       filter: '{"bool": { "must": { "match": { "firmid": "013" }}}}'
-      kibana:
-        access: rw
-        index: ".kibana_@{user}"
-        hide_apps: ["readonlyrest_kbn", "kibana:dev_tools", "/^(?!(Analytics\\|Management).*$).*$/"]
 
     - name: "013"
       external_authentication: "ExternalAuthService"


### PR DESCRIPTION
🧐Enhancement (ES) additional [validations](https://docs.readonlyrest.com/elasticsearch#configuring-an-acl-with-filter-fields-rules-when-using-kibana): `kibana` rule should not be used with some other rules in the same block