### PR TITLE
[RORDEV-1204] change default reason returned by ROR when it forbids the request

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/GlobalSettings.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/GlobalSettings.scala
@@ -35,5 +35,5 @@ object GlobalSettings {
     val default = ESWithLucene
   }
 
-  val defaultForbiddenRequestMessage: String = "forbidden"
+  val defaultForbiddenRequestMessage: String = "Forbidden by ReadonlyREST"
 }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/response/ForbiddenResponseContext.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/response/ForbiddenResponseContext.scala
@@ -89,14 +89,9 @@ object ForbiddenResponseContext {
   case object RorFailedToStart extends Cause
   case object TestSettingsNotConfigured extends Cause
 
-  def create(causes: NonEmptyList[ForbiddenResponseContext.Cause],
-             aclStaticContext: AccessControlStaticContext): ForbiddenResponseContext =
+  def from(causes: NonEmptyList[ForbiddenResponseContext.Cause],
+           aclStaticContext: AccessControlStaticContext): ForbiddenResponseContext =
     new ForbiddenResponseContext(Some(aclStaticContext), causes)
-
-  def from(causes: NonEmptyList[ForbiddenCause],
-           aclStaticContext: AccessControlStaticContext): ForbiddenResponseContext = {
-    new ForbiddenResponseContext(Some(aclStaticContext), causes.map(Cause.fromMismatchedCause))
-  }
 
   private implicit val forbiddenCauseShow: Show[Cause] = Show.show {
     case ForbiddenBlockMatch(_) => "FORBIDDEN_BY_BLOCK"

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/GlobalSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/GlobalSettingsTests.scala
@@ -77,7 +77,7 @@ class GlobalSettingsTests extends
           assertDecodingSuccess(
             yaml = noCustomSettingsYaml,
             assertion = config =>
-              config.forbiddenRequestMessage should be("forbidden")
+              config.forbiddenRequestMessage should be("Forbidden by ReadonlyREST")
           )
         }
       }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/ImpersonationSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/ImpersonationSettingsTests.scala
@@ -35,7 +35,7 @@ class ImpersonationSettingsTests extends BaseDecoderTest(
   new ImpersonationDefinitionsDecoderCreator(
     GlobalSettings(
       showBasicAuthPrompt = true,
-      forbiddenRequestMessage = "forbidden",
+      forbiddenRequestMessage = "Forbidden by ReadonlyREST",
       flsEngine = FlsEngine.ES,
       configurationIndex = RorConfigurationIndex(fullIndexName(".readonlyrest")),
       userIdCaseSensitivity = CaseSensitivity.Enabled

--- a/es67x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es67x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es70x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es70x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es710x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es710x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es711x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es711x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es714x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es714x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es716x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es716x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es717x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es717x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es717x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es717x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es72x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es72x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es73x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es73x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es74x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es74x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es77x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es77x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es78x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es78x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es79x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es79x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es80x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es80x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es810x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es810x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es810x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es810x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es811x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es811x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es812x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es812x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es813x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es813x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es814x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es814x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es815x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es815x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es816x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es816x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es816x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es816x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es81x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es81x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es82x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es82x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es83x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es83x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es84x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es84x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es85x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es85x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es87x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es87x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es88x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es88x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es89x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es89x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/CurrentUserMetadataRequestHandler.scala
@@ -78,7 +78,10 @@ class CurrentUserMetadataRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptySet[ForbiddenCause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.from(causes.toNonEmptyList, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(
+        causes.toNonEmptyList.map(ForbiddenResponseContext.Cause.fromMismatchedCause),
+        engine.core.accessControl.staticContext
+      )
     ))
   }
 

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/RegularRequestHandler.scala
@@ -111,7 +111,7 @@ class RegularRequestHandler(engine: Engine,
   private def onForbidden(requestContext: RequestContext, causes: NonEmptyList[ForbiddenResponseContext.Cause]): Unit = {
     logRequestProcessingTime(requestContext)
     esContext.listener.onFailure(ForbiddenResponse.create(
-      ForbiddenResponseContext.create(causes, engine.core.accessControl.staticContext)
+      ForbiddenResponseContext.from(causes, engine.core.accessControl.staticContext)
     ))
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.63.0
-pluginVersion=1.64.0-pre1
+pluginVersion=1.64.0-pre2
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/ImpersonationSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/ImpersonationSuite.scala
@@ -849,12 +849,12 @@ class ImpersonationSuite
       |    "root_cause":[
       |      {
       |        "type":"forbidden_response",
-      |        "reason":"forbidden",
+      |        "reason":"Forbidden by ReadonlyREST",
       |        "due_to":["OPERATION_NOT_ALLOWED", "IMPERSONATION_NOT_SUPPORTED"]
       |      }
       |    ],
       |    "type":"forbidden_response",
-      |    "reason":"forbidden",
+      |    "reason":"Forbidden by ReadonlyREST",
       |    "due_to":["OPERATION_NOT_ALLOWED", "IMPERSONATION_NOT_SUPPORTED"]
       |  },
       |  "status":403
@@ -868,12 +868,12 @@ class ImpersonationSuite
       |    "root_cause":[
       |      {
       |        "type":"forbidden_response",
-      |        "reason":"forbidden",
+      |        "reason":"Forbidden by ReadonlyREST",
       |        "due_to":["OPERATION_NOT_ALLOWED", "IMPERSONATION_NOT_ALLOWED"]
       |      }
       |    ],
       |    "type":"forbidden_response",
-      |    "reason":"forbidden",
+      |    "reason":"Forbidden by ReadonlyREST",
       |    "due_to":["OPERATION_NOT_ALLOWED", "IMPERSONATION_NOT_ALLOWED"]
       |  },
       |  "status":403
@@ -887,12 +887,12 @@ class ImpersonationSuite
       |    "root_cause":[
       |      {
       |        "type":"forbidden_response",
-      |        "reason":"forbidden",
+      |        "reason":"Forbidden by ReadonlyREST",
       |        "due_to":"TEST_SETTINGS_NOT_CONFIGURED"
       |      }
       |    ],
       |    "type":"forbidden_response",
-      |    "reason":"forbidden",
+      |    "reason":"Forbidden by ReadonlyREST",
       |    "due_to":"TEST_SETTINGS_NOT_CONFIGURED"
       |  },
       |  "status":403

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/RorDisabledSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/RorDisabledSuite.scala
@@ -61,7 +61,7 @@ class RorDisabledSuite
         val result = user1MetadataManager.fetchMetadata()
 
         result should have statusCode 403
-        result.responseJson("error")("reason").str should be("forbidden")
+        result.responseJson("error")("reason").str should be("Forbidden by ReadonlyREST")
         result.responseJson("error")("due_to").str should be("READONLYREST_NOT_ENABLED")
       }
     }

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/RorStartingSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/RorStartingSuite.scala
@@ -131,7 +131,7 @@ class RorStartingSuite extends AnyWordSpec with ESVersionSupportForAnyWordSpecLi
           .responseJson("error")
           .obj("root_cause")
           .arr.exists { json =>
-          json("reason").str == "forbidden" &&
+          json("reason").str == "Forbidden by ReadonlyREST" &&
             json("due_to").str == "READONLYREST_NOT_READY_YET"
         }
       }

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseAdminApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseAdminApiSuite.scala
@@ -1198,12 +1198,12 @@ trait BaseAdminApiSuite
         |    "root_cause":[
         |      {
         |        "type":"forbidden_response",
-        |        "reason":"forbidden",
+        |        "reason":"Forbidden by ReadonlyREST",
         |        "due_to":"TEST_SETTINGS_NOT_CONFIGURED"
         |      }
         |    ],
         |    "type":"forbidden_response",
-        |    "reason":"forbidden",
+        |    "reason":"Forbidden by ReadonlyREST",
         |    "due_to":"TEST_SETTINGS_NOT_CONFIGURED"
         |  },
         |  "status":403
@@ -1268,12 +1268,12 @@ trait BaseAdminApiSuite
         |    "root_cause":[
         |      {
         |        "type":"forbidden_response",
-        |        "reason":"forbidden",
+        |        "reason":"Forbidden by ReadonlyREST",
         |        "due_to":"OPERATION_NOT_ALLOWED"
         |      }
         |    ],
         |  "type":"forbidden_response",
-        |  "reason":"forbidden",
+        |  "reason":"Forbidden by ReadonlyREST",
         |  "due_to":"OPERATION_NOT_ALLOWED"
         |  },
         |  "status":403
@@ -1291,12 +1291,12 @@ trait BaseAdminApiSuite
         |    "root_cause":[
         |      {
         |        "type":"forbidden_response",
-        |        "reason":"forbidden",
+        |        "reason":"Forbidden by ReadonlyREST",
         |        "due_to":"IMPERSONATION_NOT_ALLOWED"
         |      }
         |    ],
         |  "type":"forbidden_response",
-        |  "reason":"forbidden",
+        |  "reason":"Forbidden by ReadonlyREST",
         |  "due_to":"IMPERSONATION_NOT_ALLOWED"
         |  },
         |  "status":403

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseIndexApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseIndexApiSuite.scala
@@ -156,7 +156,7 @@ trait BaseIndexApiSuite
           val response = dev9IndexManager.getIndex("index9")
 
           response should have statusCode forbiddenStatusReturned
-          response.responseJson should be(forbiddenByBlockResponse("forbidden"))
+          response.responseJson should be(forbiddenByBlockResponse("Forbidden by ReadonlyREST"))
         }
         "custom forbidden response for block configured" in {
           val response = dev10IndexManager.getIndex("index10")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Forbidden access responses now display a more descriptive message—“Forbidden by ReadonlyREST”—instead of a generic “forbidden”. This enhancement clarifies error information across various access scenarios for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->