### PR TITLE
[RORDEV-1501] docker images issue with accepting consent 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.65.0
-pluginVersion=1.65.0
+pluginVersion=1.65.1
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/ror-tools/src/main/scala/tech/beshu/ror/tools/RorToolsApp.scala
+++ b/ror-tools/src/main/scala/tech/beshu/ror/tools/RorToolsApp.scala
@@ -67,13 +67,14 @@ trait RorTools {
     }
   }
 
-  private def readArgsFromEnvVariables()(implicit rawEnvVariablesProvider: RawEnvVariablesProvider): Array[String] = {
+  private def readArgsFromEnvVariables()
+                                      (implicit rawEnvVariablesProvider: RawEnvVariablesProvider): Array[String] = {
     val allowedEnvVariableNames = List(
       consentFlagName,
     )
     rawEnvVariablesProvider.getSysEnv.toList
       .filter(env => allowedEnvVariableNames.contains(env._1.toLowerCase))
-      .flatMap { case (name, value) => Array(s"--$name", value) }
+      .flatMap { case (name, value) => Array(s"--${name.toLowerCase}", value) }
       .toArray
   }
 
@@ -192,6 +193,7 @@ trait RorTools {
     patchCommand,
     note(""),
     opt[String](consentFlagName)
+      .unbounded()
       .valueName("<yes/no>")
       .validate {
         case "yes" => success
@@ -255,7 +257,6 @@ trait RorTools {
 
   private def effectSetup(implicit inOut: InOut): OEffectSetup = new DefaultOEffectSetup {
     override def displayToOut(msg: String): Unit = inOut.println(msg)
-
     override def displayToErr(msg: String): Unit = inOut.printlnErr(msg)
   }
 

--- a/ror-tools/src/test/scala/tech/beshu/ror/tools/RorToolsAppSuite.scala
+++ b/ror-tools/src/test/scala/tech/beshu/ror/tools/RorToolsAppSuite.scala
@@ -165,7 +165,7 @@ class RorToolsAppSuite
           |""".stripMargin
       )
     }
-    "Patching not started when user declines to accept implications of patching (in env variable and arg)" in {
+    "Patching not started when user declines to accept implications of patching (when env variable is set and arg is passed in the same time)" in {
       val (result, output) = captureResultAndOutput(
         RorToolsTestApp.run(Array("patch", "--I_UNDERSTAND_AND_ACCEPT_ES_PATCHING", "no"))(_, _),
         mockedEnvs = Map("I_UNDERSTAND_AND_ACCEPT_ES_PATCHING" -> "no")

--- a/ror-tools/src/test/scala/tech/beshu/ror/tools/RorToolsAppSuite.scala
+++ b/ror-tools/src/test/scala/tech/beshu/ror/tools/RorToolsAppSuite.scala
@@ -28,7 +28,7 @@ import tech.beshu.ror.tools.RorTools.Result
 import tech.beshu.ror.tools.core.patches.base.EsPatchMetadataCodec
 import tech.beshu.ror.tools.core.patches.internal.FilePatch.FilePatchMetadata
 import tech.beshu.ror.tools.core.patches.internal.RorPluginDirectory.EsPatchMetadata
-import tech.beshu.ror.tools.core.utils.{OsRawEnvVariablesProvider, RawEnvVariablesProvider, InOut}
+import tech.beshu.ror.tools.core.utils.{InOut, OsRawEnvVariablesProvider, RawEnvVariablesProvider}
 import tech.beshu.ror.tools.utils.{CapturingOutputAndMockingInput, ExampleEsWithRorContainer}
 import tech.beshu.ror.utils.files.FileUtils
 
@@ -156,6 +156,18 @@ class RorToolsAppSuite
     "Patching not started when user declines to accept implications of patching (in env variable)" in {
       val (result, output) = captureResultAndOutput(
         RorToolsTestApp.run(Array("patch"))(_, _),
+        mockedEnvs = Map("I_UNDERSTAND_AND_ACCEPT_ES_PATCHING" -> "no")
+      )
+      result should equal(Result.Failure)
+      output should equal(
+        """You have to confirm, that You understand the implications of ES patching in order to perform it.
+          |You can read about patching in our documentation: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch.
+          |""".stripMargin
+      )
+    }
+    "Patching not started when user declines to accept implications of patching (in env variable and arg)" in {
+      val (result, output) = captureResultAndOutput(
+        RorToolsTestApp.run(Array("patch", "--I_UNDERSTAND_AND_ACCEPT_ES_PATCHING", "no"))(_, _),
         mockedEnvs = Map("I_UNDERSTAND_AND_ACCEPT_ES_PATCHING" -> "no")
       )
       result should equal(Result.Failure)
@@ -336,7 +348,6 @@ class RorToolsAppSuite
           .stripMargin
       )
     }
-
     "The patch is not detected when metadata file is missing and `verify` command is executed" in {
       val (patchResult, patchOutput) = captureResultAndOutput {
         RorToolsTestApp.run(Array("patch", "--I_UNDERSTAND_AND_ACCEPT_ES_PATCHING", "yes", "--es-path", esLocalPath.toString))(_, _)
@@ -368,7 +379,6 @@ class RorToolsAppSuite
            |""".stripMargin
       )
     }
-
     "The patch is not detected when metadata file is missing and `verify` command is executed (ES 9.x with detailed assertions)" excludeES(allEs6x, allEs7x, allEs8x) in {
       val (patchResult, patchOutput) = captureResultAndOutput {
         RorToolsTestApp.run(Array("patch", "--I_UNDERSTAND_AND_ACCEPT_ES_PATCHING", "yes", "--es-path", esLocalPath.toString))(_, _)


### PR DESCRIPTION
- 🐞Fix (ES) Docker images now start correctly when `I_UNDERSTAND_AND_ACCEPT_ES_PATCHING` is set.

---
Currently:

1. No ENV set (result: :white_check_mark:)
```
$ docker run -ti -u root -p 9202:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e ADMIN_USER_PASS=admin beshultd/elasticsearch-readonlyrest:9.0.3-ror-1.65.0 bash
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Elasticsearch is NOT patched. ReadonlyREST cannot be used yet. For patching instructions see our docs: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch
Elasticsearch needs to be patched to work with ReadonlyREST. You can read about patching in our documentation: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch. In this Docker image, the patching step is done automatically, but you must agree to have it done for you. You can do this by setting I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes environment variable when running the container.
```

2. `I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes` is set (result: :x:)
```
$ docker run -ti -u root -p 9202:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e ADMIN_USER_PASS=admin -e I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes beshultd/elasticsearch-readonlyrest:9.0.3-ror-1.65.0 bash
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Elasticsearch is NOT patched. ReadonlyREST cannot be used yet. For patching instructions see our docs: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Error: Unknown option --i_understand_and_accept_es_patching
Error: Unknown argument 'yes'
ROR tools 1.0.0
Usage: java -jar ror-tools.jar [patch|unpatch|verify] [options]

Command: patch [options]
patch is a command that modifies ES installation for ROR purposes
  --es-path <value>        Path to elasticsearch directory; default=/usr/share/elasticsearch

  --i_understand_and_accept_es_patching <yes/no>
                           Optional, when provided with value 'yes', it confirms that the user understands and accepts the implications of ES patching. The patching can therefore be performed. When not provided, user will be asked for confirmation in interactive mode. You can read about patching in our documentation: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch.
Command: unpatch [options]
unpatch is a command that reverts modifications done by patching
  --es-path <value>        Path to elasticsearch directory; default=/usr/share/elasticsearch

Command: verify [options]
verify is a command that verifies if ES installation is patched
  --es-path <value>        Path to elasticsearch directory; default=/usr/share/elasticsearch

  -h, --help               prints this usage text
```

3. `I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes` is set (result: :white_check_mark:)
```
$ docker run -ti -u root -p 9202:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e ADMIN_USER_PASS=admin -e I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes beshultd/elasticsearch-readonlyrest:9.0.3-ror-1.65.0 bash
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Elasticsearch is NOT patched. ReadonlyREST cannot be used yet. For patching instructions see our docs: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Creating backup ...
Patching ...
Elasticsearch is patched! ReadonlyREST is ready to use
```

4. both envs are set (result :x:)
```
$ docker run -ti -u root -p 9202:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e ADMIN_USER_PASS=admin -e I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes -e I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes beshultd/elasticsearch-readonlyrest:9.0.3-ror-1.65.0 bash
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Elasticsearch is NOT patched. ReadonlyREST cannot be used yet. For patching instructions see our docs: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Error: Unknown option --i_understand_and_accept_es_patching
Error: Unknown argument 'yes'
ROR tools 1.0.0
Usage: java -jar ror-tools.jar [patch|unpatch|verify] [options]

Command: patch [options]
patch is a command that modifies ES installation for ROR purposes
  --es-path <value>        Path to elasticsearch directory; default=/usr/share/elasticsearch

  --i_understand_and_accept_es_patching <yes/no>
                           Optional, when provided with value 'yes', it confirms that the user understands and accepts the implications of ES patching. The patching can therefore be performed. When not provided, user will be asked for confirmation in interactive mode. You can read about patching in our documentation: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch.
Command: unpatch [options]
unpatch is a command that reverts modifications done by patching
  --es-path <value>        Path to elasticsearch directory; default=/usr/share/elasticsearch

Command: verify [options]
verify is a command that verifies if ES installation is patched
  --es-path <value>        Path to elasticsearch directory; default=/usr/share/elasticsearch

  -h, --help               prints this usage text  
```

---
After this change:

1. No ENV set (result: :white_check_mark:)
```
$ docker run -ti -u root -p 9202:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e ADMIN_USER_PASS=admin beshultd/elasticsearch-readonlyrest:9.0.3-ror-1.65.1 bash
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Elasticsearch is NOT patched. ReadonlyREST cannot be used yet. For patching instructions see our docs: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch
Elasticsearch needs to be patched to work with ReadonlyREST. You can read about patching in our documentation: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch. In this Docker image, the patching step is done automatically, but you must agree to have it done for you. You can do this by setting I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes environment variable when running the container.
```

2. `I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes` is set (result: :white_check_mark:)
```
$ docker run -ti -u root -p 9202:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e ADMIN_USER_PASS=admin -e I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes beshultd/elasticsearch-readonlyrest:9.0.3-ror-1.65.1 bash
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Elasticsearch is NOT patched. ReadonlyREST cannot be used yet. For patching instructions see our docs: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Creating backup ...
Patching ...
Elasticsearch is patched! ReadonlyREST is ready to use
```

3. `I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes` is set (result: :white_check_mark:)
```
$ docker run -ti -u root -p 9202:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e ADMIN_USER_PASS=admin -e I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes beshultd/elasticsearch-readonlyrest:9.0.3-ror-1.65.1 bash
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Elasticsearch is NOT patched. ReadonlyREST cannot be used yet. For patching instructions see our docs: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Creating backup ...
Patching ...
Elasticsearch is patched! ReadonlyREST is ready to use
```

4. both envs are set (result :white_check_mark:)
```
$ docker run -ti -u root -p 9202:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e ADMIN_USER_PASS=admin -e I_UNDERSTAND_AND_ACCEPT_ES_PATCHING=yes -e I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING=yes beshultd/elasticsearch-readonlyrest:9.0.3-ror-1.65.1 bash
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Elasticsearch is NOT patched. ReadonlyREST cannot be used yet. For patching instructions see our docs: https://docs.readonlyrest.com/elasticsearch#id-3.-patch-elasticsearch
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by tech.beshu.ror.tools.scala.runtime.LazyVals$ (file:/usr/share/elasticsearch/plugins/readonlyrest/ror-tools.jar)
WARNING: Please consider reporting this to the maintainers of class tech.beshu.ror.tools.scala.runtime.LazyVals$
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Checking if Elasticsearch is patched ...
Creating backup ...
Patching ...
Elasticsearch is patched! ReadonlyREST is ready to use
```