### PR TITLE
[RORDEV-1375] snapshot restoring should not be so restrictive in case of index checking

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/elasticsearch/indices/clusterindices/BaseIndicesProcessor.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/elasticsearch/indices/clusterindices/BaseIndicesProcessor.scala
@@ -19,12 +19,12 @@ package tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices.clusteri
 import cats.Show
 import cats.data.EitherT
 import monix.eval.Task
-import tech.beshu.ror.accesscontrol.domain.Action.EsAction.restoreSnapshotAction
 import org.apache.logging.log4j.scala.Logging
 import tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices.domain.CanPass.No.Reason
 import tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices.domain.CanPass.No.Reason.IndexNotExist
 import tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices.domain.IndicesCheckContinuation.{continue, stop}
 import tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices.domain.{CanPass, CheckContinuation}
+import tech.beshu.ror.accesscontrol.domain.Action.EsAction.restoreSnapshotAction
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, KibanaIndexName, RequestedIndex}
 import tech.beshu.ror.accesscontrol.matchers.PatternsMatcher
 import tech.beshu.ror.accesscontrol.matchers.PatternsMatcher.Matchable

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/elasticsearch/indices/clusterindices/BaseIndicesProcessor.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/elasticsearch/indices/clusterindices/BaseIndicesProcessor.scala
@@ -19,7 +19,7 @@ package tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices.clusteri
 import cats.Show
 import cats.data.EitherT
 import monix.eval.Task
-import tech.beshu.ror.accesscontrol.domain.Action.EsAction
+import tech.beshu.ror.accesscontrol.domain.Action.EsAction.restoreSnapshotAction
 import org.apache.logging.log4j.scala.Logging
 import tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices.domain.CanPass.No.Reason
 import tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices.domain.CanPass.No.Reason.IndexNotExist
@@ -43,13 +43,13 @@ trait BaseIndicesProcessor {
                                                                   requestedIndices: UniqueNonEmptyList[RequestedIndex[T]])
                                                                  (implicit indicesManager: IndicesManager[T]): Task[CanPass[Set[RequestedIndex[T]]]] = {
     implicit val requestId: RequestContext.Id = requestContext.id
-    if (shouldBeTreatedAsReadonlyRequest())
+    if (shouldBeTreatedAsReadonlyRequest(requestContext))
       canIndicesReadOnlyRequestPass(requestedIndices, determinedKibanaIndex)
     else
       canIndicesWriteRequestPass(requestedIndices, determinedKibanaIndex)
   }
 
-  private def shouldBeTreatedAsReadonlyRequest() = {
+  private def shouldBeTreatedAsReadonlyRequest(requestContext: RequestContext) = {
     requestContext.action == restoreSnapshotAction || requestContext.isReadOnlyRequest
   }
 

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/domain/elasticsearch.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/domain/elasticsearch.scala
@@ -38,7 +38,7 @@ sealed trait Action {
 }
 object Action {
   final case class EsAction(override val value: String) extends Action
-  private object EsAction {
+  object EsAction {
     val fieldCapsAction: Action = EsAction("indices:data/read/field_caps")
     val getSettingsAction: Action = EsAction("indices:monitor/settings/get")
     val monitorStateAction: Action = EsAction("cluster:monitor/state")

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/domain/elasticsearch.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/domain/elasticsearch.scala
@@ -42,6 +42,7 @@ object Action {
     val fieldCapsAction: Action = EsAction("indices:data/read/field_caps")
     val getSettingsAction: Action = EsAction("indices:monitor/settings/get")
     val monitorStateAction: Action = EsAction("cluster:monitor/state")
+    val restoreSnapshotAction: Action = EsAction("cluster:admin/snapshot/restore")
   }
 
   abstract sealed class RorAction(override val value: String) extends Action with EnumEntry

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.61.1
-pluginVersion=1.62.0-pre4
+pluginVersion=1.62.0-pre6
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/SnapshotAndRestoreApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/SnapshotAndRestoreApiSuite.scala
@@ -892,7 +892,7 @@ class SnapshotAndRestoreApiSuite
           val snapshotName1 = SnapshotNameGenerator.next("dev2-snap")
           adminSnapshotManager.putSnapshot(repositoryName, snapshotName1, "*").force()
 
-          val result = dev2SnapshotManager.restoreSnapshot(repositoryName, snapshotName1, "*")
+          val result = dev2SnapshotManager.restoreSnapshot(repositoryName, snapshotName1, "index3*")
 
           result should have statusCode 403
         }

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/SnapshotAndRestoreApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/SnapshotAndRestoreApiSuite.scala
@@ -819,6 +819,21 @@ class SnapshotAndRestoreApiSuite
             val verification2 = adminIndexManager.getIndex("restored_index2")
             verification2 should have statusCode 200
           }
+          "all indices from snapshot are restored (when * is requested)" in {
+            val repositoryName = RepositoryNameGenerator.next("dev2-repo")
+            adminSnapshotManager.putRepository(repositoryName).force()
+
+            val snapshotName1 = SnapshotNameGenerator.next("dev2-snap")
+            adminSnapshotManager.putSnapshot(repositoryName, snapshotName1, "index2*").force()
+
+            val result = dev2SnapshotManager.restoreSnapshot(repositoryName, snapshotName1, "*")
+
+            result should have statusCode 200
+            val verification1 = adminIndexManager.getIndex("restored_index1")
+            verification1 should have statusCode 404
+            val verification2 = adminIndexManager.getIndex("restored_index2")
+            verification2 should have statusCode 200
+          }
           "only one index from snapshot is restored" in {
             val repositoryName = RepositoryNameGenerator.next("dev2-repo")
             adminSnapshotManager.putRepository(repositoryName).force()


### PR DESCRIPTION
🐞Fix (ES) snapshot restoring should not be so restrictive in case of index checking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for restoring snapshots with wildcard index patterns.
  - Introduced a new action for restoring snapshots in the cluster management context.

- **Bug Fixes**
  - Improved handling of read-only requests in the snapshot restoration process.

- **Refactor**
  - Updated internal logic for processing snapshot restoration actions for better clarity.
  - Modified visibility of the `EsAction` object to improve accessibility.

- **Chores**
  - Bumped plugin version to 1.62.0-pre6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->