### PR TITLE
[RODEV-1363] manual stage for publishing docker images for specified ES version of the pre-build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -409,7 +409,10 @@ stages:
               export aws_secret_access_key=$var_aws_secret_access_key
 
               export DOCKER=docker
-              docker login -u $var_docker_registry_user -p $var_docker_registry_password
+              if ! docker login -u $var_docker_registry_user -p $var_docker_registry_password; then
+                echo "Error: Failed to login to Docker registry"
+                exit 1
+              fi
 
               echo "[RELEASE_ROR] executing ROR_TASK = $ROR_TASK"
               echo ">>> ($ROR_TASK) Releasing ROR" && ci/run-pipeline.sh
@@ -538,10 +541,14 @@ stages:
                             
               export DOCKER=docker
               docker login -u $var_docker_registry_user -p $var_docker_registry_password
+              if ! docker login -u $var_docker_registry_user -p $var_docker_registry_password; then
+                echo "Error: Failed to login to Docker registry"
+                exit 1
+              fi
 
               export BUILD_ROR_ES_VERSIONS="${{ parameters.preBuildVersionsForPublishingToDockerHub }}"
               
-              if [ -z "$(echo "BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],'))" ]; then
+              if [ -z "$(echo "$BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],'))" ]; then
                 echo "Error: No ES versions specified for publishing ROR pre-builds"
                 exit 1
               fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ pool:
 stages:
 
   - stage: CVE
+    displayName: 'CVE check'
     dependsOn: [ ]
     condition: ne(variables['Build.Reason'], 'Manual')
     jobs:
@@ -55,6 +56,7 @@ stages:
               ROR_TASK: cve_check
 
   - stage: TEST
+    displayName: 'Run all tests'
     dependsOn: [ ]
     condition: ne(variables['Build.Reason'], 'Manual')
     jobs:
@@ -272,6 +274,7 @@ stages:
               ROR_TASK: integration_es67x
 
   - stage: BUILD_ROR
+    displayName: 'Build ROR plugins'
     dependsOn:
       - TEST
     condition: |
@@ -312,6 +315,7 @@ stages:
               ROR_TASK: build_es6xx
 
   - stage: DETERMINE_CI_TYPE
+    displayName: 'Determine if this is release run'
     dependsOn:
       - TEST
     condition: ne(variables['Build.Reason'], 'Manual')
@@ -327,6 +331,7 @@ stages:
             name: IsRelease
 
   - stage: UPLOAD_PRE_ROR
+    displayName: 'Upload to S3 ROR plugin pre-builds'
     dependsOn:
       - DETERMINE_CI_TYPE
       - TEST
@@ -371,6 +376,7 @@ stages:
               ROR_TASK: upload_pre_es6xx
 
   - stage: RELEASE_ROR
+    displayName: 'Release ROR plugins'
     dependsOn:
       - DETERMINE_CI_TYPE
       - TEST
@@ -424,6 +430,7 @@ stages:
               ROR_TASK: release_es6xx
 
   - stage: BUILD_MVN_ARTIFACTS
+    displayName: 'Build Maven artifacts'
     dependsOn:
       - TEST
     condition: |
@@ -446,6 +453,7 @@ stages:
               ROR_TASK: audit_compile
 
   - stage: PUBLISH_MVN_ARTIFACTS
+    displayName: 'Publish Maven artifacts'
     dependsOn:
       - DETERMINE_CI_TYPE
       - TEST
@@ -534,7 +542,7 @@ stages:
               export BUILD_ROR_ES_VERSIONS="${{ parameters.preBuildVersionsForPublishingToDockerHub }}"
               
               if [ -z "$(echo "BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],'))" ]; then
-                echo "Error: No versions specified for publishing"
+                echo "Error: No ES versions specified for publishing ROR pre-builds"
                 exit 1
               fi
               

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,12 @@ trigger:
       - '*.md'
       - '*/*/*.md'
 
+parameters:
+  - name: preBuildVersionsForPublishingToDockerHub
+    type: string
+    displayName: 'Space or comma-separated list of ES version numbers (e.g., "7.17.20 8.15.0")'
+    default: ' '
+
 pool:
   vmImage: 'ubuntu-20.04'
 
@@ -32,6 +38,7 @@ stages:
 
   - stage: CVE
     dependsOn: [ ]
+    condition: ne(variables['Build.Reason'], 'Manual')
     jobs:
       - job:
         steps:
@@ -49,6 +56,7 @@ stages:
 
   - stage: TEST
     dependsOn: [ ]
+    condition: ne(variables['Build.Reason'], 'Manual')
     jobs:
       - job:
         timeoutInMinutes: 20
@@ -266,7 +274,12 @@ stages:
   - stage: BUILD_ROR
     dependsOn:
       - TEST
-    condition: and(succeeded('TEST'), eq(variables.isPullRequest, true))
+    condition: |
+      and(
+        succeeded('TEST'), 
+        eq(variables.isPullRequest, true), 
+        ne(variables['Build.Reason'], 'Manual')
+      )
     jobs:
       - job:
         timeoutInMinutes: 120
@@ -301,6 +314,7 @@ stages:
   - stage: DETERMINE_CI_TYPE
     dependsOn:
       - TEST
+    condition: ne(variables['Build.Reason'], 'Manual')
     jobs:
       - job: EXTRACT_IS_RELEASE
         steps:
@@ -320,7 +334,8 @@ stages:
       and(
         succeeded('TEST'),
         or(eq(variables.isDevelop, true), eq(variables.isMaster, true)),
-        eq(dependencies.DETERMINE_CI_TYPE.outputs['EXTRACT_IS_RELEASE.IsRelease.value'], false)
+        eq(dependencies.DETERMINE_CI_TYPE.outputs['EXTRACT_IS_RELEASE.IsRelease.value'], false),
+        ne(variables['Build.Reason'], 'Manual')
       )
     jobs:
       - job:
@@ -363,7 +378,8 @@ stages:
       and(
         succeeded('TEST'), 
         or(eq(variables.isDevelop, true), eq(variables.isMaster, true)),
-        eq(dependencies.DETERMINE_CI_TYPE.outputs['EXTRACT_IS_RELEASE.IsRelease.value'], true)
+        eq(dependencies.DETERMINE_CI_TYPE.outputs['EXTRACT_IS_RELEASE.IsRelease.value'], true),
+        ne(variables['Build.Reason'], 'Manual')
       )
     jobs:
       - job:
@@ -410,7 +426,12 @@ stages:
   - stage: BUILD_MVN_ARTIFACTS
     dependsOn:
       - TEST
-    condition: and(succeeded('TEST'), ne(variables.isMaster, true))
+    condition: |
+      and(
+        succeeded('TEST'), 
+        ne(variables.isMaster, true), 
+        ne(variables['Build.Reason'], 'Manual')
+      )
     jobs:
       - job:
         steps:
@@ -432,7 +453,8 @@ stages:
       and(
         succeeded('TEST'), 
         eq(variables.isMaster, true),
-        eq(dependencies.DETERMINE_CI_TYPE.outputs['EXTRACT_IS_RELEASE.IsRelease.value'], true)
+        eq(dependencies.DETERMINE_CI_TYPE.outputs['EXTRACT_IS_RELEASE.IsRelease.value'], true),
+        ne(variables['Build.Reason'], 'Manual')
       )
     jobs:
       - job:
@@ -489,3 +511,37 @@ stages:
               VAR_GPG_PASSPHRASE: $(GPG_PASSPHRASE)
               VAR_GPG_KEY_ID: $(GPG_KEY_ID)
             condition: eq(404, variables.mvn_status)
+
+  - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
+    displayName: 'Publish docker images for specified pre-builds'
+    condition: eq(variables['Build.Reason'], 'Manual')
+    jobs:
+      - job: PUBLISH
+        displayName: 'Publishing'
+        timeoutInMinutes: "600"
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: false
+            persistCredentials: true
+          - script: |
+              set -ex
+                            
+              export DOCKER=docker
+              docker login -u $var_docker_registry_user -p $var_docker_registry_password
+
+              export BUILD_ROR_ES_VERSIONS="${{ parameters.preBuildVersionsForPublishingToDockerHub }}"
+              
+              if [ -z "$(echo "BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],'))" ]; then
+                echo "Error: No versions specified for publishing"
+                exit 1
+              fi
+              
+              echo "[RELEASE_ROR] executing ROR_TASK = $ROR_TASK"
+              echo ">>> ($ROR_TASK) Publish docker images for specified pre-builds" && ci/run-pipeline.sh
+            timeoutInMinutes: "600"
+            condition: succeeded()
+            env:
+              ROR_TASK: publish_pre_builds_docker_images
+              var_docker_registry_user: $(DOCKER_REGISTRY_USER)
+              var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -514,6 +514,7 @@ stages:
 
   - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
     displayName: 'Publish docker images for specified pre-builds'
+    dependsOn: [ ]
     condition: eq(variables['Build.Reason'], 'Manual')
     jobs:
       - job: PUBLISH

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -548,7 +548,7 @@ stages:
 
               export BUILD_ROR_ES_VERSIONS="${{ parameters.preBuildVersionsForPublishingToDockerHub }}"
               
-              if [ -z "$(echo "$BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],'))" ]; then
+              if [ -z "$(echo "$BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],')" ]; then
                 echo "Error: No ES versions specified for publishing ROR pre-builds"
                 exit 1
               fi

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ tasks.register("publishEsRorDockerImage", RorTaskFinder) {
     dependsOn it.findRorTaskForEsVersion('pushRorDockerImage')
 }
 
+tasks.register("publishEsRorPreBuildDockerImage", RorTaskFinder) {
+    dependsOn it.findRorTaskForEsVersion('pushRorPreBuildDockerImage')
+}
+
 group = 'tech.beshu.ror'
 version = pluginVersion
 

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -329,5 +329,5 @@ if [[ $ROR_TASK == "publish_maven_artifacts" ]] && [[ $TRAVIS_BRANCH == "master"
 fi
 
 if [[ -z $TRAVIS ]] || [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
-  public_ror_prebuild_plugin "8.14.3"
+  public_ror_prebuild_plugin "8.14.3" # todo: fixme
 fi

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -286,6 +286,21 @@ release_ror_plugin() {
   fi
 }
 
+public_ror_prebuild_plugin() {
+  if [ "$#" -ne 1 ]; then
+    echo "What ES version should I release plugin for?"
+    return 1
+  fi
+
+  local ES_VERSION=$1
+
+  echo ""
+  echo "PUBLISHING ROR PRE-BUILD for ES $ES_VERSION:"
+
+  ./gradlew publishEsRorPreBuildDockerImage "-PesVersion=$ES_VERSION" </dev/null
+  $DOCKER system prune -fa
+}
+
 if [[ -z $TRAVIS ]] || [[ $ROR_TASK == "release_es8xx" ]]; then
   release_ror_plugins "ci/supported-es-versions/es8x.txt"
 fi
@@ -311,4 +326,8 @@ if [[ $ROR_TASK == "publish_maven_artifacts" ]] && [[ $TRAVIS_BRANCH == "master"
   else
     echo ">>> Skipping publishing audit module artifacts"
   fi
+fi
+
+if [[ -z $TRAVIS ]] || [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
+  public_ror_prebuild_plugin "8.14.3"
 fi

--- a/es67x/build.gradle
+++ b/es67x/build.gradle
@@ -184,7 +184,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es67x/build.gradle
+++ b/es67x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -151,8 +152,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -164,7 +165,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es70x/build.gradle
+++ b/es70x/build.gradle
@@ -177,7 +177,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es70x/build.gradle
+++ b/es70x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -144,8 +145,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -157,7 +158,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es710x/build.gradle
+++ b/es710x/build.gradle
@@ -178,7 +178,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es710x/build.gradle
+++ b/es710x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -145,8 +146,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -158,7 +159,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es711x/build.gradle
+++ b/es711x/build.gradle
@@ -183,7 +183,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es711x/build.gradle
+++ b/es711x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -150,8 +151,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -163,7 +164,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es714x/build.gradle
+++ b/es714x/build.gradle
@@ -177,7 +177,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es714x/build.gradle
+++ b/es714x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -144,8 +145,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -157,7 +158,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es716x/build.gradle
+++ b/es716x/build.gradle
@@ -178,7 +178,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es716x/build.gradle
+++ b/es716x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -145,8 +146,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -158,7 +159,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es717x/build.gradle
+++ b/es717x/build.gradle
@@ -178,7 +178,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es717x/build.gradle
+++ b/es717x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -145,8 +146,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -158,7 +159,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es72x/build.gradle
+++ b/es72x/build.gradle
@@ -177,7 +177,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es72x/build.gradle
+++ b/es72x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -144,8 +145,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -157,7 +158,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es73x/build.gradle
+++ b/es73x/build.gradle
@@ -177,7 +177,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es73x/build.gradle
+++ b/es73x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -144,8 +145,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -157,7 +158,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es74x/build.gradle
+++ b/es74x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -152,8 +153,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -165,7 +166,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es74x/build.gradle
+++ b/es74x/build.gradle
@@ -185,7 +185,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es77x/build.gradle
+++ b/es77x/build.gradle
@@ -178,7 +178,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es77x/build.gradle
+++ b/es77x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -145,8 +146,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -158,7 +159,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es78x/build.gradle
+++ b/es78x/build.gradle
@@ -178,7 +178,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es78x/build.gradle
+++ b/es78x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -145,8 +146,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -158,7 +159,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es79x/build.gradle
+++ b/es79x/build.gradle
@@ -178,7 +178,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es79x/build.gradle
+++ b/es79x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(11)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -145,8 +146,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -158,7 +159,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es80x/build.gradle
+++ b/es80x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es80x/build.gradle
+++ b/es80x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es810x/build.gradle
+++ b/es810x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es810x/build.gradle
+++ b/es810x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es811x/build.gradle
+++ b/es811x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es811x/build.gradle
+++ b/es811x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es812x/build.gradle
+++ b/es812x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es812x/build.gradle
+++ b/es812x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es813x/build.gradle
+++ b/es813x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es813x/build.gradle
+++ b/es813x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es814x/build.gradle
+++ b/es814x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es814x/build.gradle
+++ b/es814x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es815x/build.gradle
+++ b/es815x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es815x/build.gradle
+++ b/es815x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es816x/build.gradle
+++ b/es816x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es816x/build.gradle
+++ b/es816x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es81x/build.gradle
+++ b/es81x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es81x/build.gradle
+++ b/es81x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es82x/build.gradle
+++ b/es82x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es82x/build.gradle
+++ b/es82x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es83x/build.gradle
+++ b/es83x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es83x/build.gradle
+++ b/es83x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es84x/build.gradle
+++ b/es84x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es84x/build.gradle
+++ b/es84x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es85x/build.gradle
+++ b/es85x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es85x/build.gradle
+++ b/es85x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es87x/build.gradle
+++ b/es87x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es87x/build.gradle
+++ b/es87x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es88x/build.gradle
+++ b/es88x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es88x/build.gradle
+++ b/es88x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/es89x/build.gradle
+++ b/es89x/build.gradle
@@ -26,8 +26,9 @@ plugins {
 def pluginFullName = pluginName + '-' + version
 def projectJavaLanguageVersion = JavaLanguageVersion.of(17)
 def moduleEsVersion = project.property('esVersion') != null ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-def dockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
-def dockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def releaseDockerImageLatest = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-latest'
+def releaseDockerImageVersion = 'beshultd/elasticsearch-readonlyrest:' + moduleEsVersion + '-ror-' + pluginVersion
+def preBuildDockerImageVersion = 'beshultd/elasticsearch-readonlyrest-dev:' + moduleEsVersion + '-ror-' + pluginVersion
 
 java {
     toolchain {
@@ -146,8 +147,8 @@ tasks.register('buildRorDockerImage', DockerBuildImage) {
             ES_VERSION: project.properties['esVersion'],
             ROR_VERSION: pluginVersion
     ]
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 
 tasks.register('removeRorDockerImage', DockerRemoveImage) {
@@ -159,7 +160,31 @@ tasks.register('removeRorDockerImage', DockerRemoveImage) {
 tasks.register('pushRorDockerImage', DockerPushImage) {
     dependsOn buildRorDockerImage
 
-    images.add(dockerImageLatest)
-    images.add(dockerImageVersion)
+    images.add(releaseDockerImageLatest)
+    images.add(releaseDockerImageVersion)
 }
 pushRorDockerImage.configure { finalizedBy removeRorDockerImage }
+
+tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
+    dependsOn('packageRorPlugin', 'prepareDockerImageFiles')
+
+    inputDir = layout.buildDirectory.dir("docker-image")
+    buildArgs = [
+            ES_VERSION: project.properties['esVersion'],
+            ROR_VERSION: pluginVersion
+    ]
+    images.add(preBuildDockerImageVersion)
+}
+
+tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
+    dependsOn buildRorPreBuildDockerImage
+    force = true
+    targetImageId buildRorDockerImage.getImageId()
+}
+
+tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {
+    dependsOn buildRorPreBuildDockerImage
+
+    images.add(preBuildDockerImageVersion)
+}
+pushRorPreBuildDockerImage.configure { finalizedBy removeRorPreBuildDockerImage }

--- a/es89x/build.gradle
+++ b/es89x/build.gradle
@@ -179,7 +179,7 @@ tasks.register('buildRorPreBuildDockerImage', DockerBuildImage) {
 tasks.register('removeRorPreBuildDockerImage', DockerRemoveImage) {
     dependsOn buildRorPreBuildDockerImage
     force = true
-    targetImageId buildRorDockerImage.getImageId()
+    targetImageId buildRorPreBuildDockerImage.getImageId()
 }
 
 tasks.register('pushRorPreBuildDockerImage', DockerPushImage) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.61.1
-pluginVersion=1.62.0-pre3
+pluginVersion=1.62.0-pre4
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m


### PR DESCRIPTION
The pre-build docker images will be stored here:
https://hub.docker.com/r/beshultd/elasticsearch-readonlyrest-dev/tags

You can trigger pre-build docker image publishing in [the pipeline](https://dev.azure.com/beshu-tech/ReadonlyREST%20for%20Elasticsearch/_build?definitionId=1) by clicking `Run pipeline` button, choosing a branch and specifying KBN versions:
![Screenshot 2025-01-12 at 11 31 34](https://github.com/user-attachments/assets/8ca074c0-bab2-4809-a536-c346a43f1770)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for pre-build Docker image management across multiple Elasticsearch versions.
	- Introduced new tasks for building, removing, and pushing pre-build Docker images.

- **Improvements**
	- Standardized Docker image naming conventions.
	- Enhanced build pipeline configuration for more flexible image publishing.

- **Chores**
	- Updated plugin version to 1.62.0-pre4.
	- Refactored build scripts to support pre-build image tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->