### PR TITLE
[RORDEV-1152] ES testcontainer fixes

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     testImplementation  group: 'org.scalamock',              name: 'scalamock_3',                version: '6.0.0'
     testImplementation  group: 'org.scalatestplus',          name: 'scalacheck-1-16_3',          version: '3.2.14.0'
     testImplementation  group: 'org.scalatest',              name: 'scalatest_3',                version: '3.2.16'
-    testImplementation  group: 'com.dimafeng',               name: 'testcontainers-scala_3',     version: '0.41.3'
+    testImplementation  group: 'com.dimafeng',               name: 'testcontainers-scala_3',     version: '0.40.17'
 
     constraints {
         api group: 'io.netty',              name: 'netty-codec-http2',                  version: '4.1.108.Final'

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/misc/EsStartupChecker.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/misc/EsStartupChecker.scala
@@ -35,10 +35,10 @@ class EsStartupChecker private(name: String,
   extends LazyLogging {
 
   def waitForStart(): Boolean = {
-    retryBackoff(clusterIsReady(client), maxRetries = 30, interval = 2 seconds)
+    retryBackoff(clusterIsReady(client), maxRetries = 150, interval = 2 seconds)
       .map((_: Unit) => true)
       .onErrorRecover(_ => false)
-      .runSyncUnsafe(2 minutes)
+      .runSyncUnsafe(5 minutes)
   }
 
   private def retryBackoff[A](source: Task[A],


### PR DESCRIPTION
Fixes:
- ES container startup timeout was reduced to 1 minute, instead of intended 2 minutes, now restored to the 5 minutes default from before Scala 3 migration
- testcontainers-scala downgraded back to 0.40.17 - I could not consistently reproduce it, but there may be a bug in 0.41.x, that manifests when using Dockerfile and copying files (testcontainers-java/issues/1348, testcontainers-java/issues/7239)