### PR TITLE
[RORDEV-1178] regression fix: `groups` defined as string not only array of strings

### DIFF
--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/GroupsRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/GroupsRuleSettingsTests.scala
@@ -129,7 +129,7 @@ sealed abstract class GroupsRuleSettingsTests[R <: BaseGroupsRule : ClassTag](ru
                    |
                    |  users:
                    |  - username: [cartman, "ca*"]
-                   |    groups: ["group1", "group3"]
+                   |    groups: "group1"
                    |    auth_key: "cartman:pass"
                    |
                    |""".stripMargin,
@@ -139,7 +139,7 @@ sealed abstract class GroupsRuleSettingsTests[R <: BaseGroupsRule : ClassTag](ru
                 rule.settings.usersDefinitions.length should be(1)
                 inside(rule.settings.usersDefinitions.head) { case UserDef(_, patterns, WithoutGroupsMapping(authRule, localGroups)) =>
                   patterns should be(UserIdPatterns(UniqueNonEmptyList.of(User.UserIdPattern(User.Id("cartman")), User.UserIdPattern(User.Id("ca*")))))
-                  localGroups should be(UniqueNonEmptyList.of(group("group1"), group("group3")))
+                  localGroups should be(UniqueNonEmptyList.of(group("group1")))
                   authRule shouldBe an[AuthKeyRule]
                   authRule.asInstanceOf[AuthKeyRule].settings should be {
                     BasicAuthenticationRule.Settings(Credentials(User.Id("cartman"), PlainTextSecret("pass")))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.57.0
-pluginVersion=1.57.0
+pluginVersion=1.57.1
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m


### PR DESCRIPTION
🐞Fix (ES) configuration parsing regression: one group definition can be a string