### PR TITLE
[RORDEV-1607] CVE-2025-58057, CVE-2025-58056 fixes

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -105,12 +105,12 @@ dependencies {
     testImplementation  group: 'com.dimafeng',               name: 'testcontainers-scala-core_3',     version: '0.41.4'
 
     constraints {
-        api group: 'io.netty',              name: 'netty-codec-http2',                  version: '4.1.119.Final'
-        api group: 'io.netty',              name: 'netty-handler-proxy',                version: '4.1.119.Final'
-        api group: 'io.netty',              name: 'netty-resolver-dns',                 version: '4.1.119.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-unix-common', version: '4.1.119.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-epoll',       version: '4.1.119.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-kqueue',      version: '4.1.119.Final'
+        api group: 'io.netty',              name: 'netty-codec-http2',                  version: '4.1.126.Final'
+        api group: 'io.netty',              name: 'netty-handler-proxy',                version: '4.1.126.Final'
+        api group: 'io.netty',              name: 'netty-resolver-dns',                 version: '4.1.126.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-unix-common', version: '4.1.126.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-epoll',       version: '4.1.126.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-kqueue',      version: '4.1.126.Final'
         api group: 'com.google.guava',      name: 'guava',                              version: '32.0.1-jre'
         api group: 'io.spray',              name: 'spray-json_3',                       version: '1.3.6'
         api group: 'org.asynchttpclient',   name: 'async-http-client',                  version: '3.0.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.66.1
-pluginVersion=1.66.1
+pluginVersion=1.67.0-pre2
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m


### PR DESCRIPTION
🚨Security Fix (ES) [CVE-2025-58057](https://nvd.nist.gov/vuln/detail/CVE-2025-58057), [CVE-2025-58056](https://nvd.nist.gov/vuln/detail/CVE-2025-58056)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Netty components to 4.1.126.Final to improve stability and platform compatibility (HTTP/2, proxy handler, DNS resolver, and native transports for Unix/epoll/kqueue).
  * Bumped internal plugin version to 1.67.0-pre2 to align with the upcoming release cycle.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->