### PR TITLE
[RORDEV-1488] ES startup settings related to loading ROR settings

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/boot/ReadonlyRest.scala
+++ b/core/src/main/scala/tech/beshu/ror/boot/ReadonlyRest.scala
@@ -70,6 +70,7 @@ class ReadonlyRest(coreFactory: CoreFactory,
     val loadingDelay = RorProperties.atStartupRorIndexSettingLoadingDelay(environmentConfig.propertiesProvider)
     val loadingAttemptsCount = RorProperties.atStartupRorIndexSettingsLoadingAttemptsCount(environmentConfig.propertiesProvider)
     val loadingAttemptsInterval = RorProperties.atStartupRorIndexSettingsLoadingAttemptsInterval(environmentConfig.propertiesProvider)
+    if(esConfig.rorIndex.)
     val action = LoadRawRorConfig.load(
       env = esEnv,
       esConfig = esConfig,

--- a/core/src/main/scala/tech/beshu/ror/boot/ReadonlyRest.scala
+++ b/core/src/main/scala/tech/beshu/ror/boot/ReadonlyRest.scala
@@ -70,15 +70,19 @@ class ReadonlyRest(coreFactory: CoreFactory,
     val loadingDelay = RorProperties.atStartupRorIndexSettingLoadingDelay(environmentConfig.propertiesProvider)
     val loadingAttemptsCount = RorProperties.atStartupRorIndexSettingsLoadingAttemptsCount(environmentConfig.propertiesProvider)
     val loadingAttemptsInterval = RorProperties.atStartupRorIndexSettingsLoadingAttemptsInterval(environmentConfig.propertiesProvider)
-    if(esConfig.rorIndex.)
-    val action = LoadRawRorConfig.load(
-      env = esEnv,
-      esConfig = esConfig,
-      configurationIndex = esConfig.rorIndex.index,
-      loadingDelay = loadingDelay,
-      loadingAttemptsCount = loadingAttemptsCount,
-      loadingAttemptsInterval = loadingAttemptsInterval
-    )
+
+    val action =
+      if (esConfig.rorEsLevelSettings.forceLoadRorFromFile) {
+        LoadRawRorConfig.loadFromFile(esEnv.configPath)
+      } else {
+        LoadRawRorConfig.loadFromIndexWithFileFallback(
+          configurationIndex = esConfig.rorIndex.index,
+          loadingDelay = loadingDelay,
+          loadingAttemptsCount = loadingAttemptsCount,
+          loadingAttemptsInterval = loadingAttemptsInterval,
+          fallbackConfigFilePath = esEnv.configPath
+        )
+      }
     runStartingFailureProgram(action)
   }
 
@@ -86,7 +90,7 @@ class ReadonlyRest(coreFactory: CoreFactory,
     val loadingDelay = RorProperties.atStartupRorIndexSettingLoadingDelay(environmentConfig.propertiesProvider)
     val loadingAttemptsCount = RorProperties.atStartupRorIndexSettingsLoadingAttemptsCount(environmentConfig.propertiesProvider)
     val loadingAttemptsInterval = RorProperties.atStartupRorIndexSettingsLoadingAttemptsInterval(environmentConfig.propertiesProvider)
-    val action = LoadRawTestRorConfig.load(
+    val action = LoadRawTestRorConfig.loadFromIndexWithFallback(
       configurationIndex = esConfig.rorIndex.index,
       loadingDelay = loadingDelay,
       indexLoadingAttemptsCount = loadingAttemptsCount,

--- a/core/src/main/scala/tech/beshu/ror/boot/ReadonlyRest.scala
+++ b/core/src/main/scala/tech/beshu/ror/boot/ReadonlyRest.scala
@@ -67,21 +67,21 @@ class ReadonlyRest(coreFactory: CoreFactory,
   }
 
   private def loadRorConfig(esConfig: EsConfig) = {
-    val loadingDelay = RorProperties.atStartupRorIndexSettingLoadingDelay(environmentConfig.propertiesProvider)
-    val loadingAttemptsCount = RorProperties.atStartupRorIndexSettingsLoadingAttemptsCount(environmentConfig.propertiesProvider)
-    val loadingAttemptsInterval = RorProperties.atStartupRorIndexSettingsLoadingAttemptsInterval(environmentConfig.propertiesProvider)
-
     val action =
       if (esConfig.rorEsLevelSettings.forceLoadRorFromFile) {
         LoadRawRorConfig.loadFromFile(esEnv.configPath)
       } else {
-        LoadRawRorConfig.loadFromIndexWithFileFallback(
-          configurationIndex = esConfig.rorIndex.index,
-          loadingDelay = loadingDelay,
-          loadingAttemptsCount = loadingAttemptsCount,
-          loadingAttemptsInterval = loadingAttemptsInterval,
-          fallbackConfigFilePath = esEnv.configPath
-        )
+        val loadingDelay = RorProperties.atStartupRorIndexSettingLoadingDelay(environmentConfig.propertiesProvider)
+        val loadingAttemptsCount = RorProperties.atStartupRorIndexSettingsLoadingAttemptsCount(environmentConfig.propertiesProvider)
+        val loadingAttemptsInterval = RorProperties.atStartupRorIndexSettingsLoadingAttemptsInterval(environmentConfig.propertiesProvider)
+        LoadRawRorConfig
+          .loadFromIndexWithFileFallback(
+            configurationIndex = esConfig.rorIndex.index,
+            loadingDelay = loadingDelay,
+            loadingAttemptsCount = loadingAttemptsCount,
+            loadingAttemptsInterval = loadingAttemptsInterval,
+            fallbackConfigFilePath = esEnv.configPath
+          )
       }
     runStartingFailureProgram(action)
   }
@@ -90,13 +90,14 @@ class ReadonlyRest(coreFactory: CoreFactory,
     val loadingDelay = RorProperties.atStartupRorIndexSettingLoadingDelay(environmentConfig.propertiesProvider)
     val loadingAttemptsCount = RorProperties.atStartupRorIndexSettingsLoadingAttemptsCount(environmentConfig.propertiesProvider)
     val loadingAttemptsInterval = RorProperties.atStartupRorIndexSettingsLoadingAttemptsInterval(environmentConfig.propertiesProvider)
-    val action = LoadRawTestRorConfig.loadFromIndexWithFallback(
-      configurationIndex = esConfig.rorIndex.index,
-      loadingDelay = loadingDelay,
-      indexLoadingAttemptsCount = loadingAttemptsCount,
-      indexLoadingAttemptsInterval = loadingAttemptsInterval,
-      fallbackConfig = notSetTestRorConfig
-    )
+    val action = LoadRawTestRorConfig
+      .loadFromIndexWithFallback(
+        configurationIndex = esConfig.rorIndex.index,
+        loadingDelay = loadingDelay,
+        indexLoadingAttemptsCount = loadingAttemptsCount,
+        indexLoadingAttemptsInterval = loadingAttemptsInterval,
+        fallbackConfig = notSetTestRorConfig
+      )
     EitherT.right(runTestProgram(action))
   }
 

--- a/core/src/main/scala/tech/beshu/ror/boot/RorInstance.scala
+++ b/core/src/main/scala/tech/beshu/ror/boot/RorInstance.scala
@@ -55,7 +55,7 @@ class RorInstance private(boot: ReadonlyRest,
   logger.info("ReadonlyREST was loaded ...")
   private val configsReloadTask = mode match {
     case Mode.WithPeriodicIndexCheck =>
-      RorProperties.rorIndexSettingReloadInterval(environmentConfig.propertiesProvider) match {
+      RorProperties.rorIndexSettingsReloadInterval(environmentConfig.propertiesProvider) match {
         case RefreshInterval.Disabled =>
           logger.info(s"[CLUSTERWIDE SETTINGS] Scheduling in-index settings check disabled")
           Cancelable.empty

--- a/core/src/main/scala/tech/beshu/ror/configuration/ConfigLoading.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/ConfigLoading.scala
@@ -21,7 +21,7 @@ import tech.beshu.ror.accesscontrol.domain.RorConfigurationIndex
 import tech.beshu.ror.configuration.loader.LoadedRorConfig
 import tech.beshu.ror.configuration.loader.LoadedRorConfig.{FileConfig, ForcedFileConfig, IndexConfig}
 import tech.beshu.ror.es.EsEnv
-import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
+import tech.beshu.ror.utils.DurationOps.NonNegativeFiniteDuration
 
 import java.nio.file.Path
 
@@ -38,12 +38,12 @@ object ConfigLoading {
       extends LoadConfigAction[ErrorOr[ForcedFileConfig[RawRorConfig]]]
     final case class LoadRorConfigFromFile(path: Path)
       extends LoadConfigAction[ErrorOr[FileConfig[RawRorConfig]]]
-    final case class LoadRorConfigFromIndex(index: RorConfigurationIndex, loadingDelay: Option[PositiveFiniteDuration])
+    final case class LoadRorConfigFromIndex(index: RorConfigurationIndex, loadingDelay: NonNegativeFiniteDuration)
       extends LoadConfigAction[IndexErrorOr[IndexConfig[RawRorConfig]]]
   }
 
   def loadRorConfigFromIndex(index: RorConfigurationIndex,
-                             loadingDelay: Option[PositiveFiniteDuration]): LoadRorConfig[IndexErrorOr[IndexConfig[RawRorConfig]]] =
+                             loadingDelay: NonNegativeFiniteDuration): LoadRorConfig[IndexErrorOr[IndexConfig[RawRorConfig]]] =
     Free.liftF(LoadConfigAction.LoadRorConfigFromIndex(index, loadingDelay))
 
   def loadRorConfigFromFile(path: Path): LoadRorConfig[ErrorOr[FileConfig[RawRorConfig]]] =

--- a/core/src/main/scala/tech/beshu/ror/configuration/ConfigLoading.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/ConfigLoading.scala
@@ -21,6 +21,7 @@ import tech.beshu.ror.accesscontrol.domain.RorConfigurationIndex
 import tech.beshu.ror.configuration.loader.LoadedRorConfig
 import tech.beshu.ror.configuration.loader.LoadedRorConfig.{FileConfig, ForcedFileConfig, IndexConfig}
 import tech.beshu.ror.es.EsEnv
+import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
 
 import java.nio.file.Path
 
@@ -31,14 +32,19 @@ object ConfigLoading {
 
   sealed trait LoadConfigAction[A]
   object LoadConfigAction {
-    final case class LoadEsConfig(env: EsEnv) extends LoadConfigAction[ErrorOr[EsConfig]]
-    final case class ForceLoadRorConfigFromFile(path: Path) extends LoadConfigAction[ErrorOr[ForcedFileConfig[RawRorConfig]]]
-    final case class LoadRorConfigFromFile(path: Path) extends LoadConfigAction[ErrorOr[FileConfig[RawRorConfig]]]
-    final case class LoadRorConfigFromIndex(index: RorConfigurationIndex) extends LoadConfigAction[IndexErrorOr[IndexConfig[RawRorConfig]]]
+    final case class LoadEsConfig(env: EsEnv)
+      extends LoadConfigAction[ErrorOr[EsConfig]]
+    final case class ForceLoadRorConfigFromFile(path: Path)
+      extends LoadConfigAction[ErrorOr[ForcedFileConfig[RawRorConfig]]]
+    final case class LoadRorConfigFromFile(path: Path)
+      extends LoadConfigAction[ErrorOr[FileConfig[RawRorConfig]]]
+    final case class LoadRorConfigFromIndex(index: RorConfigurationIndex, loadingDelay: Option[PositiveFiniteDuration])
+      extends LoadConfigAction[IndexErrorOr[IndexConfig[RawRorConfig]]]
   }
 
-  def loadRorConfigFromIndex(index: RorConfigurationIndex): LoadRorConfig[IndexErrorOr[IndexConfig[RawRorConfig]]] =
-    Free.liftF(LoadConfigAction.LoadRorConfigFromIndex(index))
+  def loadRorConfigFromIndex(index: RorConfigurationIndex,
+                             loadingDelay: Option[PositiveFiniteDuration]): LoadRorConfig[IndexErrorOr[IndexConfig[RawRorConfig]]] =
+    Free.liftF(LoadConfigAction.LoadRorConfigFromIndex(index, loadingDelay))
 
   def loadRorConfigFromFile(path: Path): LoadRorConfig[ErrorOr[FileConfig[RawRorConfig]]] =
     Free.liftF(LoadConfigAction.LoadRorConfigFromFile(path))

--- a/core/src/main/scala/tech/beshu/ror/configuration/RorProperties.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/RorProperties.scala
@@ -18,6 +18,8 @@ package tech.beshu.ror.configuration
 
 import better.files.File
 import cats.Show
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.NonNegative
 import eu.timepit.refined.types.string.NonEmptyString
 import org.apache.logging.log4j.scala.Logging
 import squants.information.{Information, Megabytes}
@@ -36,31 +38,49 @@ object RorProperties extends Logging {
   object defaults {
     val refreshInterval: PositiveFiniteDuration = (5 second).toRefinedPositiveUnsafe
     val loadingDelay: PositiveFiniteDuration = (5 second).toRefinedPositiveUnsafe
+    val loadingAttemptsCount: Int Refined NonNegative = Refined.unsafeApply(5)
+    val loadingAttemptsInterval: PositiveFiniteDuration = (5 second).toRefinedPositiveUnsafe
     val rorSettingsMaxSize: Information = Megabytes(3)
   }
 
   object keys {
-    val rorConfig: NonEmptyString = nes("com.readonlyrest.settings.file.path")
-    val refreshInterval: NonEmptyString = nes("com.readonlyrest.settings.refresh.interval")
-    val loadingDelay: NonEmptyString = nes("com.readonlyrest.settings.loading.delay")
+    val rorSettingsFilePath: NonEmptyString = nes("com.readonlyrest.settings.file.path")
+    val rorSettingsRefreshInterval: NonEmptyString = nes("com.readonlyrest.settings.refresh.interval")
+    val startupIndexLoadingDelay: NonEmptyString = nes("com.readonlyrest.settings.loading.delay")
+    val startupIndexLoadingAttemptsInterval: NonEmptyString = nes("com.readonlyrest.settings.loading.attempts.interval")
+    val startupIndexLoadingAttemptsCount: NonEmptyString = nes("com.readonlyrest.settings.loading.attempts.count")
     val rorSettingsMaxSize: NonEmptyString = nes("com.readonlyrest.settings.maxSize")
   }
 
-  def rorConfigCustomFile(implicit propertiesProvider: PropertiesProvider): Option[File] =
+  def rorSettingsCustomFile(implicit propertiesProvider: PropertiesProvider): Option[File] =
     propertiesProvider
-      .getProperty(PropName(keys.rorConfig))
+      .getProperty(PropName(keys.rorSettingsFilePath))
       .map(File(_))
 
-  def rorIndexSettingReloadInterval(implicit propertiesProvider: PropertiesProvider): RefreshInterval =
+  def rorIndexSettingsReloadInterval(implicit propertiesProvider: PropertiesProvider): RefreshInterval =
     getProperty(
-      keys.refreshInterval,
+      keys.rorSettingsRefreshInterval,
       str => toRefreshInterval(str),
       RefreshInterval.Enabled(defaults.refreshInterval)
     )
 
-  def rorIndexSettingLoadingDelay(implicit propertiesProvider: PropertiesProvider): LoadingDelay =
+  def atStartupRorIndexSettingsLoadingAttemptsInterval(implicit propertiesProvider: PropertiesProvider): LoadingAttemptsInterval =
     getProperty(
-      keys.loadingDelay,
+      keys.startupIndexLoadingAttemptsInterval,
+      str => toLoadingAttemptsInterval(str),
+      LoadingAttemptsInterval(defaults.loadingAttemptsInterval)
+    )
+
+  def atStartupRorIndexSettingsLoadingAttemptsCount(implicit propertiesProvider: PropertiesProvider): LoadingAttemptsCount =
+    getProperty(
+      keys.startupIndexLoadingAttemptsCount,
+      str => toLoadingAttempts(str),
+      LoadingAttemptsCount(defaults.loadingAttemptsCount)
+    )
+
+  def atStartupRorIndexSettingLoadingDelay(implicit propertiesProvider: PropertiesProvider): LoadingDelay =
+    getProperty(
+      keys.startupIndexLoadingDelay,
       str => toLoadingDelay(str),
       LoadingDelay(defaults.refreshInterval)
     )
@@ -104,30 +124,42 @@ object RorProperties extends Logging {
     case None => RefreshInterval.Disabled
   }
 
+  private def toLoadingAttemptsInterval(value: String): Try[LoadingAttemptsInterval] = toPositiveFiniteDuration(value).map {
+    case Some(value) => LoadingAttemptsInterval(value)
+    case None => LoadingAttemptsInterval(defaults.loadingAttemptsInterval)
+  }
+
   private def toLoadingDelay(value: String): Try[LoadingDelay] = toPositiveFiniteDuration(value).map {
     case Some(value) => LoadingDelay(value)
     case None => LoadingDelay(defaults.loadingDelay)
   }
+
+  private def toLoadingAttempts(value: String): Try[LoadingAttemptsCount] = toNonNegativeInt(value).map(LoadingAttemptsCount.apply)
 
   private def toPositiveFiniteDuration(value: String): Try[Option[PositiveFiniteDuration]] =
     toPositiveInt(value).map(_.map(_.toLong.seconds.toRefinedPositiveUnsafe))
 
   private def toPositiveInt(value: String): Try[Option[Int]] = Try {
     Try(Integer.valueOf(value)) match {
-      case Success(interval) if interval == 0 => None
-      case Success(interval) if interval > 0 => Some(interval)
+      case Success(int) if int == 0 => None
+      case Success(int) if int > 0 => Some(int)
       case Success(_) | Failure(_) => throw new IllegalArgumentException(s"Cannot convert '${value.show}' to positive integer")
     }
   }
 
-  final case class LoadingDelay(duration: PositiveFiniteDuration)
+  private def toNonNegativeInt(value: String): Try[Int Refined NonNegative] = Try {
+    Try(Integer.valueOf(value)) match {
+      case Success(int) if int > 0 => Refined.unsafeApply(int)
+      case Success(_) | Failure(_) => throw new IllegalArgumentException(s"Cannot convert '${value.show}' to non-negative integer")
+    }
+  }
 
+  final case class LoadingDelay(duration: PositiveFiniteDuration) extends AnyVal
   object LoadingDelay {
-    implicit val showLoadingDelay: Show[LoadingDelay] = Show[FiniteDuration].contramap(_.duration.value)
+    implicit val show: Show[LoadingDelay] = Show[FiniteDuration].contramap(_.duration.value)
   }
 
   sealed trait RefreshInterval
-
   object RefreshInterval {
     case object Disabled extends RefreshInterval
 
@@ -137,5 +169,19 @@ object RorProperties extends Logging {
       case Disabled => "0 sec"
       case Enabled(interval) => interval.value.toString()
     }
+  }
+
+  final case class LoadingAttemptsCount(value: Int Refined NonNegative) extends AnyVal
+  object LoadingAttemptsCount {
+    def unsafeFrom(value: Int): LoadingAttemptsCount = LoadingAttemptsCount(Refined.unsafeApply(value))
+
+    val zero: LoadingAttemptsCount = LoadingAttemptsCount.unsafeFrom(0)
+
+    implicit val show: Show[LoadingAttemptsCount] = Show[Int].contramap(_.value.value)
+  }
+
+  final case class LoadingAttemptsInterval(value: PositiveFiniteDuration) extends AnyVal
+  object LoadingAttemptsInterval {
+    implicit val show: Show[LoadingAttemptsInterval] = Show[FiniteDuration].contramap(_.value.value)
   }
 }

--- a/core/src/main/scala/tech/beshu/ror/configuration/TestConfigLoading.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/TestConfigLoading.scala
@@ -19,6 +19,7 @@ package tech.beshu.ror.configuration
 import cats.free.Free
 import tech.beshu.ror.accesscontrol.domain.RorConfigurationIndex
 import tech.beshu.ror.configuration.loader.LoadedTestRorConfig
+import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
 
 object TestConfigLoading {
   type IndexErrorOr[A] = LoadedTestRorConfig.LoadingIndexError Either A
@@ -26,11 +27,12 @@ object TestConfigLoading {
 
   sealed trait LoadTestConfigAction[A]
   object LoadTestConfigAction {
-    final case class LoadRorConfigFromIndex(index: RorConfigurationIndex)
+    final case class LoadRorConfigFromIndex(index: RorConfigurationIndex, loadingDelay: Option[PositiveFiniteDuration])
       extends LoadTestConfigAction[IndexErrorOr[LoadedTestRorConfig.IndexConfig[TestRorConfig]]]
   }
 
-  def loadRorConfigFromIndex(index: RorConfigurationIndex): LoadTestRorConfig[IndexErrorOr[LoadedTestRorConfig.IndexConfig[TestRorConfig]]] =
-    Free.liftF(LoadTestConfigAction.LoadRorConfigFromIndex(index))
+  def loadRorConfigFromIndex(index: RorConfigurationIndex,
+                             loadingDelay: Option[PositiveFiniteDuration]): LoadTestRorConfig[IndexErrorOr[LoadedTestRorConfig.IndexConfig[TestRorConfig]]] =
+    Free.liftF(LoadTestConfigAction.LoadRorConfigFromIndex(index, loadingDelay))
 
 }

--- a/core/src/main/scala/tech/beshu/ror/configuration/TestConfigLoading.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/TestConfigLoading.scala
@@ -19,7 +19,7 @@ package tech.beshu.ror.configuration
 import cats.free.Free
 import tech.beshu.ror.accesscontrol.domain.RorConfigurationIndex
 import tech.beshu.ror.configuration.loader.LoadedTestRorConfig
-import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
+import tech.beshu.ror.utils.DurationOps.NonNegativeFiniteDuration
 
 object TestConfigLoading {
   type IndexErrorOr[A] = LoadedTestRorConfig.LoadingIndexError Either A
@@ -27,12 +27,12 @@ object TestConfigLoading {
 
   sealed trait LoadTestConfigAction[A]
   object LoadTestConfigAction {
-    final case class LoadRorConfigFromIndex(index: RorConfigurationIndex, loadingDelay: Option[PositiveFiniteDuration])
+    final case class LoadRorConfigFromIndex(index: RorConfigurationIndex, loadingDelay: NonNegativeFiniteDuration)
       extends LoadTestConfigAction[IndexErrorOr[LoadedTestRorConfig.IndexConfig[TestRorConfig]]]
   }
 
   def loadRorConfigFromIndex(index: RorConfigurationIndex,
-                             loadingDelay: Option[PositiveFiniteDuration]): LoadTestRorConfig[IndexErrorOr[LoadedTestRorConfig.IndexConfig[TestRorConfig]]] =
+                             loadingDelay: NonNegativeFiniteDuration): LoadTestRorConfig[IndexErrorOr[LoadedTestRorConfig.IndexConfig[TestRorConfig]]] =
     Free.liftF(LoadTestConfigAction.LoadRorConfigFromIndex(index, loadingDelay))
 
 }

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/ConfigLoadingInterpreter.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/ConfigLoadingInterpreter.scala
@@ -31,9 +31,7 @@ import tech.beshu.ror.configuration.loader.FileConfigLoader.FileConfigError
 import tech.beshu.ror.configuration.loader.LoadedRorConfig.*
 import tech.beshu.ror.configuration.{ConfigLoading, EnvironmentConfig, EsConfig}
 import tech.beshu.ror.implicits.*
-import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
-
-import scala.concurrent.duration.Duration
+import tech.beshu.ror.utils.DurationOps.NonNegativeFiniteDuration
 
 object ConfigLoadingInterpreter extends Logging {
 
@@ -102,11 +100,11 @@ object ConfigLoadingInterpreter extends Logging {
 
   private def loadFromIndex[A](indexConfigManager: IndexConfigManager,
                                index: RorConfigurationIndex,
-                               loadingDelay: Option[PositiveFiniteDuration]) = {
+                               loadingDelay: NonNegativeFiniteDuration) = {
     EitherT {
       indexConfigManager
         .load(index)
-        .delayExecution(loadingDelay.map(_.value).getOrElse(Duration.Zero))
+        .delayExecution(loadingDelay.value)
     }
   }
 

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/FileConfigLoader.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/FileConfigLoader.scala
@@ -36,7 +36,7 @@ class FileConfigLoader(esConfigPath: Path)
   private implicit val propertiesProvider: PropertiesProvider = environmentConfig.propertiesProvider
   
   def rawConfigFile: File = {
-    RorProperties.rorConfigCustomFile match {
+    RorProperties.rorSettingsCustomFile match {
       case Some(customRorFile) => customRorFile
       case None => File(s"${esConfigPath.toAbsolutePath}/readonlyrest.yml")
     }

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawRorConfig.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawRorConfig.scala
@@ -19,12 +19,14 @@ package tech.beshu.ror.configuration.loader
 import cats.free.Free
 import tech.beshu.ror.accesscontrol.domain.RorConfigurationIndex
 import tech.beshu.ror.configuration.ConfigLoading.*
+import tech.beshu.ror.configuration.RawRorConfig
 import tech.beshu.ror.configuration.RorProperties.{LoadingAttemptsCount, LoadingAttemptsInterval, LoadingDelay}
 import tech.beshu.ror.configuration.loader.LoadedRorConfig.FileConfig
-import tech.beshu.ror.configuration.RawRorConfig
-import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
+import tech.beshu.ror.utils.DurationOps.{NonNegativeFiniteDuration, RefinedDurationOps}
 
 import java.nio.file.Path
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
 
 object LoadRawRorConfig {
 
@@ -37,8 +39,7 @@ object LoadRawRorConfig {
                                     fallbackConfigFilePath: Path): LoadRorConfig[LoadResult] = {
     attemptLoadingConfigFromIndex(
       index = configurationIndex,
-      currentDelay = None,
-      delay = loadingDelay,
+      currentDelay = loadingDelay.value,
       attemptsCount = loadingAttemptsCount,
       attemptsInterval = loadingAttemptsInterval,
       fallback = loadRorConfigFromFile(fallbackConfigFilePath)
@@ -53,7 +54,7 @@ object LoadRawRorConfig {
 
   def loadFromIndex(configurationIndex: RorConfigurationIndex): LoadRorConfig[LoadResult] = {
     for {
-      result <- loadRorConfigFromIndex(configurationIndex, loadingDelay = None)
+      result <- loadRorConfigFromIndex(configurationIndex, loadingDelay = (0 seconds).toRefinedNonNegativeUnsafe)
       rawRorConfig <- result match {
         case Left(LoadedRorConfig.IndexNotExist) =>
           Free.pure[LoadConfigAction, LoadResult](Left(LoadedRorConfig.IndexNotExist))
@@ -68,8 +69,7 @@ object LoadRawRorConfig {
   }
 
   private def attemptLoadingConfigFromIndex(index: RorConfigurationIndex,
-                                            currentDelay: Option[PositiveFiniteDuration],
-                                            delay: LoadingDelay,
+                                            currentDelay: NonNegativeFiniteDuration,
                                             attemptsCount: LoadingAttemptsCount,
                                             attemptsInterval: LoadingAttemptsInterval,
                                             fallback: LoadRorConfig[ErrorOr[FileConfig[RawRorConfig]]]): LoadRorConfig[LoadResult] = {
@@ -83,8 +83,7 @@ object LoadRawRorConfig {
             case Left(LoadedRorConfig.IndexNotExist) =>
               Free.defer(attemptLoadingConfigFromIndex(
                 index = index,
-                currentDelay = Some(delay.duration),
-                delay = delay,
+                currentDelay = attemptsInterval.value,
                 attemptsCount = LoadingAttemptsCount.unsafeFrom(attemptsCount - 1),
                 attemptsInterval = attemptsInterval,
                 fallback = fallback

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawRorConfig.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawRorConfig.scala
@@ -48,8 +48,8 @@ object LoadRawRorConfig {
 
   def loadFromFile(configFilePath: Path): LoadRorConfig[LoadResult] = {
     for {
-      loadedFileOrIndex <- forceLoadRorConfigFromFile(configFilePath)
-    } yield loadedFileOrIndex
+      loadedConfig <- forceLoadRorConfigFromFile(configFilePath)
+    } yield loadedConfig
   }
 
   def loadFromIndex(configurationIndex: RorConfigurationIndex): LoadRorConfig[LoadResult] = {

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawRorConfig.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawRorConfig.scala
@@ -21,7 +21,7 @@ import tech.beshu.ror.accesscontrol.domain.RorConfigurationIndex
 import tech.beshu.ror.configuration.ConfigLoading.*
 import tech.beshu.ror.configuration.RorProperties.{LoadingAttemptsCount, LoadingAttemptsInterval, LoadingDelay}
 import tech.beshu.ror.configuration.loader.LoadedRorConfig.FileConfig
-import tech.beshu.ror.configuration.{EsConfig, RawRorConfig}
+import tech.beshu.ror.configuration.RawRorConfig
 import tech.beshu.ror.es.EsEnv
 import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
 
@@ -30,13 +30,13 @@ object LoadRawRorConfig {
   type LoadResult = ErrorOr[LoadedRorConfig[RawRorConfig]]
 
   def load(env: EsEnv,
-           esConfig: EsConfig,
+           forceLoadRorFromFile: Boolean,
            configurationIndex: RorConfigurationIndex,
            loadingDelay: LoadingDelay,
            loadingAttemptsCount: LoadingAttemptsCount,
            loadingAttemptsInterval: LoadingAttemptsInterval): LoadRorConfig[LoadResult] = {
     for {
-      loadedFileOrIndex <- if (esConfig.rorEsLevelSettings.forceLoadRorFromFile) {
+      loadedFileOrIndex <- if (forceLoadRorFromFile) {
         forceLoadRorConfigFromFile(env.configPath)
       } else {
         attemptLoadingConfigFromIndex(
@@ -48,6 +48,12 @@ object LoadRawRorConfig {
           fallback = loadRorConfigFromFile(env.configPath)
         )
       }
+    } yield loadedFileOrIndex
+  }
+
+  def loadFromFile(env: EsEnv): LoadRorConfig[LoadResult] = {
+    for {
+      loadedFileOrIndex <- forceLoadRorConfigFromFile(env.configPath)
     } yield loadedFileOrIndex
   }
 

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawTestRorConfig.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawTestRorConfig.scala
@@ -21,7 +21,7 @@ import tech.beshu.ror.accesscontrol.domain.RorConfigurationIndex
 import tech.beshu.ror.configuration.RorProperties.{LoadingAttemptsCount, LoadingAttemptsInterval, LoadingDelay}
 import tech.beshu.ror.configuration.TestConfigLoading.*
 import tech.beshu.ror.configuration.TestRorConfig
-import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
+import tech.beshu.ror.utils.DurationOps.NonNegativeFiniteDuration
 
 object LoadRawTestRorConfig {
 
@@ -32,8 +32,7 @@ object LoadRawTestRorConfig {
                                 fallbackConfig: TestRorConfig): LoadTestRorConfig[IndexErrorOr[LoadedTestRorConfig[TestRorConfig]]] = {
     attemptLoadingConfigFromIndex(
       index = configurationIndex,
-      currentDelay = None,
-      delay = loadingDelay,
+      currentDelay = loadingDelay.value,
       attemptsCount = indexLoadingAttemptsCount,
       attemptsInterval = indexLoadingAttemptsInterval,
       fallback = fallbackConfig
@@ -41,8 +40,7 @@ object LoadRawTestRorConfig {
   }
 
   private def attemptLoadingConfigFromIndex(index: RorConfigurationIndex,
-                                            currentDelay: Option[PositiveFiniteDuration],
-                                            delay: LoadingDelay,
+                                            currentDelay: NonNegativeFiniteDuration,
                                             attemptsCount: LoadingAttemptsCount,
                                             attemptsInterval: LoadingAttemptsInterval,
                                             fallback: TestRorConfig): LoadTestRorConfig[IndexErrorOr[LoadedTestRorConfig[TestRorConfig]]] = {
@@ -58,8 +56,7 @@ object LoadRawTestRorConfig {
             case Left(LoadedTestRorConfig.IndexNotExist) =>
               Free.defer(attemptLoadingConfigFromIndex(
                 index = index,
-                currentDelay = Some(delay.duration),
-                delay = delay,
+                currentDelay = attemptsInterval.value,
                 attemptsCount = LoadingAttemptsCount.unsafeFrom(attemptsCount - 1),
                 attemptsInterval = attemptsInterval,
                 fallback = fallback

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawTestRorConfig.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/LoadRawTestRorConfig.scala
@@ -25,11 +25,11 @@ import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
 
 object LoadRawTestRorConfig {
 
-  def load(configurationIndex: RorConfigurationIndex,
-           loadingDelay: LoadingDelay,
-           indexLoadingAttemptsCount: LoadingAttemptsCount,
-           indexLoadingAttemptsInterval: LoadingAttemptsInterval,
-           fallbackConfig: TestRorConfig): LoadTestRorConfig[IndexErrorOr[LoadedTestRorConfig[TestRorConfig]]] = {
+  def loadFromIndexWithFallback(configurationIndex: RorConfigurationIndex,
+                                loadingDelay: LoadingDelay,
+                                indexLoadingAttemptsCount: LoadingAttemptsCount,
+                                indexLoadingAttemptsInterval: LoadingAttemptsInterval,
+                                fallbackConfig: TestRorConfig): LoadTestRorConfig[IndexErrorOr[LoadedTestRorConfig[TestRorConfig]]] = {
     attemptLoadingConfigFromIndex(
       index = configurationIndex,
       currentDelay = None,

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/TestConfigLoadingInterpreter.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/TestConfigLoadingInterpreter.scala
@@ -28,9 +28,7 @@ import tech.beshu.ror.configuration.loader.ConfigLoader.ConfigLoaderError.{Parsi
 import tech.beshu.ror.configuration.loader.LoadedTestRorConfig.*
 import tech.beshu.ror.configuration.{TestConfigLoading, TestRorConfig}
 import tech.beshu.ror.implicits.*
-import tech.beshu.ror.utils.DurationOps.PositiveFiniteDuration
-
-import scala.concurrent.duration.Duration
+import tech.beshu.ror.utils.DurationOps.NonNegativeFiniteDuration
 
 object TestConfigLoadingInterpreter extends Logging {
 
@@ -69,11 +67,11 @@ object TestConfigLoadingInterpreter extends Logging {
 
   private def loadFromIndex(indexConfigManager: IndexTestConfigManager,
                             index: RorConfigurationIndex,
-                            loadingDelay: Option[PositiveFiniteDuration]) = {
+                            loadingDelay: NonNegativeFiniteDuration) = {
     EitherT {
       indexConfigManager
         .load(index)
-        .delayExecution(loadingDelay.map(_.value).getOrElse(Duration.Zero))
+        .delayExecution(loadingDelay.value)
     }
   }
 

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/distributed/RawRorConfigLoadingAction.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/distributed/RawRorConfigLoadingAction.scala
@@ -25,12 +25,12 @@ import tech.beshu.ror.es.{EsEnv, IndexJsonContentService}
 
 object RawRorConfigLoadingAction {
 
-  def load(env: EsEnv, indexJsonContentService: IndexJsonContentService)
-          (implicit environmentConfig: EnvironmentConfig): Task[Either[LoadedRorConfig.Error, LoadedRorConfig[RawRorConfig]]] = {
+  def loadFromIndex(env: EsEnv, indexJsonContentService: IndexJsonContentService)
+                   (implicit environmentConfig: EnvironmentConfig): Task[Either[LoadedRorConfig.Error, LoadedRorConfig[RawRorConfig]]] = {
     val compiler = ConfigLoadingInterpreter.create(new IndexConfigManager(indexJsonContentService))
     (for {
       esConfig <- EitherT(ConfigLoading.loadEsConfig(env))
-      loadedConfig <- EitherT(LoadRawRorConfig.loadOnce(esConfig.rorIndex.index))
+      loadedConfig <- EitherT(LoadRawRorConfig.loadFromIndex(esConfig.rorIndex.index))
     } yield loadedConfig).value.foldMap(compiler)
   }
 

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/distributed/RawRorConfigLoadingAction.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/distributed/RawRorConfigLoadingAction.scala
@@ -20,20 +20,17 @@ import cats.data.EitherT
 import monix.eval.Task
 import tech.beshu.ror.configuration.index.IndexConfigManager
 import tech.beshu.ror.configuration.loader.{ConfigLoadingInterpreter, LoadRawRorConfig, LoadedRorConfig}
-import tech.beshu.ror.configuration.{ConfigLoading, EnvironmentConfig, RawRorConfig, RorProperties}
+import tech.beshu.ror.configuration.{ConfigLoading, EnvironmentConfig, RawRorConfig}
 import tech.beshu.ror.es.{EsEnv, IndexJsonContentService}
 
 object RawRorConfigLoadingAction {
 
   def load(env: EsEnv, indexJsonContentService: IndexJsonContentService)
           (implicit environmentConfig: EnvironmentConfig): Task[Either[LoadedRorConfig.Error, LoadedRorConfig[RawRorConfig]]] = {
-    val compiler = ConfigLoadingInterpreter.create(
-      new IndexConfigManager(indexJsonContentService),
-      RorProperties.rorIndexSettingLoadingDelay(environmentConfig.propertiesProvider)
-    )
+    val compiler = ConfigLoadingInterpreter.create(new IndexConfigManager(indexJsonContentService))
     (for {
       esConfig <- EitherT(ConfigLoading.loadEsConfig(env))
-      loadedConfig <- EitherT(LoadRawRorConfig.load(env, esConfig, esConfig.rorIndex.index))
+      loadedConfig <- EitherT(LoadRawRorConfig.loadOnce(esConfig.rorIndex.index))
     } yield loadedConfig).value.foldMap(compiler)
   }
 

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/distributed/internode/dto/LoadedConfigErrorDto.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/distributed/internode/dto/LoadedConfigErrorDto.scala
@@ -63,6 +63,7 @@ object LoadedConfigErrorDto {
       CannotUseRorConfigurationWhenXpackSecurityIsEnabledDTO.create(o)
     case o: LoadedRorConfig.IndexParsingError => IndexParsingErrorDTO.create(o)
     case _: LoadedRorConfig.IndexUnknownStructure.type => IndexUnknownStructureDTO
+    case _: LoadedRorConfig.IndexNotExist.type => IndexUnknownStructureDTO
   }
 
   def fromDto(o: LoadedConfigErrorDto): LoadedRorConfig.Error = o match {

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/distributed/internode/dto/LoadedConfigErrorDto.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/distributed/internode/dto/LoadedConfigErrorDto.scala
@@ -42,6 +42,8 @@ object LoadedConfigErrorDto {
         derivedEncoderWithType[IndexParsingErrorDTO]("FileParsingErrorDTO")(dto)
       case IndexUnknownStructureDTO =>
         derivedEncoderWithType[IndexUnknownStructureDTO.type]("IndexUnknownStructureDTO")(IndexUnknownStructureDTO)
+      case IndexNotExistDTO =>
+        derivedEncoderWithType[IndexNotExistDTO.type]("IndexNotExistDTO")(IndexNotExistDTO)
     },
     decoders = Map(
       "FileParsingErrorDTO" -> derivedDecoderOfSubtype[LoadedConfigErrorDto, FileParsingErrorDTO],
@@ -51,6 +53,7 @@ object LoadedConfigErrorDto {
       "CannotUseRorConfigurationWhenXpackSecurityIsEnabledDTO" -> derivedDecoderOfSubtype[LoadedConfigErrorDto, CannotUseRorConfigurationWhenXpackSecurityIsEnabledDTO],
       "FileParsingErrorDTO" -> derivedDecoderOfSubtype[LoadedConfigErrorDto, FileParsingErrorDTO],
       "IndexUnknownStructureDTO" -> derivedDecoderOfSubtype[LoadedConfigErrorDto, IndexUnknownStructureDTO.type],
+      "IndexNotExistDTO" -> derivedDecoderOfSubtype[LoadedConfigErrorDto, IndexNotExistDTO.type],
     )
   )
 
@@ -63,7 +66,7 @@ object LoadedConfigErrorDto {
       CannotUseRorConfigurationWhenXpackSecurityIsEnabledDTO.create(o)
     case o: LoadedRorConfig.IndexParsingError => IndexParsingErrorDTO.create(o)
     case _: LoadedRorConfig.IndexUnknownStructure.type => IndexUnknownStructureDTO
-    case _: LoadedRorConfig.IndexNotExist.type => IndexUnknownStructureDTO
+    case _: LoadedRorConfig.IndexNotExist.type => IndexNotExistDTO
   }
 
   def fromDto(o: LoadedConfigErrorDto): LoadedRorConfig.Error = o match {
@@ -75,6 +78,7 @@ object LoadedConfigErrorDto {
       CannotUseRorConfigurationWhenXpackSecurityIsEnabledDTO.fromDto(o)
     case o: IndexParsingErrorDTO => IndexParsingErrorDTO.fromDto(o)
     case _: IndexUnknownStructureDTO.type => LoadedRorConfig.IndexUnknownStructure
+    case _: IndexNotExistDTO.type  => LoadedRorConfig.IndexNotExist
   }
 
   final case class FileParsingErrorDTO(message: String) extends LoadedConfigErrorDto
@@ -173,8 +177,16 @@ object LoadedConfigErrorDto {
 
   case object IndexUnknownStructureDTO extends LoadedConfigErrorDto {
     implicit lazy val codecIndexUnknownStructureDto: Codec[IndexUnknownStructureDTO.type] = {
-      val enc: Encoder[IndexUnknownStructureDTO.type] = Encoder.encodeString.contramap(_ => "index_not_exist")
+      val enc = Encoder.encodeString.contramap[IndexUnknownStructureDTO.type](_ => "unknown_structure")
       val dec = Decoder.decodeString.map(_ => IndexUnknownStructureDTO)
+      Codec.from(dec, enc)
+    }
+  }
+
+  case object IndexNotExistDTO extends LoadedConfigErrorDto {
+    implicit lazy val codecIndexNotFoundDto: Codec[IndexNotExistDTO.type] = {
+      val enc = Encoder.encodeString.contramap[IndexNotExistDTO.type](_ => "index_not_exist")
+      val dec = Decoder.decodeString.map(_ => IndexNotExistDTO)
       Codec.from(dec, enc)
     }
   }

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/domain.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/domain.scala
@@ -36,7 +36,7 @@ object LoadedRorConfig {
   sealed trait LoadingIndexError
   final case class IndexParsingError(message: String) extends LoadedRorConfig.Error with LoadingIndexError
   case object IndexUnknownStructure extends LoadedRorConfig.Error with LoadingIndexError
-  case object IndexNotExist extends LoadingIndexError
+  case object IndexNotExist extends LoadedRorConfig.Error with LoadingIndexError
 }
 
 sealed trait LoadedTestRorConfig[A]

--- a/core/src/main/scala/tech/beshu/ror/configuration/loader/external/dto/package.scala
+++ b/core/src/main/scala/tech/beshu/ror/configuration/loader/external/dto/package.scala
@@ -30,5 +30,6 @@ package object dto {
       s"""ROR ${typeOfConfiguration.show} cannot be used when XPack Security is enabled"""
     case LoadedRorConfig.IndexParsingError(message) => s"""index parsing error: ${message.show}"""
     case LoadedRorConfig.IndexUnknownStructure => "index unknown structure"
+    case LoadedRorConfig.IndexNotExist => "index not exist"
   }
 }

--- a/core/src/main/scala/tech/beshu/ror/utils/DurationOps.scala
+++ b/core/src/main/scala/tech/beshu/ror/utils/DurationOps.scala
@@ -17,7 +17,7 @@
 package tech.beshu.ror.utils
 
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.numeric.{NonNegative, Positive}
 
 import java.util.concurrent.TimeUnit as JTimeUnit
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -25,6 +25,7 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 object DurationOps {
 
   type PositiveFiniteDuration = FiniteDuration Refined Positive
+  type NonNegativeFiniteDuration = FiniteDuration Refined NonNegative
 
   implicit class RefinedDurationOps(val duration: Duration) extends AnyVal {
     def toRefinedPositive: Either[String, PositiveFiniteDuration] = duration match {
@@ -36,6 +37,16 @@ object DurationOps {
 
     def toRefinedPositiveUnsafe: PositiveFiniteDuration =
       toRefinedPositive.fold(err => throw new IllegalArgumentException(err), identity)
+
+    def toRefineNonNegative: Either[String, NonNegativeFiniteDuration] = duration match {
+      case v: FiniteDuration if v.toMillis >= 0 =>
+        Right(Refined.unsafeApply(v))
+      case _ =>
+        Left(s"Cannot map '${duration.toString}' to finite duration.")
+    }
+
+    def toRefinedNonNegativeUnsafe: NonNegativeFiniteDuration =
+      toRefineNonNegative.fold(err => throw new IllegalArgumentException(err), identity)
 
     def inShortFormat: String = {
       val d = duration.toCoarsest

--- a/core/src/test/scala/tech/beshu/ror/unit/boot/ReadonlyRestStartingTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/boot/ReadonlyRestStartingTests.scala
@@ -79,7 +79,7 @@ class ReadonlyRestStartingTests
           val mockedIndexJsonContentManager = mock[IndexJsonContentService]
           (mockedIndexJsonContentManager.sourceOf _)
             .expects(fullIndexName(".readonlyrest"), "1")
-            .repeated(5)
+            .repeated(1)
             .returns(Task.now(Left(CannotReachContentSource)))
 
           mockIndexJsonContentManagerSourceOfCallTestConfig(mockedIndexJsonContentManager)
@@ -278,7 +278,7 @@ class ReadonlyRestStartingTests
           val mockedIndexJsonContentManager = mock[IndexJsonContentService]
           (mockedIndexJsonContentManager.sourceOf _)
             .expects(fullIndexName(".readonlyrest"), "1")
-            .repeated(5)
+            .repeated(1)
             .returns(Task.now(Left(ContentNotFound)))
 
           val readonlyRest = readonlyRestBoot(mock[CoreFactory], mockedIndexJsonContentManager, "/boot_tests/index_config_not_exists_malformed_file_config/")
@@ -293,7 +293,7 @@ class ReadonlyRestStartingTests
           val mockedIndexJsonContentManager = mock[IndexJsonContentService]
           (mockedIndexJsonContentManager.sourceOf _)
             .expects(fullIndexName(".readonlyrest"), "1")
-            .repeated(5)
+            .repeated(1)
             .returns(Task.now(Left(ContentNotFound)))
           mockIndexJsonContentManagerSourceOfCallTestConfig(mockedIndexJsonContentManager)
 
@@ -502,7 +502,7 @@ class ReadonlyRestStartingTests
 
             (mockedIndexJsonContentManager.sourceOf _)
               .expects(fullIndexName(".readonlyrest"), "2")
-              .repeated(5)
+              .repeated(1)
               .returns(Task.now(Left(CannotReachContentSource)))
 
             val coreFactory = mock[CoreFactory]
@@ -1414,7 +1414,8 @@ class ReadonlyRestStartingTests
         mapWithIntervalFrom(refreshInterval) ++
           mapWithMaxYamlSize(maxYamlSize) ++
           Map(
-            "com.readonlyrest.settings.loading.delay" -> "1"
+            "com.readonlyrest.settings.loading.delay" -> "1",
+            "com.readonlyrest.settings.loading.attempts.count" -> "1"
           )
       )
     )

--- a/core/src/test/scala/tech/beshu/ror/unit/configuration/LoadRawRorConfigTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/configuration/LoadRawRorConfigTest.scala
@@ -40,7 +40,7 @@ class LoadRawRorConfigTest extends AnyWordSpec with EitherValues{
         (ConfigLoading.LoadConfigAction.ForceLoadRorConfigFromFile(esEnv.configPath), Right(ForcedFileConfig(rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = true, esEnv, rorConfigurationIndex, indexLoadingAttempts = 0)
+      val program = LoadRawRorConfig.load(isLoadingFromFileForced = true, esEnv, rorConfigurationIndex, loadingAttemptsCount = 0)
       val result = program.foldMap(compiler)
       val ffc = result.asInstanceOf[Right[Nothing, ForcedFileConfig[RawRorConfig]]]
       ffc.value.value shouldEqual rawRorConfig
@@ -50,7 +50,7 @@ class LoadRawRorConfigTest extends AnyWordSpec with EitherValues{
         (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Right(IndexConfig(rorConfigurationIndex, rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, indexLoadingAttempts = 1)
+      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 1)
       val result = program.foldMap(compiler)
       val ffc = result.asInstanceOf[Right[Nothing, IndexConfig[RawRorConfig]]]
       ffc.value.value shouldEqual rawRorConfig
@@ -61,7 +61,7 @@ class LoadRawRorConfigTest extends AnyWordSpec with EitherValues{
         (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Right(IndexConfig(rorConfigurationIndex, rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, indexLoadingAttempts = 5)
+      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 5)
       val result = program.foldMap(compiler)
       val ffc = result.asInstanceOf[Right[Nothing, IndexConfig[RawRorConfig]]]
       ffc.value.value shouldEqual rawRorConfig
@@ -76,7 +76,7 @@ class LoadRawRorConfigTest extends AnyWordSpec with EitherValues{
         (ConfigLoading.LoadConfigAction.LoadRorConfigFromFile(esEnv.configPath), Right(FileConfig(rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, indexLoadingAttempts = 5)
+      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 5)
       val result = program.foldMap(compiler)
       result.toOption.get shouldBe FileConfig(rawRorConfig)
     }
@@ -85,7 +85,7 @@ class LoadRawRorConfigTest extends AnyWordSpec with EitherValues{
         (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexUnknownStructure)),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, indexLoadingAttempts = 5)
+      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 5)
       val result = program.foldMap(compiler)
       result shouldBe a[Left[LoadedRorConfig.IndexUnknownStructure.type, _]]
     }
@@ -94,7 +94,7 @@ class LoadRawRorConfigTest extends AnyWordSpec with EitherValues{
         (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexParsingError("error"))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, indexLoadingAttempts = 5)
+      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 5)
       val result = program.foldMap(compiler)
       result shouldBe a[Left[LoadedRorConfig.IndexParsingError, _]]
       result.left.value.asInstanceOf[LoadedRorConfig.IndexParsingError].message shouldBe "error"

--- a/core/src/test/scala/tech/beshu/ror/unit/configuration/LoadRawRorConfigTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/configuration/LoadRawRorConfigTest.scala
@@ -25,7 +25,7 @@ import tech.beshu.ror.accesscontrol.domain.{IndexName, RorConfigurationIndex}
 import tech.beshu.ror.configuration.ConfigLoading.LoadConfigAction
 import tech.beshu.ror.configuration.loader.LoadedRorConfig.{FileConfig, ForcedFileConfig, IndexConfig}
 import tech.beshu.ror.configuration.loader.{LoadRawRorConfig, LoadedRorConfig}
-import tech.beshu.ror.configuration.{ConfigLoading, RawRorConfig}
+import tech.beshu.ror.configuration.{ConfigLoading, EsConfig, RawRorConfig}
 import tech.beshu.ror.es.EsEnv
 import tech.beshu.ror.utils.TestsUtils.{defaultEsVersionForTests, unsafeNes}
 
@@ -40,6 +40,10 @@ class LoadRawRorConfigTest extends AnyWordSpec with EitherValues{
         (ConfigLoading.LoadConfigAction.ForceLoadRorConfigFromFile(esEnv.configPath), Right(ForcedFileConfig(rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
+      LoadRawRorConfig.load(
+        esEnv,
+        EsConfig()
+      )
       val program = LoadRawRorConfig.load(isLoadingFromFileForced = true, esEnv, rorConfigurationIndex, loadingAttemptsCount = 0)
       val result = program.foldMap(compiler)
       val ffc = result.asInstanceOf[Right[Nothing, ForcedFileConfig[RawRorConfig]]]

--- a/core/src/test/scala/tech/beshu/ror/unit/configuration/LoadRawRorConfigTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/configuration/LoadRawRorConfigTest.scala
@@ -23,82 +23,118 @@ import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.wordspec.AnyWordSpec
 import tech.beshu.ror.accesscontrol.domain.{IndexName, RorConfigurationIndex}
 import tech.beshu.ror.configuration.ConfigLoading.LoadConfigAction
+import tech.beshu.ror.configuration.ConfigLoading.LoadConfigAction.*
+import tech.beshu.ror.configuration.RawRorConfig
+import tech.beshu.ror.configuration.RorProperties.{LoadingAttemptsCount, LoadingAttemptsInterval, LoadingDelay}
 import tech.beshu.ror.configuration.loader.LoadedRorConfig.{FileConfig, ForcedFileConfig, IndexConfig}
 import tech.beshu.ror.configuration.loader.{LoadRawRorConfig, LoadedRorConfig}
-import tech.beshu.ror.configuration.{ConfigLoading, EsConfig, RawRorConfig}
 import tech.beshu.ror.es.EsEnv
 import tech.beshu.ror.utils.TestsUtils.{defaultEsVersionForTests, unsafeNes}
 
 import java.nio.file.Paths
-import scala.language.existentials
+import scala.concurrent.duration.*
+import scala.language.{existentials, postfixOps}
 
 class LoadRawRorConfigTest extends AnyWordSpec with EitherValues{
   import LoadRawRorConfigTest.*
   "Free monad loader program" should {
     "load forced file" in {
       val steps = List(
-        (ConfigLoading.LoadConfigAction.ForceLoadRorConfigFromFile(esEnv.configPath), Right(ForcedFileConfig(rawRorConfig))),
+        (ForceLoadRorConfigFromFile(esEnv.configPath), Right(ForcedFileConfig(rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
-      LoadRawRorConfig.load(
-        esEnv,
-        EsConfig()
-      )
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = true, esEnv, rorConfigurationIndex, loadingAttemptsCount = 0)
+      val program = LoadRawRorConfig.loadFromFile(esEnv.configPath)
       val result = program.foldMap(compiler)
       val ffc = result.asInstanceOf[Right[Nothing, ForcedFileConfig[RawRorConfig]]]
       ffc.value.value shouldEqual rawRorConfig
     }
     "load successfully from index" in {
+      val loadingDelay = LoadingDelay.unsafeFrom(2 seconds)
       val steps = List(
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Right(IndexConfig(rorConfigurationIndex, rawRorConfig))),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingDelay.value), Right(IndexConfig(rorConfigurationIndex, rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 1)
+      val program = LoadRawRorConfig.loadFromIndexWithFileFallback(
+        configurationIndex = rorConfigurationIndex,
+        loadingDelay = loadingDelay,
+        loadingAttemptsCount = LoadingAttemptsCount.unsafeFrom(1),
+        loadingAttemptsInterval = LoadingAttemptsInterval.unsafeFrom(1 second),
+        fallbackConfigFilePath = esEnv.configPath
+      )
       val result = program.foldMap(compiler)
       val ffc = result.asInstanceOf[Right[Nothing, IndexConfig[RawRorConfig]]]
       ffc.value.value shouldEqual rawRorConfig
     }
     "load successfully from index, after failure" in {
+      val loadingDelay = LoadingDelay.unsafeFrom(2 seconds)
+      val loadingAttemptsInterval = LoadingAttemptsInterval.unsafeFrom(1 second)
       val steps = List(
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexNotExist)),
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Right(IndexConfig(rorConfigurationIndex, rawRorConfig))),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingDelay.value), Left(LoadedRorConfig.IndexNotExist)),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingAttemptsInterval.value), Right(IndexConfig(rorConfigurationIndex, rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 5)
+      val program = LoadRawRorConfig.loadFromIndexWithFileFallback(
+        configurationIndex = rorConfigurationIndex,
+        loadingDelay = loadingDelay,
+        loadingAttemptsCount = LoadingAttemptsCount.unsafeFrom(5),
+        loadingAttemptsInterval = loadingAttemptsInterval,
+        fallbackConfigFilePath = esEnv.configPath
+      )
       val result = program.foldMap(compiler)
       val ffc = result.asInstanceOf[Right[Nothing, IndexConfig[RawRorConfig]]]
       ffc.value.value shouldEqual rawRorConfig
     }
     "load from file when index not exist" in {
+      val loadingDelay = LoadingDelay.unsafeFrom(2 seconds)
+      val loadingAttemptsInterval = LoadingAttemptsInterval.unsafeFrom(1 second)
       val steps = List(
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexNotExist)),
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexNotExist)),
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexNotExist)),
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexNotExist)),
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexNotExist)),
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromFile(esEnv.configPath), Right(FileConfig(rawRorConfig))),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingDelay.value), Left(LoadedRorConfig.IndexNotExist)),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingAttemptsInterval.value), Left(LoadedRorConfig.IndexNotExist)),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingAttemptsInterval.value), Left(LoadedRorConfig.IndexNotExist)),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingAttemptsInterval.value), Left(LoadedRorConfig.IndexNotExist)),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingAttemptsInterval.value), Left(LoadedRorConfig.IndexNotExist)),
+        (LoadRorConfigFromFile(esEnv.configPath), Right(FileConfig(rawRorConfig))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 5)
+      val program = LoadRawRorConfig.loadFromIndexWithFileFallback(
+        configurationIndex = rorConfigurationIndex,
+        loadingDelay = loadingDelay,
+        loadingAttemptsCount = LoadingAttemptsCount.unsafeFrom(5),
+        loadingAttemptsInterval = loadingAttemptsInterval,
+        fallbackConfigFilePath = esEnv.configPath
+      )
       val result = program.foldMap(compiler)
       result.toOption.get shouldBe FileConfig(rawRorConfig)
     }
     "unknown index structure fail loading from index immediately" in {
+      val loadingDelay = LoadingDelay.unsafeFrom(2 seconds)
       val steps = List(
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexUnknownStructure)),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingDelay.value), Left(LoadedRorConfig.IndexUnknownStructure)),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 5)
+      val program = LoadRawRorConfig.loadFromIndexWithFileFallback(
+        configurationIndex = rorConfigurationIndex,
+        loadingDelay = loadingDelay,
+        loadingAttemptsCount = LoadingAttemptsCount.unsafeFrom(5),
+        loadingAttemptsInterval = LoadingAttemptsInterval.unsafeFrom(1 second),
+        fallbackConfigFilePath = esEnv.configPath
+      )
       val result = program.foldMap(compiler)
       result shouldBe a[Left[LoadedRorConfig.IndexUnknownStructure.type, _]]
     }
     "parse index error fail loading from index immediately" in {
+      val loadingDelay = LoadingDelay.unsafeFrom(2 seconds)
       val steps = List(
-        (ConfigLoading.LoadConfigAction.LoadRorConfigFromIndex(rorConfigurationIndex), Left(LoadedRorConfig.IndexParsingError("error"))),
+        (LoadRorConfigFromIndex(rorConfigurationIndex, loadingDelay.value), Left(LoadedRorConfig.IndexParsingError("error"))),
       )
       val compiler = IdCompiler.instance(steps)
-      val program = LoadRawRorConfig.load(isLoadingFromFileForced = false, esEnv, rorConfigurationIndex, loadingAttemptsCount = 5)
+      val program = LoadRawRorConfig.loadFromIndexWithFileFallback(
+        configurationIndex = rorConfigurationIndex,
+        loadingDelay = loadingDelay,
+        loadingAttemptsCount = LoadingAttemptsCount.unsafeFrom(5),
+        loadingAttemptsInterval = LoadingAttemptsInterval.unsafeFrom(1 second),
+        fallbackConfigFilePath = esEnv.configPath
+      )
       val result = program.foldMap(compiler)
       result shouldBe a[Left[LoadedRorConfig.IndexParsingError, _]]
       result.left.value.asInstanceOf[LoadedRorConfig.IndexParsingError].message shouldBe "error"

--- a/es67x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -16,7 +16,6 @@
  */
 package tech.beshu.ror.es.actions.rrconfig
 
-import java.util
 import cats.implicits.*
 import org.elasticsearch.action.FailedNodeException
 import org.elasticsearch.action.support.ActionFilters
@@ -29,13 +28,14 @@ import org.elasticsearch.env.Environment
 import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.TransportService
 import tech.beshu.ror.configuration.EnvironmentConfig
-import tech.beshu.ror.configuration.loader.distributed.{NodeConfig, RawRorConfigLoadingAction, Timeout}
 import tech.beshu.ror.configuration.loader.*
-import tech.beshu.ror.es.{EsEnv, IndexJsonContentService}
+import tech.beshu.ror.configuration.loader.distributed.{NodeConfig, RawRorConfigLoadingAction, Timeout}
+import tech.beshu.ror.es.IndexJsonContentService
 import tech.beshu.ror.es.services.EsIndexJsonContentService
 import tech.beshu.ror.es.utils.EsEnvProvider
 import tech.beshu.ror.utils.AccessControllerHelper.doPrivileged
 
+import java.util
 import scala.annotation.unused
 import scala.concurrent.duration.*
 import scala.language.postfixOps

--- a/es67x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es67x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -107,7 +107,7 @@ class TransportRRConfigAction(setting: Settings,
 
   private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es70x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es70x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -97,7 +97,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es710x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es710x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -109,7 +109,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es711x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es711x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -109,7 +109,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es714x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -109,7 +109,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es716x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -105,7 +105,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es717x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es717x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -105,7 +105,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es72x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es72x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -97,7 +97,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es73x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es73x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -98,7 +98,7 @@ class TransportRRConfigAction(actionName: String,
 
   private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es74x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es74x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -109,7 +109,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es77x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es77x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -109,7 +109,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es78x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es78x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -109,7 +109,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es79x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es79x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -109,7 +109,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es80x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
   private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es810x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es810x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -103,7 +103,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es811x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -104,7 +104,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es812x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -98,7 +98,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es813x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -98,7 +98,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es814x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -98,7 +98,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es815x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -99,7 +99,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es816x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es816x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -98,7 +98,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es818x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -98,7 +98,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es81x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es82x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es83x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es84x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es85x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es87x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es88x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es89x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -106,7 +106,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/es90x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/actions/rrconfig/TransportRRConfigAction.scala
@@ -98,7 +98,7 @@ class TransportRRConfigAction(actionName: String,
 
    private def loadConfig() = doPrivileged {
     RawRorConfigLoadingAction
-      .load(EsEnvProvider.create(env), indexContentProvider)
+      .loadFromIndex(EsEnvProvider.create(env), indexContentProvider)
       .map(_.map(_.map(_.raw)))
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.64.2
-pluginVersion=1.65.0-pre1
+pluginVersion=1.65.0-pre2
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/RorStartingSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/RorStartingSuite.scala
@@ -181,7 +181,8 @@ private object RorStartingSuite extends EsModulePatterns {
           clusterName = clusterName,
           securityType = SecurityType.RorWithXpackSecurity(
             ReadonlyRestWithEnabledXpackSecurityPlugin.Config.Attributes.default.copy(
-              rorConfigFileName = rorConfigFile
+              rorConfigFileName = rorConfigFile,
+              rorInIndexConfigLoadingDelay = 5 seconds
             )
           ),
           containerSpecification = ContainerSpecification.empty.copy(

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestPlugin.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestPlugin.scala
@@ -23,7 +23,8 @@ import tech.beshu.ror.utils.containers.images.ReadonlyRestPlugin.Config.{Attribu
 import tech.beshu.ror.utils.containers.images.domain.{Enabled, SourceFile}
 import tech.beshu.ror.utils.misc.Version
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.language.postfixOps
 
 object ReadonlyRestPlugin {
   final case class Config(rorConfig: File,
@@ -31,6 +32,7 @@ object ReadonlyRestPlugin {
                           attributes: Attributes)
   object Config {
     final case class Attributes(rorConfigReloading: Enabled[FiniteDuration],
+                                rorInIndexConfigLoadingDelay: FiniteDuration,
                                 rorCustomSettingsIndex: Option[String],
                                 restSsl: Enabled[RestSsl],
                                 internodeSsl: Enabled[InternodeSsl],
@@ -38,6 +40,7 @@ object ReadonlyRestPlugin {
     object Attributes {
       val default: Attributes = Attributes(
         rorConfigReloading = Enabled.No,
+        rorInIndexConfigLoadingDelay = 0 seconds,
         rorCustomSettingsIndex = None,
         restSsl = Enabled.Yes(RestSsl.Ror(SourceFile.EsFile)),
         internodeSsl = Enabled.No,
@@ -106,7 +109,7 @@ class ReadonlyRestPlugin(esVersion: String,
 
   private def addLoadingSettings() = {
     Seq(
-      s"-Dcom.readonlyrest.settings.loading.delay=0sec",
+      s"-Dcom.readonlyrest.settings.loading.delay=${config.attributes.rorInIndexConfigLoadingDelay.toMillis}ms",
       s"-Dcom.readonlyrest.settings.loading.attempts.count=1",
       s"-Dcom.readonlyrest.settings.loading.attempts.interval=0sec"
     )

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestPlugin.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestPlugin.scala
@@ -90,6 +90,7 @@ class ReadonlyRestPlugin(esVersion: String,
     builder
       .add(unboundidDebug(false))
       .add(rorReloadingInterval())
+      .add(addLoadingSettings(): _*)
   }
 
   private def unboundidDebug(enabled: Boolean) =
@@ -101,6 +102,14 @@ class ReadonlyRestPlugin(esVersion: String,
       case Enabled.Yes(interval: FiniteDuration) => interval.toSeconds.toInt
     }
     s"-Dcom.readonlyrest.settings.refresh.interval=$intervalSeconds"
+  }
+
+  private def addLoadingSettings() = {
+    Seq(
+      s"-Dcom.readonlyrest.settings.loading.delay=0 sec",
+      s"-Dcom.readonlyrest.settings.loading.attempts.count=1",
+      s"-Dcom.readonlyrest.settings.loading.attempts.interval=0 sec"
+    )
   }
 
   private implicit class InstallRorPlugin(val image: DockerImageDescription) {

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestPlugin.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestPlugin.scala
@@ -97,18 +97,18 @@ class ReadonlyRestPlugin(esVersion: String,
     s"-Dcom.unboundid.ldap.sdk.debug.enabled=${if (enabled) true else false}"
 
   private def rorReloadingInterval() = {
-    val intervalSeconds = config.attributes.rorConfigReloading match {
-      case Enabled.No => 0
-      case Enabled.Yes(interval: FiniteDuration) => interval.toSeconds.toInt
+    val interval = config.attributes.rorConfigReloading match {
+      case Enabled.No => "0sec"
+      case Enabled.Yes(interval: FiniteDuration) => s"${interval.toMillis.toInt}ms"
     }
-    s"-Dcom.readonlyrest.settings.refresh.interval=$intervalSeconds"
+    s"-Dcom.readonlyrest.settings.refresh.interval=$interval"
   }
 
   private def addLoadingSettings() = {
     Seq(
-      s"-Dcom.readonlyrest.settings.loading.delay=0 sec",
+      s"-Dcom.readonlyrest.settings.loading.delay=0sec",
       s"-Dcom.readonlyrest.settings.loading.attempts.count=1",
-      s"-Dcom.readonlyrest.settings.loading.attempts.interval=0 sec"
+      s"-Dcom.readonlyrest.settings.loading.attempts.interval=0sec"
     )
   }
 

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestWithEnabledXpackSecurityPlugin.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/ReadonlyRestWithEnabledXpackSecurityPlugin.scala
@@ -29,6 +29,7 @@ object ReadonlyRestWithEnabledXpackSecurityPlugin {
                           attributes: Attributes)
   object Config {
     final case class Attributes(rorConfigReloading: Enabled[FiniteDuration],
+                                rorInIndexConfigLoadingDelay: FiniteDuration,
                                 rorCustomSettingsIndex: Option[String],
                                 restSsl: Enabled[RestSsl],
                                 internodeSsl: Enabled[InternodeSsl],
@@ -36,6 +37,7 @@ object ReadonlyRestWithEnabledXpackSecurityPlugin {
     object Attributes {
       val default: Attributes = Attributes(
         rorConfigReloading = ReadonlyRestPlugin.Config.Attributes.default.rorConfigReloading,
+        rorInIndexConfigLoadingDelay = ReadonlyRestPlugin.Config.Attributes.default.rorInIndexConfigLoadingDelay,
         rorCustomSettingsIndex = ReadonlyRestPlugin.Config.Attributes.default.rorCustomSettingsIndex,
         restSsl = if(XpackSecurityPlugin.Config.Attributes.default.restSslEnabled) Enabled.Yes(RestSsl.Xpack) else Enabled.No,
         internodeSsl = if(XpackSecurityPlugin.Config.Attributes.default.internodeSslEnabled) Enabled.Yes(InternodeSsl.Xpack) else Enabled.No,
@@ -93,6 +95,7 @@ class ReadonlyRestWithEnabledXpackSecurityPlugin(esVersion: String,
       rorPlugin = config.rorPlugin,
       attributes = ReadonlyRestPlugin.Config.Attributes(
         config.attributes.rorConfigReloading,
+        config.attributes.rorInIndexConfigLoadingDelay,
         config.attributes.rorCustomSettingsIndex,
         restSsl = createRorRestSsl(),
         internodeSsl = createRorInternodeSsl(),


### PR DESCRIPTION
🧐Enhancement (ES) ROR settings related JVM properties improvements

---
Two new properties have been added to control retry behavior when loading ReadonlyREST settings from the index:
- `com.readonlyrest.settings.loading.attempts.count` (default 5) - specifies the number of retry attempts to load the in-index ReadonlyREST settings before falling back to the .readonlyrest file.
- `com.readonlyrest.settings.loading.attempts.interval` (default 5s) - defines the interval between retry attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable retry logic and fallback mechanisms for loading configuration, including new settings for delay, attempts count, and interval.
  - Improved error reporting for missing configuration indices.

- **Improvements**
  - Enhanced type safety and clarity for configuration loading parameters.
  - Refined configuration property names for better clarity and consistency.
  - More explicit and robust handling of configuration loading errors.
  - Updated JVM options to include default settings for loading delay, attempts count, and interval.

- **Bug Fixes**
  - Corrected error message mappings and improved error handling for non-existent indices.
  - Fixed method naming for reload interval configuration.

- **Tests**
  - Updated tests to reflect new configuration loading parameters and improved type safety.
  - Reduced redundant test calls and improved test setup for configuration loading scenarios.

- **Chores**
  - Updated plugin version to 1.65.0-pre4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->