### PR TITLE
[RORDEV-1455] "users" section username duplication check feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out/
 *-execution-hints.log
 *-execution-times.log
 *.log
+*/bin
 
 // ignore the downloaded model files in git
 src/test/resources/models/

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/GlobalSettings.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/GlobalSettings.scala
@@ -22,7 +22,8 @@ final case class GlobalSettings(showBasicAuthPrompt: Boolean,
                                 forbiddenRequestMessage: String,
                                 flsEngine: GlobalSettings.FlsEngine,
                                 configurationIndex: RorConfigurationIndex,
-                                userIdCaseSensitivity: CaseSensitivity)
+                                userIdCaseSensitivity: CaseSensitivity,
+                                usersDefinitionDuplicateUsernamesValidationEnabled: Boolean)
 
 object GlobalSettings {
 

--- a/core/src/test/scala/tech/beshu/ror/integration/CaseInsensitiveGroupsWithProxyAuthAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/CaseInsensitiveGroupsWithProxyAuthAccessControlTests.scala
@@ -33,7 +33,8 @@ class CaseInsensitiveGroupsWithProxyAuthAccessControlTests extends AnyWordSpec
   override protected def configYaml: String =
     """
       |readonlyrest:
-      |  username_case_sensitivity: case_insensitive
+      |  global_settings:
+      |    username_case_sensitivity: case_insensitive
       |
       |  access_control_rules:
       |  - name: "Allowed only for group1 and group2"

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/EnabledAccessControlListTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/EnabledAccessControlListTests.scala
@@ -133,7 +133,8 @@ class EnabledAccessControlListTests extends AnyWordSpec with MockFactory with In
           forbiddenRequestMessage = "Forbidden",
           flsEngine = FlsEngine.default,
           configurationIndex = RorConfigurationIndex(IndexName.Full(".readonlyrest")),
-          userIdCaseSensitivity = CaseSensitivity.Enabled
+          userIdCaseSensitivity = CaseSensitivity.Enabled,
+          usersDefinitionDuplicateUsernamesValidationEnabled = true
         ),
         Set.empty
       )

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/definitions/user/UserDefinitionsValidatorTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/definitions/user/UserDefinitionsValidatorTests.scala
@@ -1,0 +1,147 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+package tech.beshu.ror.unit.acl.blocks.definitions.user
+
+import cats.data.NonEmptyList
+import eu.timepit.refined.types.string.NonEmptyString
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import tech.beshu.ror.accesscontrol.blocks.definitions.UserDef
+import tech.beshu.ror.accesscontrol.blocks.definitions.UserDef.Mode.WithoutGroupsMapping
+import tech.beshu.ror.accesscontrol.blocks.definitions.user.UserDefinitionsValidator
+import tech.beshu.ror.accesscontrol.blocks.definitions.user.UserDefinitionsValidator.ValidationError
+import tech.beshu.ror.accesscontrol.blocks.rules.auth.AuthKeyRule
+import tech.beshu.ror.accesscontrol.blocks.rules.auth.base.BasicAuthenticationRule
+import tech.beshu.ror.accesscontrol.blocks.rules.auth.base.impersonation.Impersonation
+import tech.beshu.ror.accesscontrol.domain.*
+import tech.beshu.ror.accesscontrol.factory.GlobalSettings
+import tech.beshu.ror.accesscontrol.factory.decoders.definitions.Definitions
+import tech.beshu.ror.utils.RefinedUtils.nes
+import tech.beshu.ror.utils.TestsUtils.*
+import tech.beshu.ror.utils.uniquelist.UniqueNonEmptyList
+
+class UserDefinitionsValidatorTests extends AnyWordSpec with Matchers {
+
+  "UserDefinitionsValidator" should {
+    "validate user definitions successfully" when {
+      "there are no duplicate usernames" in {
+        val validator = new UserDefinitionsValidator(globalSettings(validationEnabled = true))
+
+        val definitions = Definitions(
+          List(
+            createUserDef("user1", "user2"),
+            createUserDef("user3", "user*")
+          )
+        )
+
+        validator.validate(definitions) shouldBe Right(())
+      }
+      "there are wildcards in usernames" in {
+        val validator = new UserDefinitionsValidator(globalSettings(validationEnabled = true))
+
+        val definitions = Definitions(
+          List(
+            createUserDef("user1", "user*"),
+            createUserDef("user*", "admin")
+          )
+        )
+
+        validator.validate(definitions) shouldBe Right(())
+      }
+      "there are duplicate usernames but validation is disabled" in {
+        val validator = new UserDefinitionsValidator(globalSettings(validationEnabled = false))
+
+        val definitions = Definitions(
+          List(
+            createUserDef("user1", "user2"),
+            createUserDef("user2", "user3")
+          )
+        )
+
+        validator.validate(definitions) shouldBe Right(())
+      }
+    }
+
+    "return validation error" when {
+      "there are duplicate usernames and validation is enabled" in {
+        val validator = new UserDefinitionsValidator(globalSettings(validationEnabled = true))
+
+        val definitions = Definitions(
+          List(
+            createUserDef("user1", "user2"),
+            createUserDef("user2", "user3")
+          )
+        )
+
+        val result = validator.validate(definitions)
+
+        result shouldBe Left(NonEmptyList.of(
+          ValidationError.DuplicatedUsernameForLocalUser(userId("user2"))
+        ))
+      }
+    }
+
+    "return multiple validation errors" when {
+      "there are multiple duplicate usernames" in {
+        val validator = new UserDefinitionsValidator(globalSettings(validationEnabled = true))
+
+        val definitions = Definitions(
+          List(
+            createUserDef("user1", "user2", "user3"),
+            createUserDef("user2", "user4"),
+            createUserDef("user3", "user5")
+          )
+        )
+
+        val result = validator.validate(definitions)
+
+        result shouldBe Left(NonEmptyList.of(
+          ValidationError.DuplicatedUsernameForLocalUser(userId("user2")),
+          ValidationError.DuplicatedUsernameForLocalUser(userId("user3"))
+        ))
+      }
+    }
+  }
+
+  private def globalSettings(validationEnabled: Boolean): GlobalSettings = {
+    GlobalSettings(
+      showBasicAuthPrompt = false,
+      forbiddenRequestMessage = "Forbidden",
+      flsEngine = GlobalSettings.FlsEngine.default,
+      configurationIndex = RorConfigurationIndex(IndexName.Full(nes(".readonlyrest"))),
+      userIdCaseSensitivity = CaseSensitivity.Enabled,
+      usersDefinitionDuplicateUsernamesValidationEnabled = validationEnabled
+    )
+  }
+
+  private def createUserDef(username: String, usernames: String*): UserDef = {
+    UserDef(
+      userIdPatterns(username, usernames: _*),
+      WithoutGroupsMapping(
+        new AuthKeyRule(
+          BasicAuthenticationRule.Settings(Credentials(
+            User.Id(NonEmptyString.unsafeFrom("example-user")),
+            PlainTextSecret(NonEmptyString.unsafeFrom("example-password"))
+          )),
+          CaseSensitivity.Enabled,
+          Impersonation.Disabled,
+        ),
+        UniqueNonEmptyList.of(group("example-group1", "Example Group 1"))
+      )
+    )
+  }
+}

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/auth/GroupsRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/auth/GroupsRuleTests.scala
@@ -45,7 +45,6 @@ import tech.beshu.ror.accesscontrol.blocks.{BlockContext, BlockContextUpdater}
 import tech.beshu.ror.accesscontrol.domain.*
 import tech.beshu.ror.accesscontrol.domain.GroupIdLike.GroupId
 import tech.beshu.ror.accesscontrol.domain.LoggedUser.DirectlyLoggedUser
-import tech.beshu.ror.accesscontrol.domain.User.UserIdPattern
 import tech.beshu.ror.mocks.{MockRequestContext, MockRestRequest}
 import tech.beshu.ror.providers.{EnvVarsProvider, OsEnvVarsProvider}
 import tech.beshu.ror.syntax.*
@@ -161,14 +160,6 @@ trait GroupsRuleTests[GL <: GroupsLogic: GroupsLogic.Creator] extends AnyWordSpe
       case None =>
         result should be(Rejected())
     }
-  }
-
-  def userIdPatterns(id: String, ids: String*): UserIdPatterns = {
-    UserIdPatterns(
-      UniqueNonEmptyList.unsafeFrom(
-        (id :: ids.toList).map(str => UserIdPattern(User.Id(NonEmptyString.unsafeFrom(str))))
-      )
-    )
   }
 
   def groups(g1: String, gs: String*): UniqueNonEmptyList[Group] = {

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/GlobalSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/GlobalSettingsTests.scala
@@ -26,8 +26,8 @@ import tech.beshu.ror.accesscontrol.factory.RawRorConfigBasedCoreFactory.CoreCre
 import tech.beshu.ror.accesscontrol.factory.decoders.GlobalStaticSettingsDecoder
 import tech.beshu.ror.accesscontrol.utils.{SyncDecoder, SyncDecoderCreator}
 
-class GlobalSettingsTests extends
-  BaseDecoderTest(GlobalSettingsTests.decoder) {
+class GlobalSettingsTests
+  extends BaseDecoderTest(GlobalSettingsTests.decoder) {
 
   "A global settings should be able to be loaded from config (in the 'readonlyrest.global_settings' section level)" when {
     "'prompt_for_basic_auth'" should {
@@ -194,6 +194,39 @@ class GlobalSettingsTests extends
         }
       }
     }
+    "'users_section_duplicate_usernames_detection'" should {
+      "be decoded with success" when {
+        "enabled" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   users_section_duplicate_usernames_detection: true
+                     """.stripMargin,
+            assertion = config =>
+              config.usersDefinitionDuplicateUsernamesValidationEnabled should be(true)
+          )
+        }
+        "disabled" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   users_section_duplicate_usernames_detection: false
+                     """.stripMargin,
+            assertion = config =>
+              config.usersDefinitionDuplicateUsernamesValidationEnabled should be(false)
+          )
+        }
+        "no defined" in {
+          assertDecodingSuccess(
+            yaml = noCustomSettingsYaml,
+            assertion = config =>
+              config.usersDefinitionDuplicateUsernamesValidationEnabled should be(true)
+          )
+        }
+      }
+    }
   }
 
   "A global settings should be able to be loaded from config (in the 'readonlyrest' section level)" when {
@@ -351,6 +384,37 @@ class GlobalSettingsTests extends
         }
       }
     }
+    "'users_section_duplicate_usernames_detection'" should {
+      "be decoded with success" when {
+        "enabled" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | users_section_duplicate_usernames_detection: true
+                   """.stripMargin,
+            assertion = config =>
+              config.usersDefinitionDuplicateUsernamesValidationEnabled should be(true)
+          )
+        }
+        "disabled" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | users_section_duplicate_usernames_detection: false
+                   """.stripMargin,
+            assertion = config =>
+              config.usersDefinitionDuplicateUsernamesValidationEnabled should be(false)
+          )
+        }
+        "not defined" in {
+          assertDecodingSuccess(
+            yaml = noCustomSettingsYaml,
+            assertion = config =>
+              config.usersDefinitionDuplicateUsernamesValidationEnabled should be(true)
+          )
+        }
+      }
+    }
   }
 
   "The deprecated and the new syntax of global settings cannot be mixed" when {
@@ -411,6 +475,21 @@ class GlobalSettingsTests extends
           error =>
             error should be(GeneralReadonlyrestSettingsError(Message(
               "Detected duplicated settings (usage of current and deprecated syntax). You cannot use '.global_settings.username_case_sensitivity' together with '.username_case_sensitivity'. Pick one syntax."
+            )))
+      )
+    }
+    "it's 'users_section_duplicate_usernames_detection'" in {
+      assertDecodingFailure(
+        yaml =
+          s"""
+             | users_section_duplicate_usernames_detection: true
+             | global_settings:
+             |   users_section_duplicate_usernames_detection: true
+                                """.stripMargin,
+        assertion =
+          error =>
+            error should be(GeneralReadonlyrestSettingsError(Message(
+              "Detected duplicated settings (usage of current and deprecated syntax). You cannot use '.global_settings.users_section_duplicate_usernames_detection' together with '.users_section_duplicate_usernames_detection'. Pick one syntax."
             )))
       )
     }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/GlobalSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/GlobalSettingsTests.scala
@@ -29,7 +29,174 @@ import tech.beshu.ror.accesscontrol.utils.{SyncDecoder, SyncDecoderCreator}
 class GlobalSettingsTests extends
   BaseDecoderTest(GlobalSettingsTests.decoder) {
 
-  "A global settings should be able to be loaded from config" when {
+  "A global settings should be able to be loaded from config (in the 'readonlyrest.global_settings' section level)" when {
+    "'prompt_for_basic_auth'" should {
+      "be decoded with success" when {
+        "enabled" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   prompt_for_basic_auth: true
+               """.stripMargin,
+            assertion = config =>
+              config.showBasicAuthPrompt should be(true)
+          )
+        }
+        "disabled" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   prompt_for_basic_auth: false
+               """.stripMargin,
+            assertion = config =>
+              config.showBasicAuthPrompt should be(false)
+          )
+        }
+        "not defined" in {
+          assertDecodingSuccess(
+            yaml = noCustomSettingsYaml,
+            assertion = config =>
+              config.showBasicAuthPrompt should be(false)
+          )
+        }
+      }
+    }
+    "'response_if_req_forbidden'" should {
+      "be decoded with success" when {
+        "custom message" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   response_if_req_forbidden: custom_forbidden_response
+               """.stripMargin,
+            assertion = config =>
+              config.forbiddenRequestMessage should be("custom_forbidden_response")
+          )
+        }
+        "not defined" in {
+          assertDecodingSuccess(
+            yaml = noCustomSettingsYaml,
+            assertion = config =>
+              config.forbiddenRequestMessage should be("Forbidden by ReadonlyREST")
+          )
+        }
+      }
+    }
+    "'fls_engine'" should {
+      "be decoded with success" when {
+        "lucene" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   fls_engine: lucene
+               """.stripMargin,
+            assertion = config =>
+              config.flsEngine should be(FlsEngine.Lucene)
+          )
+        }
+        "es_with_lucene" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   fls_engine: es_with_lucene
+               """.stripMargin,
+            assertion = config =>
+              config.flsEngine should be(FlsEngine.ESWithLucene)
+          )
+        }
+        "es" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   fls_engine: es
+               """.stripMargin,
+            assertion = config =>
+              config.flsEngine should be(FlsEngine.ES)
+          )
+        }
+        "not defined" in {
+          assertDecodingSuccess(
+            yaml = noCustomSettingsYaml,
+            assertion = config =>
+              config.flsEngine should be(FlsEngine.ESWithLucene)
+          )
+        }
+      }
+      "be decoded with failure" when {
+        "unknown engine type" in {
+          assertDecodingFailure(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   fls_engine: custom
+               """.stripMargin,
+            assertion =
+              error =>
+                error should be(GeneralReadonlyrestSettingsError(Message(
+                  "Unknown fls engine: 'custom'. Supported: 'es_with_lucene'(default), 'es'.")
+                ))
+          )
+        }
+      }
+    }
+    "'username_case_sensitivity'" should {
+      "be decoded with success" when {
+        "case sensitive" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   username_case_sensitivity: case_sensitive
+               """.stripMargin,
+            assertion = config =>
+              config.userIdCaseSensitivity should be(CaseSensitivity.Enabled)
+          )
+        }
+        "case insensitive" in {
+          assertDecodingSuccess(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   username_case_sensitivity: case_insensitive
+               """.stripMargin,
+            assertion = config =>
+              config.userIdCaseSensitivity should be(CaseSensitivity.Disabled)
+          )
+        }
+        "no defined" in {
+          assertDecodingSuccess(
+            yaml = noCustomSettingsYaml,
+            assertion = config =>
+              config.userIdCaseSensitivity should be(CaseSensitivity.Enabled)
+          )
+        }
+      }
+      "be decoded with failure" when {
+        "unknown type" in {
+          assertDecodingFailure(
+            yaml =
+              s"""
+                 | global_settings:
+                 |   username_case_sensitivity: custom
+               """.stripMargin,
+            assertion =
+              error =>
+                error should be(GeneralReadonlyrestSettingsError(Message(
+                  "Unknown username case mapping: 'custom'. Supported: 'case_insensitive', 'case_sensitive'(default).")
+                ))
+          )
+        }
+      }
+    }
+  }
+
+  "A global settings should be able to be loaded from config (in the 'readonlyrest' section level)" when {
     "'prompt_for_basic_auth'" should {
       "be decoded with success" when {
         "enabled" in {

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/GlobalSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/GlobalSettingsTests.scala
@@ -353,6 +353,69 @@ class GlobalSettingsTests extends
     }
   }
 
+  "The deprecated and the new syntax of global settings cannot be mixed" when {
+    "it's 'prompt_for_basic_auth'" in {
+      assertDecodingFailure(
+        yaml =
+          s"""
+             | global_settings:
+             |   prompt_for_basic_auth: true
+             | prompt_for_basic_auth: true
+               """.stripMargin,
+        assertion =
+          error =>
+            error should be(GeneralReadonlyrestSettingsError(Message(
+              "Detected duplicated settings (usage of current and deprecated syntax). You cannot use '.global_settings.prompt_for_basic_auth' together with '.prompt_for_basic_auth'. Pick one syntax."
+            )))
+      )
+    }
+    "it's 'response_if_req_forbidden'" in {
+      assertDecodingFailure(
+        yaml =
+          s"""
+             | response_if_req_forbidden: "forbidden"
+             | global_settings:
+             |   response_if_req_forbidden: "forbidden"
+                """.stripMargin,
+        assertion =
+          error =>
+            error should be(GeneralReadonlyrestSettingsError(Message(
+              "Detected duplicated settings (usage of current and deprecated syntax). You cannot use '.global_settings.response_if_req_forbidden' together with '.response_if_req_forbidden'. Pick one syntax."
+            )))
+      )
+    }
+    "it's 'fls_engine'" in {
+      assertDecodingFailure(
+        yaml =
+          s"""
+             | fls_engine: "es"
+             | global_settings:
+             |   fls_engine: "es"
+                      """.stripMargin,
+        assertion =
+          error =>
+            error should be(GeneralReadonlyrestSettingsError(Message(
+              "Detected duplicated settings (usage of current and deprecated syntax). You cannot use '.global_settings.fls_engine' together with '.fls_engine'. Pick one syntax."
+            )))
+      )
+    }
+    "it's 'username_case_sensitivity'" in {
+      assertDecodingFailure(
+        yaml =
+          s"""
+             | username_case_sensitivity: "case_insensitive"
+             | global_settings:
+             |   username_case_sensitivity: "case_insensitive"
+                            """.stripMargin,
+        assertion =
+          error =>
+            error should be(GeneralReadonlyrestSettingsError(Message(
+              "Detected duplicated settings (usage of current and deprecated syntax). You cannot use '.global_settings.username_case_sensitivity' together with '.username_case_sensitivity'. Pick one syntax."
+            )))
+      )
+    }
+  }
+
   private lazy val noCustomSettingsYaml =
     s"""
        | rules:

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/ImpersonationSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/ImpersonationSettingsTests.scala
@@ -38,7 +38,8 @@ class ImpersonationSettingsTests extends BaseDecoderTest(
       forbiddenRequestMessage = "Forbidden by ReadonlyREST",
       flsEngine = FlsEngine.ES,
       configurationIndex = RorConfigurationIndex(fullIndexName(".readonlyrest")),
-      userIdCaseSensitivity = CaseSensitivity.Enabled
+      userIdCaseSensitivity = CaseSensitivity.Enabled,
+      usersDefinitionDuplicateUsernamesValidationEnabled = true
     ),
     Definitions[ExternalAuthenticationService](Nil),
     Definitions[ProxyAuth](Nil),

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/UsersRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/auth/UsersRuleSettingsTests.scala
@@ -39,7 +39,8 @@ class UsersRuleSettingsTests extends BaseRuleSettingsDecoderTest[UsersRule] {
       forbiddenRequestMessage = "Forbidden",
       flsEngine = FlsEngine.default,
       configurationIndex = RorConfigurationIndex(IndexName.Full(".readonlyrest")),
-      userIdCaseSensitivity = CaseSensitivity.Enabled
+      userIdCaseSensitivity = CaseSensitivity.Enabled,
+      usersDefinitionDuplicateUsernamesValidationEnabled = true
     ),
   )
 

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/elasticsearch/FieldsRuleSettingsTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/elasticsearch/FieldsRuleSettingsTest.scala
@@ -131,8 +131,8 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             yaml =
               """
                 |readonlyrest:
-                |
-                |  fls_engine: "lucene"
+                |  global_settings:
+                |    fls_engine: "lucene"
                 |
                 |  access_control_rules:
                 |
@@ -153,7 +153,8 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
               """
                 |readonlyrest:
                 |
-                |  fls_engine: "es"
+                |  global_settings:
+                |    fls_engine: "es"
                 |
                 |  access_control_rules:
                 |
@@ -277,7 +278,8 @@ class FieldsRuleSettingsTest extends BaseRuleSettingsDecoderTest[FieldsRule] {
             """
               |readonlyrest:
               |
-              |  fls_engine: "something"
+              |  global_settings:
+              |    fls_engine: "something"
               |
               |  access_control_rules:
               |

--- a/eshome/config/readonlyrest.yml
+++ b/eshome/config/readonlyrest.yml
@@ -1,6 +1,7 @@
 readonlyrest:
 
-  prompt_for_basic_auth: false
+  global_settings:
+    prompt_for_basic_auth: false
 
   access_control_rules:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.63.0
-pluginVersion=1.64.0-pre5
+pluginVersion=1.64.0-pre6
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/resources/external_authentication/readonlyrest.yml
+++ b/integration-tests/src/test/resources/external_authentication/readonlyrest.yml
@@ -1,16 +1,12 @@
 readonlyrest:
 
-  # (De)activate plugin
   enable: true
 
-  # HTTP response body in case of forbidden request.
-  # If this is null or omitted, the name of the first violated access control rule is returned (useful for debugging!)
-  response_if_req_forbidden: <h1>Forbidden</h1>
+  global_settings:
+    response_if_req_forbidden: <h1>Forbidden</h1>
 
-  # Default policy is to forbid everything, so let's define a whitelist
   access_control_rules:
 
-  # ES container initializer need this rule to configure ES instance after startup
   - name: "CONTAINER ADMIN"
     type: allow
     auth_key: admin:container

--- a/integration-tests/src/test/resources/field_level_security_engine/readonlyrest_fls_engine_es.yml
+++ b/integration-tests/src/test/resources/field_level_security_engine/readonlyrest_fls_engine_es.yml
@@ -1,6 +1,7 @@
 readonlyrest:
 
-  fls_engine: "es"
+  global_settings:
+    fls_engine: "es"
 
   access_control_rules:
 

--- a/integration-tests/src/test/resources/field_level_security_engine/readonlyrest_fls_engine_es_with_lucene.yml
+++ b/integration-tests/src/test/resources/field_level_security_engine/readonlyrest_fls_engine_es_with_lucene.yml
@@ -1,6 +1,7 @@
 readonlyrest:
 
-  fls_engine: "es_with_lucene"
+  global_settings:
+    fls_engine: "es_with_lucene"
 
   access_control_rules:
 

--- a/integration-tests/src/test/resources/field_level_security_engine/readonlyrest_fls_engine_lucene.yml
+++ b/integration-tests/src/test/resources/field_level_security_engine/readonlyrest_fls_engine_lucene.yml
@@ -1,6 +1,7 @@
 readonlyrest:
 
-  fls_engine: "lucene"
+  global_settings:
+    fls_engine: "lucene"
 
   access_control_rules:
 

--- a/integration-tests/src/test/resources/index_api/free_readonlyrest.yml
+++ b/integration-tests/src/test/resources/index_api/free_readonlyrest.yml
@@ -1,6 +1,7 @@
 readonlyrest:
 
-  prompt_for_basic_auth: true
+  global_settings:
+    prompt_for_basic_auth: true
 
   access_control_rules:
 

--- a/integration-tests/src/test/resources/index_api/nonfree_readonlyrest.yml
+++ b/integration-tests/src/test/resources/index_api/nonfree_readonlyrest.yml
@@ -1,6 +1,7 @@
 readonlyrest:
 
-  prompt_for_basic_auth: false
+  global_settings:
+    prompt_for_basic_auth: false
 
   access_control_rules:
 

--- a/integration-tests/src/test/resources/rev_proxy_groups_provider/readonlyrest.yml
+++ b/integration-tests/src/test/resources/rev_proxy_groups_provider/readonlyrest.yml
@@ -1,13 +1,10 @@
 readonlyrest:
 
-  # HTTP response body in case of forbidden request.
-  # If this is null or omitted, the name of the first violated access control rule is returned (useful for debugging!)
-  response_if_req_forbidden: <h1>Forbidden</h1>
+  global_settings:
+    response_if_req_forbidden: <h1>Forbidden</h1>
 
-  # Default policy is to forbid everything, so let's define a whitelist
   access_control_rules:
 
-  # ES container initializer need this rule to configure ES instance after startup
   - name: "CONTAINER ADMIN"
     type: allow
     auth_key: admin:container


### PR DESCRIPTION
🧐Enhancement (ES) username duplication check in the "users" section of ROR ES settings can be optionally disabled
🧐Enhancement (ES) `readonlyrest.global_settings` in ES ROR settings 

Docs ref: https://github.com/beshu-tech/readonlyrest-docs/pull/259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global setting to enable or disable duplicate username validation in user definitions.
  - Improved error reporting for configuration decoding, including detailed errors for unknown or duplicated settings.

- **Refactor**
  - All global settings (such as prompt for basic auth, response if request forbidden, fls engine, username case sensitivity, and duplicate username detection) must now be placed under a unified global settings section in the configuration files.

- **Bug Fixes**
  - Enhanced handling of configuration keys to prevent conflicts between new and deprecated syntaxes.

- **Documentation**
  - Updated test cases and configuration examples to reflect the new global settings hierarchy and validation behavior.

- **Chores**
  - Updated plugin version to 1.64.0-pre6.
  - Improved .gitignore to exclude all bin directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->