### PR TITLE
[RORDEV-1202] fixed: typo in LDAP server side filtering setting name

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/definitions/LdapServicesDecoder.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/definitions/LdapServicesDecoder.scala
@@ -271,7 +271,7 @@ object LdapServicesDecoder {
         groupIdAttribute <- c.downField("group_name_attribute").as[Option[GroupIdAttribute]]
         uniqueMemberAttribute <- c.downField("unique_member_attribute").as[Option[UniqueMemberAttribute]]
         groupAttributeIsDN <- c.downField("group_attribute_is_dn").as[Option[Boolean]]
-        serverSideGroupsFiltering <- c.downField("sever_side_groups_filtering").as[Option[Boolean]]
+        serverSideGroupsFiltering <- c.downFields("server_side_groups_filtering", "sever_side_groups_filtering").as[Option[Boolean]]
       } yield DefaultGroupSearch(
         searchGroupBaseDn,
         groupSearchFilter.getOrElse(GroupSearchFilter.default),

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/LdapAuthRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/LdapAuthRuleSettingsTests.scala
@@ -79,7 +79,7 @@ class LdapAuthRuleSettingsTests
                |    ssl_enabled: false
                |    search_user_base_DN: "ou=People,dc=example,dc=com"
                |    search_groups_base_DN: "ou=People,dc=example,dc=com"
-               |    sever_side_groups_filtering: true
+               |    server_side_groups_filtering: true
                |""".stripMargin,
           assertion = rule => {
             assertLdapAuthNServiceLayerTypes(rule.authentication.settings.ldap, withRuleLevelCaching = true)

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/LdapAuthorizationRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/LdapAuthorizationRuleSettingsTests.scala
@@ -114,7 +114,7 @@ class LdapAuthorizationRuleSettingsTests
                |    ssl_enabled: false
                |    search_user_base_DN: "ou=People,dc=example,dc=com"
                |    search_groups_base_DN: "ou=People,dc=example,dc=com"
-               |    sever_side_groups_filtering: false
+               |    server_side_groups_filtering: false
                |""".stripMargin,
           assertion = rule => {
             rule.settings.permittedGroupsLogic should be (GroupsLogic.Or(PermittedGroupIds(
@@ -146,7 +146,7 @@ class LdapAuthorizationRuleSettingsTests
                |    ssl_enabled: false
                |    search_user_base_DN: "ou=People,dc=example,dc=com"
                |    search_groups_base_DN: "ou=People,dc=example,dc=com"
-               |    sever_side_groups_filtering: true
+               |    server_side_groups_filtering: true
                |""".stripMargin,
           assertion = rule => {
             rule.settings.permittedGroupsLogic should be(GroupsLogic.Or(PermittedGroupIds(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.57.3
-pluginVersion=1.58.0-pre1
+pluginVersion=1.58.0-pre2
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m


### PR DESCRIPTION
"sever_side_groups_filtering" -> "server_side_groups_filtering"

The fix is backward compatible. We still support the setting name with the typo.