### PR TITLE
[RORDEV-1464] fixed: 8.17.6 docker image + consistent method of installing gosu

### DIFF
--- a/es716x/Dockerfile
+++ b/es716x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER elasticsearch
 

--- a/es717x/Dockerfile
+++ b/es717x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER elasticsearch
 

--- a/es80x/Dockerfile
+++ b/es80x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER elasticsearch
 

--- a/es810x/Dockerfile
+++ b/es810x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es811x/Dockerfile
+++ b/es811x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es812x/Dockerfile
+++ b/es812x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es813x/Dockerfile
+++ b/es813x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es814x/Dockerfile
+++ b/es814x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es815x/Dockerfile
+++ b/es815x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es816x/Dockerfile
+++ b/es816x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -9,19 +28,18 @@ ARG ROR_VERSION
 ENV KIBANA_USER_PASS=kibana
 ENV ADMIN_USER_PASS=admin
 
-USER root
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
-
-USER 1000
-
 COPY readonlyrest-${ROR_VERSION}_es${ES_VERSION}.zip /tmp/readonlyrest.zip
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
+USER root
+
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
+
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:///tmp/readonlyrest.zip
+
+USER 1000
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]

--- a/es818x/Dockerfile
+++ b/es818x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es81x/Dockerfile
+++ b/es81x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER elasticsearch
 

--- a/es82x/Dockerfile
+++ b/es82x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER elasticsearch
 

--- a/es83x/Dockerfile
+++ b/es83x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER elasticsearch
 

--- a/es84x/Dockerfile
+++ b/es84x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER elasticsearch
 

--- a/es85x/Dockerfile
+++ b/es85x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es87x/Dockerfile
+++ b/es87x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es88x/Dockerfile
+++ b/es88x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 

--- a/es89x/Dockerfile
+++ b/es89x/Dockerfile
@@ -1,7 +1,26 @@
 ARG ES_VERSION
 ARG ROR_VERSION
 
+FROM alpine:3.21.0 AS builder
+
+ENV GOSU_VERSION=1.17
+RUN set -eux; \
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    # verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all;
+
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+COPY --from=builder /usr/local/bin/gosu /usr/local/bin/gosu
 
 ARG ES_VERSION
 ARG ROR_VERSION
@@ -11,10 +30,9 @@ ENV ADMIN_USER_PASS=admin
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gosu && \
-    rm -rf /var/lib/apt/lists/* && \
-    gosu nobody true
+RUN chmod +x /usr/local/bin/gosu \
+    && gosu --version \
+    && gosu nobody true
 
 USER 1000
 


### PR DESCRIPTION
In this PR:
1. Fixed Docker image creation for ES 8.17.6
2. A consistent method of `gosu` installation for all ES versions