### PR TITLE
Adjust ror-tools tests to ES versions > 9.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.63.0
-pluginVersion=1.64.0-pre8
+pluginVersion=1.64.0-pre9
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/ror-tools/src/test/scala/tech/beshu/ror/tools/RorToolsAppSuite.scala
+++ b/ror-tools/src/test/scala/tech/beshu/ror/tools/RorToolsAppSuite.scala
@@ -373,9 +373,9 @@ class RorToolsAppSuite
            | - otherwise the ES installation is corrupted and ES must be reinstalled
            |Problems:
            | - backup catalog is present, but there is no metadata file
-           | - file x-pack-core-9.0.0.jar was patched by ROR ${metadata.rorVersion}
-           | - file x-pack-ilm-9.0.0.jar was patched by ROR ${metadata.rorVersion}
-           | - file x-pack-security-9.0.0.jar was patched by ROR ${metadata.rorVersion}
+           | - file x-pack-core-$esVersionUsed.jar was patched by ROR ${metadata.rorVersion}
+           | - file x-pack-ilm-$esVersionUsed.jar was patched by ROR ${metadata.rorVersion}
+           | - file x-pack-security-$esVersionUsed.jar was patched by ROR ${metadata.rorVersion}
            |""".stripMargin
       )
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the plugin version identifier to "1.64.0-pre9".

- **Tests**
  - Improved test error messages to display the actual Elasticsearch version used, ensuring clearer and more accurate test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->