### PR TITLE
[RORDEV-1402] Manual job for integration tests in Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@ variables:
   isDevelop: $[eq(variables['Build.SourceBranch'], 'refs/heads/develop')]
   isEpic: $[or(contains(variables['Build.SourceBranch'], 'epic/'), contains(variables['System.PullRequest.SourceBranch'], 'epic/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
-  forceRunAllTests: ${{ parameters.forceRunAllTests }}
 
 trigger:
   batch: false
@@ -27,17 +26,17 @@ trigger:
       - '*/*/*.md'
 
 parameters:
+  - name: actionToPerform
+    type: string
+    displayName: '(Manual) action to perform'
+    default: 'publish_docker_image_pre_builds'
+    values:
+      - 'publish_docker_image_pre_builds'
+      - 'run_all_tests'
   - name: preBuildVersionsForPublishingToDockerHub
     type: string
     displayName: 'Space or comma-separated list of ES version numbers (e.g., "7.17.20 8.15.0")'
     default: ' '
-  - name: forceRunAllTests
-    displayName: 'Force run all tests'
-    type: boolean
-    default: false
-    values:
-      - false
-      - true
 
 pool:
   vmImage: 'ubuntu-24.04'
@@ -615,12 +614,42 @@ stages:
     dependsOn: [ ]
     condition:
       and(
+        succeeded(),
         eq(variables['Build.Reason'], 'Manual'),
-        eq(variables.forceRunAllTests, true)
+        eq('${{ parameters.actionToPerform }}', 'run_all_tests')
       )
     jobs:
       - job:
-        condition: succeeded()
+        timeoutInMinutes: 20
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: false
+            persistCredentials: true
+          - script: |
+              # Translate back env vars to avoid cyclical reference :/
+              export aws_access_key_id=$var_aws_access_key_id
+              export aws_secret_access_key=$var_aws_secret_access_key
+
+              echo "[TEST] executing ROR_TASK = $ROR_TASK"
+              ci/run-pipeline.sh
+            env:
+              var_aws_access_key_id: $(aws_access_key_id)
+              var_aws_secret_access_key: $(aws_secret_access_key)
+          - task: PublishTestResults@2
+            condition: failed()
+            inputs:
+              testRunTitle: "$(ROR_TASK) results"
+              testResultsFiles: "**/TEST*xml"
+              mergeTestResults: true
+        strategy:
+          maxParallel: 99
+          matrix:
+            LICENSE:
+              ROR_TASK: license
+            UNIT:
+              ROR_TASK: core_tests
+      - job:
         container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
@@ -650,7 +679,6 @@ stages:
             IT_es90x:
               ROR_TASK: integration_es90x
       - job:
-        condition: succeeded()
         container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
@@ -712,7 +740,6 @@ stages:
             IT_es80x:
               ROR_TASK: integration_es80x
       - job:
-        condition: succeeded()
         container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
@@ -741,11 +768,68 @@ stages:
           matrix:
             IT_es90x:
               ROR_TASK: integration_es90x
+      - job:
+        timeoutInMinutes: 120
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: false
+            persistCredentials: true
+          - script: |
+              # Translate back env vars to avoid cyclical reference :/
+              export aws_access_key_id=$var_aws_access_key_id
+              export aws_secret_access_key=$var_aws_secret_access_key
+
+              echo "[TEST] executing ROR_TASK = $ROR_TASK"
+              ci/run-pipeline.sh
+            env:
+              var_aws_access_key_id: $(aws_access_key_id)
+              var_aws_secret_access_key: $(aws_secret_access_key)
+          - task: PublishTestResults@2
+            condition: failed()
+            inputs:
+              testRunTitle: "$(ROR_TASK) results"
+              testResultsFiles: "**/TEST*xml"
+              mergeTestResults: true
+        strategy:
+          maxParallel: 99
+          matrix:
+            IT_es717x:
+              ROR_TASK: integration_es717x
+            IT_es716x:
+              ROR_TASK: integration_es716x
+            IT_es714x:
+              ROR_TASK: integration_es714x
+            IT_es711x:
+              ROR_TASK: integration_es711x
+            IT_es710x:
+              ROR_TASK: integration_es710x
+            IT_es79x:
+              ROR_TASK: integration_es79x
+            IT_es78x:
+              ROR_TASK: integration_es78x
+            IT_es77x:
+              ROR_TASK: integration_es77x
+            IT_es74x:
+              ROR_TASK: integration_es74x
+            IT_es73x:
+              ROR_TASK: integration_es73x
+            IT_es72x:
+              ROR_TASK: integration_es72x
+            IT_es70x:
+              ROR_TASK: integration_es70x
+            IT_es67x:
+              ROR_TASK: integration_es67x
 
   - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
     displayName: 'Publish docker images for specified pre-builds'
     dependsOn: [ ]
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'))
+    condition:
+      and(
+        succeeded(),
+        eq(variables['Build.Reason'], 'Manual'),
+        eq('${{ parameters.actionToPerform }}', 'publish_docker_image_pre_builds')
+      )
     jobs:
       - job: PUBLISH
         displayName: 'Publishing'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ variables:
   isDevelop: $[eq(variables['Build.SourceBranch'], 'refs/heads/develop')]
   isEpic: $[or(contains(variables['Build.SourceBranch'], 'epic/'), contains(variables['System.PullRequest.SourceBranch'], 'epic/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
+  runIntegrationTests: ${{ parameters.runIntegrationTests }}
 
 trigger:
   batch: false
@@ -30,6 +31,13 @@ parameters:
     type: string
     displayName: 'Space or comma-separated list of ES version numbers (e.g., "7.17.20 8.15.0")'
     default: ' '
+  - name: runIntegrationTests
+    displayName: 'Run Integration Tests'
+    type: boolean
+    default: false
+    values:
+      - false
+      - true
 
 pool:
   vmImage: 'ubuntu-24.04'
@@ -605,7 +613,11 @@ stages:
   - stage: INTEGRATION_TEST
     displayName: 'Run integration tests'
     dependsOn: [ ]
-    condition: eq(variables['Build.Reason'], 'Manual')
+    condition:
+      and(
+        eq(variables['Build.Reason'], 'Manual'),
+        eq(variables.runIntegrationTests, true)
+      )
     jobs:
       - job:
         container: openjdk:22-slim

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -602,6 +602,123 @@ stages:
               VAR_GPG_KEY_ID: $(GPG_KEY_ID)
             condition: eq(404, variables.mvn_status)
 
+  - stage: INTEGRATION_TEST
+    displayName: 'Run integration tests'
+    dependsOn: [ ]
+    condition: eq(variables['Build.Reason'], 'Manual')
+    jobs:
+      - job:
+        container: openjdk:22-slim
+        timeoutInMinutes: 120
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: false
+            persistCredentials: true
+          - script: |
+              # Translate back env vars to avoid cyclical reference :/
+              export aws_access_key_id=$var_aws_access_key_id
+              export aws_secret_access_key=$var_aws_secret_access_key
+
+              echo "[TEST] executing ROR_TASK = $ROR_TASK"
+              ci/run-pipeline.sh
+            env:
+              var_aws_access_key_id: $(aws_access_key_id)
+              var_aws_secret_access_key: $(aws_secret_access_key)
+          - task: PublishTestResults@2
+            condition: failed()
+            inputs:
+              testRunTitle: "$(ROR_TASK) results"
+              testResultsFiles: "**/TEST*xml"
+              mergeTestResults: true
+        strategy:
+          maxParallel: 99
+          matrix:
+            IT_es816x:
+              ROR_TASK: integration_es816x
+            IT_es815x:
+              ROR_TASK: integration_es815x
+            IT_es814x:
+              ROR_TASK: integration_es814x
+            IT_es813x:
+              ROR_TASK: integration_es813x
+            IT_es812x:
+              ROR_TASK: integration_es812x
+            IT_es811x:
+              ROR_TASK: integration_es811x
+            IT_es810x:
+              ROR_TASK: integration_es810x
+            IT_es89x:
+              ROR_TASK: integration_es89x
+            IT_es88x:
+              ROR_TASK: integration_es88x
+            IT_es87x:
+              ROR_TASK: integration_es87x
+            IT_es85x:
+              ROR_TASK: integration_es85x
+            IT_es84x:
+              ROR_TASK: integration_es84x
+            IT_es83x:
+              ROR_TASK: integration_es83x
+            IT_es82x:
+              ROR_TASK: integration_es82x
+            IT_es81x:
+              ROR_TASK: integration_es81x
+            IT_es80x:
+              ROR_TASK: integration_es80x
+      - job:
+        timeoutInMinutes: 120
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: false
+            persistCredentials: true
+          - script: |
+              # Translate back env vars to avoid cyclical reference :/
+              export aws_access_key_id=$var_aws_access_key_id
+              export aws_secret_access_key=$var_aws_secret_access_key
+
+              echo "[TEST] executing ROR_TASK = $ROR_TASK"
+              ci/run-pipeline.sh
+            env:
+              var_aws_access_key_id: $(aws_access_key_id)
+              var_aws_secret_access_key: $(aws_secret_access_key)
+          - task: PublishTestResults@2
+            condition: failed()
+            inputs:
+              testRunTitle: "$(ROR_TASK) results"
+              testResultsFiles: "**/TEST*xml"
+              mergeTestResults: true
+        strategy:
+          maxParallel: 99
+          matrix:
+            IT_es717x:
+              ROR_TASK: integration_es717x
+            IT_es716x:
+              ROR_TASK: integration_es716x
+            IT_es714x:
+              ROR_TASK: integration_es714x
+            IT_es711x:
+              ROR_TASK: integration_es711x
+            IT_es710x:
+              ROR_TASK: integration_es710x
+            IT_es79x:
+              ROR_TASK: integration_es79x
+            IT_es78x:
+              ROR_TASK: integration_es78x
+            IT_es77x:
+              ROR_TASK: integration_es77x
+            IT_es74x:
+              ROR_TASK: integration_es74x
+            IT_es73x:
+              ROR_TASK: integration_es73x
+            IT_es72x:
+              ROR_TASK: integration_es72x
+            IT_es70x:
+              ROR_TASK: integration_es70x
+            IT_es67x:
+              ROR_TASK: integration_es67x
+
   - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
     displayName: 'Publish docker images for specified pre-builds'
     dependsOn: [ ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
   isDevelop: $[eq(variables['Build.SourceBranch'], 'refs/heads/develop')]
   isEpic: $[or(contains(variables['Build.SourceBranch'], 'epic/'), contains(variables['System.PullRequest.SourceBranch'], 'epic/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
-  runIntegrationTests: ${{ parameters.runIntegrationTests }}
+  forceRunAllTests: ${{ parameters.forceRunAllTests }}
 
 trigger:
   batch: false
@@ -31,8 +31,8 @@ parameters:
     type: string
     displayName: 'Space or comma-separated list of ES version numbers (e.g., "7.17.20 8.15.0")'
     default: ' '
-  - name: runIntegrationTests
-    displayName: 'Run Integration Tests'
+  - name: forceRunAllTests
+    displayName: 'Force run all tests'
     type: boolean
     default: false
     values:
@@ -610,16 +610,17 @@ stages:
               VAR_GPG_KEY_ID: $(GPG_KEY_ID)
             condition: eq(404, variables.mvn_status)
 
-  - stage: INTEGRATION_TEST
-    displayName: 'Run integration tests'
+  - stage: FORCED_RUN_OF_ALL_TESTS
+    displayName: 'Manual run of all tests'
     dependsOn: [ ]
     condition:
       and(
         eq(variables['Build.Reason'], 'Manual'),
-        eq(variables.runIntegrationTests, true)
+        eq(variables.forceRunAllTests, true)
       )
     jobs:
       - job:
+        condition: succeeded()
         container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
@@ -646,6 +647,38 @@ stages:
         strategy:
           maxParallel: 99
           matrix:
+            IT_es90x:
+              ROR_TASK: integration_es90x
+      - job:
+        condition: succeeded()
+        container: openjdk:22-slim
+        timeoutInMinutes: 120
+        steps:
+          - checkout: self
+            fetchDepth: 1
+            clean: false
+            persistCredentials: true
+          - script: |
+              # Translate back env vars to avoid cyclical reference :/
+              export aws_access_key_id=$var_aws_access_key_id
+              export aws_secret_access_key=$var_aws_secret_access_key
+
+              echo "[TEST] executing ROR_TASK = $ROR_TASK"
+              ci/run-pipeline.sh
+            env:
+              var_aws_access_key_id: $(aws_access_key_id)
+              var_aws_secret_access_key: $(aws_secret_access_key)
+          - task: PublishTestResults@2
+            condition: failed()
+            inputs:
+              testRunTitle: "$(ROR_TASK) results"
+              testResultsFiles: "**/TEST*xml"
+              mergeTestResults: true
+        strategy:
+          maxParallel: 99
+          matrix:
+            IT_es818x:
+              ROR_TASK: integration_es818x
             IT_es816x:
               ROR_TASK: integration_es816x
             IT_es815x:
@@ -679,6 +712,8 @@ stages:
             IT_es80x:
               ROR_TASK: integration_es80x
       - job:
+        condition: succeeded()
+        container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
           - checkout: self
@@ -704,32 +739,8 @@ stages:
         strategy:
           maxParallel: 99
           matrix:
-            IT_es717x:
-              ROR_TASK: integration_es717x
-            IT_es716x:
-              ROR_TASK: integration_es716x
-            IT_es714x:
-              ROR_TASK: integration_es714x
-            IT_es711x:
-              ROR_TASK: integration_es711x
-            IT_es710x:
-              ROR_TASK: integration_es710x
-            IT_es79x:
-              ROR_TASK: integration_es79x
-            IT_es78x:
-              ROR_TASK: integration_es78x
-            IT_es77x:
-              ROR_TASK: integration_es77x
-            IT_es74x:
-              ROR_TASK: integration_es74x
-            IT_es73x:
-              ROR_TASK: integration_es73x
-            IT_es72x:
-              ROR_TASK: integration_es72x
-            IT_es70x:
-              ROR_TASK: integration_es70x
-            IT_es67x:
-              ROR_TASK: integration_es67x
+            IT_es90x:
+              ROR_TASK: integration_es90x
 
   - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
     displayName: 'Publish docker images for specified pre-builds'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,14 @@ stages:
   - stage: TEST
     displayName: 'Run all tests'
     dependsOn: [ ]
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'Manual'))
+    condition:
+      and(
+        succeeded(),
+        or(
+          ne(variables['Build.Reason'], 'Manual'),
+          and(eq(variables['Build.Reason'], 'Manual'), eq('${{ parameters.actionToPerform }}', 'run_all_tests'))
+        )
+      )
     jobs:
       - job:
         timeoutInMinutes: 20
@@ -98,7 +105,16 @@ stages:
             UNIT:
               ROR_TASK: core_tests
       - job:
-        condition: and(succeeded(), or(eq(variables.isEpic, true), eq(variables.isDevelop, true), eq(variables.isMaster, true)))
+        condition:
+          and(
+            succeeded(),
+            or(
+              eq(variables.isEpic, true),
+              eq(variables.isDevelop, true),
+              eq(variables.isMaster, true),
+              and(eq(variables['Build.Reason'], 'Manual'), eq('${{ parameters.actionToPerform }}', 'run_all_tests'))
+            )
+          )
         container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
@@ -128,7 +144,16 @@ stages:
             IT_es90x:
               ROR_TASK: integration_es90x
       - job:
-        condition: and(succeeded(), or(eq(variables.isEpic, true), eq(variables.isDevelop, true), eq(variables.isMaster, true)))
+        condition:
+          and(
+            succeeded(),
+            or(
+              eq(variables.isEpic, true),
+              eq(variables.isDevelop, true),
+              eq(variables.isMaster, true),
+              and(eq(variables['Build.Reason'], 'Manual'), eq('${{ parameters.actionToPerform }}', 'run_all_tests'))
+            )
+          )
         container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
@@ -190,7 +215,14 @@ stages:
             IT_es80x:
               ROR_TASK: integration_es80x
       - job:
-        condition: and(succeeded(), ne(variables.isEpic, true), ne(variables.isDevelop, true), ne(variables.isMaster, true))
+        condition:
+          and(
+            succeeded(),
+            ne(variables.isEpic, true),
+            ne(variables.isDevelop, true),
+            ne(variables.isMaster, true),
+            not(and(eq(variables['Build.Reason'], 'Manual'), eq('${{ parameters.actionToPerform }}', 'run_all_tests')))
+          )
         container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
@@ -220,7 +252,14 @@ stages:
             IT_es90x:
               ROR_TASK: integration_es90x
       - job:
-        condition: and(succeeded(), ne(variables.isEpic, true), ne(variables.isDevelop, true), ne(variables.isMaster, true))
+        condition:
+          and(
+            succeeded(),
+            ne(variables.isEpic, true),
+            ne(variables.isDevelop, true),
+            ne(variables.isMaster, true),
+            not(and(eq(variables['Build.Reason'], 'Manual'), eq('${{ parameters.actionToPerform }}', 'run_all_tests')))
+          )
         container: openjdk:22-slim
         timeoutInMinutes: 120
         steps:
@@ -254,7 +293,16 @@ stages:
             IT_es80x:
               ROR_TASK: integration_es80x
       - job:
-        condition: and(succeeded(), or(eq(variables.isEpic, true), eq(variables.isDevelop, true), eq(variables.isMaster, true)))
+        condition:
+          and(
+            succeeded(),
+            or(
+              eq(variables.isEpic, true),
+              eq(variables.isDevelop, true),
+              eq(variables.isMaster, true),
+              and(eq(variables['Build.Reason'], 'Manual'), eq('${{ parameters.actionToPerform }}', 'run_all_tests'))
+            )
+          )
         timeoutInMinutes: 120
         steps:
           - checkout: self
@@ -307,7 +355,14 @@ stages:
             IT_es67x:
               ROR_TASK: integration_es67x
       - job:
-        condition: and(succeeded(), ne(variables.isEpic, true), ne(variables.isDevelop, true), ne(variables.isMaster, true))
+        condition:
+          and(
+            succeeded(),
+            ne(variables.isEpic, true),
+            ne(variables.isDevelop, true),
+            ne(variables.isMaster, true),
+            not(and(eq(variables['Build.Reason'], 'Manual'), eq('${{ parameters.actionToPerform }}', 'run_all_tests')))
+          )
         timeoutInMinutes: 120
         steps:
           - checkout: self
@@ -608,218 +663,6 @@ stages:
               VAR_GPG_PASSPHRASE: $(GPG_PASSPHRASE)
               VAR_GPG_KEY_ID: $(GPG_KEY_ID)
             condition: eq(404, variables.mvn_status)
-
-  - stage: FORCED_RUN_OF_ALL_TESTS
-    displayName: 'Manual run of all tests'
-    dependsOn: [ ]
-    condition:
-      and(
-        succeeded(),
-        eq(variables['Build.Reason'], 'Manual'),
-        eq('${{ parameters.actionToPerform }}', 'run_all_tests')
-      )
-    jobs:
-      - job:
-        timeoutInMinutes: 20
-        steps:
-          - checkout: self
-            fetchDepth: 1
-            clean: false
-            persistCredentials: true
-          - script: |
-              # Translate back env vars to avoid cyclical reference :/
-              export aws_access_key_id=$var_aws_access_key_id
-              export aws_secret_access_key=$var_aws_secret_access_key
-
-              echo "[TEST] executing ROR_TASK = $ROR_TASK"
-              ci/run-pipeline.sh
-            env:
-              var_aws_access_key_id: $(aws_access_key_id)
-              var_aws_secret_access_key: $(aws_secret_access_key)
-          - task: PublishTestResults@2
-            condition: failed()
-            inputs:
-              testRunTitle: "$(ROR_TASK) results"
-              testResultsFiles: "**/TEST*xml"
-              mergeTestResults: true
-        strategy:
-          maxParallel: 99
-          matrix:
-            LICENSE:
-              ROR_TASK: license
-            UNIT:
-              ROR_TASK: core_tests
-      - job:
-        container: openjdk:22-slim
-        timeoutInMinutes: 120
-        steps:
-          - checkout: self
-            fetchDepth: 1
-            clean: false
-            persistCredentials: true
-          - script: |
-              # Translate back env vars to avoid cyclical reference :/
-              export aws_access_key_id=$var_aws_access_key_id
-              export aws_secret_access_key=$var_aws_secret_access_key
-
-              echo "[TEST] executing ROR_TASK = $ROR_TASK"
-              ci/run-pipeline.sh
-            env:
-              var_aws_access_key_id: $(aws_access_key_id)
-              var_aws_secret_access_key: $(aws_secret_access_key)
-          - task: PublishTestResults@2
-            condition: failed()
-            inputs:
-              testRunTitle: "$(ROR_TASK) results"
-              testResultsFiles: "**/TEST*xml"
-              mergeTestResults: true
-        strategy:
-          maxParallel: 99
-          matrix:
-            IT_es90x:
-              ROR_TASK: integration_es90x
-      - job:
-        container: openjdk:22-slim
-        timeoutInMinutes: 120
-        steps:
-          - checkout: self
-            fetchDepth: 1
-            clean: false
-            persistCredentials: true
-          - script: |
-              # Translate back env vars to avoid cyclical reference :/
-              export aws_access_key_id=$var_aws_access_key_id
-              export aws_secret_access_key=$var_aws_secret_access_key
-
-              echo "[TEST] executing ROR_TASK = $ROR_TASK"
-              ci/run-pipeline.sh
-            env:
-              var_aws_access_key_id: $(aws_access_key_id)
-              var_aws_secret_access_key: $(aws_secret_access_key)
-          - task: PublishTestResults@2
-            condition: failed()
-            inputs:
-              testRunTitle: "$(ROR_TASK) results"
-              testResultsFiles: "**/TEST*xml"
-              mergeTestResults: true
-        strategy:
-          maxParallel: 99
-          matrix:
-            IT_es818x:
-              ROR_TASK: integration_es818x
-            IT_es816x:
-              ROR_TASK: integration_es816x
-            IT_es815x:
-              ROR_TASK: integration_es815x
-            IT_es814x:
-              ROR_TASK: integration_es814x
-            IT_es813x:
-              ROR_TASK: integration_es813x
-            IT_es812x:
-              ROR_TASK: integration_es812x
-            IT_es811x:
-              ROR_TASK: integration_es811x
-            IT_es810x:
-              ROR_TASK: integration_es810x
-            IT_es89x:
-              ROR_TASK: integration_es89x
-            IT_es88x:
-              ROR_TASK: integration_es88x
-            IT_es87x:
-              ROR_TASK: integration_es87x
-            IT_es85x:
-              ROR_TASK: integration_es85x
-            IT_es84x:
-              ROR_TASK: integration_es84x
-            IT_es83x:
-              ROR_TASK: integration_es83x
-            IT_es82x:
-              ROR_TASK: integration_es82x
-            IT_es81x:
-              ROR_TASK: integration_es81x
-            IT_es80x:
-              ROR_TASK: integration_es80x
-      - job:
-        container: openjdk:22-slim
-        timeoutInMinutes: 120
-        steps:
-          - checkout: self
-            fetchDepth: 1
-            clean: false
-            persistCredentials: true
-          - script: |
-              # Translate back env vars to avoid cyclical reference :/
-              export aws_access_key_id=$var_aws_access_key_id
-              export aws_secret_access_key=$var_aws_secret_access_key
-
-              echo "[TEST] executing ROR_TASK = $ROR_TASK"
-              ci/run-pipeline.sh
-            env:
-              var_aws_access_key_id: $(aws_access_key_id)
-              var_aws_secret_access_key: $(aws_secret_access_key)
-          - task: PublishTestResults@2
-            condition: failed()
-            inputs:
-              testRunTitle: "$(ROR_TASK) results"
-              testResultsFiles: "**/TEST*xml"
-              mergeTestResults: true
-        strategy:
-          maxParallel: 99
-          matrix:
-            IT_es90x:
-              ROR_TASK: integration_es90x
-      - job:
-        timeoutInMinutes: 120
-        steps:
-          - checkout: self
-            fetchDepth: 1
-            clean: false
-            persistCredentials: true
-          - script: |
-              # Translate back env vars to avoid cyclical reference :/
-              export aws_access_key_id=$var_aws_access_key_id
-              export aws_secret_access_key=$var_aws_secret_access_key
-
-              echo "[TEST] executing ROR_TASK = $ROR_TASK"
-              ci/run-pipeline.sh
-            env:
-              var_aws_access_key_id: $(aws_access_key_id)
-              var_aws_secret_access_key: $(aws_secret_access_key)
-          - task: PublishTestResults@2
-            condition: failed()
-            inputs:
-              testRunTitle: "$(ROR_TASK) results"
-              testResultsFiles: "**/TEST*xml"
-              mergeTestResults: true
-        strategy:
-          maxParallel: 99
-          matrix:
-            IT_es717x:
-              ROR_TASK: integration_es717x
-            IT_es716x:
-              ROR_TASK: integration_es716x
-            IT_es714x:
-              ROR_TASK: integration_es714x
-            IT_es711x:
-              ROR_TASK: integration_es711x
-            IT_es710x:
-              ROR_TASK: integration_es710x
-            IT_es79x:
-              ROR_TASK: integration_es79x
-            IT_es78x:
-              ROR_TASK: integration_es78x
-            IT_es77x:
-              ROR_TASK: integration_es77x
-            IT_es74x:
-              ROR_TASK: integration_es74x
-            IT_es73x:
-              ROR_TASK: integration_es73x
-            IT_es72x:
-              ROR_TASK: integration_es72x
-            IT_es70x:
-              ROR_TASK: integration_es70x
-            IT_es67x:
-              ROR_TASK: integration_es67x
 
   - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
     displayName: 'Publish docker images for specified pre-builds'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a manual option to either publish pre-build Docker images or run all tests in the pipeline.
  - Added a comprehensive testing stage with multiple parallel jobs covering core, license, and integration tests across different Elasticsearch versions.
  - Enhanced flexibility and control over the pipeline execution with a new parameter to select the desired action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->