### PR TITLE
[RORDEV-1632] Bump dependency-check plugin, setup OSS analyzer

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
                 # Using the wrong API key breaks the CVE check.
 
                 export NVD_API_KEY=$var_nvd_api_key
-                export OSS_INDEX_USER=$var_oss_index_user
+                export OSS_INDEX_USERNAME=$var_oss_index_username
                 export OSS_INDEX_PASSWORD=$var_oss_index_password
               fi
 
@@ -85,7 +85,7 @@ stages:
               var_nvd_api_key: $(NVD_API_KEY)
               var_dependency_check_data_dir: $(dependencyCheckDataDir)
               var_is_fork: $(System.PullRequest.IsFork)
-              var_oss_index_user: $(OSS_INDEX_USER)
+              var_oss_index_username: $(OSS_INDEX_USERNAME)
               var_oss_index_password: $(OSS_INDEX_PASSWORD)
           - task: Cache@2
             displayName: 'Save updated CVE DB in cache'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,6 +74,8 @@ stages:
                 # Using the wrong API key breaks the CVE check.
 
                 export NVD_API_KEY=$var_nvd_api_key
+                export OSS_INDEX_USER=$var_oss_index_user
+                export OSS_INDEX_PASSWORD=$var_oss_index_password
               fi
 
               ci/run-pipeline.sh
@@ -83,6 +85,8 @@ stages:
               var_nvd_api_key: $(NVD_API_KEY)
               var_dependency_check_data_dir: $(dependencyCheckDataDir)
               var_is_fork: $(System.PullRequest.IsFork)
+              var_oss_index_user: $(OSS_INDEX_USER)
+              var_oss_index_password: $(OSS_INDEX_PASSWORD)
           - task: Cache@2
             displayName: 'Save updated CVE DB in cache'
             inputs:

--- a/build-base/build.gradle
+++ b/build-base/build.gradle
@@ -26,5 +26,5 @@ repositories {
 dependencies {
     implementation "com.star-zero.gradle:githook:1.2.1"
     implementation "gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1"
-    implementation "org.owasp.dependencycheck:org.owasp.dependencycheck.gradle.plugin:12.1.3"
+    implementation "org.owasp.dependencycheck:org.owasp.dependencycheck.gradle.plugin:12.1.6"
 }

--- a/build-base/src/main/groovy/readonlyrest.base-common-conventions.gradle
+++ b/build-base/src/main/groovy/readonlyrest.base-common-conventions.gradle
@@ -69,11 +69,11 @@ dependencyCheck {
         ossIndex {
             // Configure the OSS Index analyzer. If no credentials are supplied,
             // dependency-check will skip this analyzer and log a warning.
-            if (System.getenv('OSS_INDEX_USER')) {
-                user = System.getenv('OSS_INDEX_USER')
+            if (System.getenv('OSS_INDEX_USERNAME')) {
+                username = System.getenv('OSS_INDEX_USERNAME')
             }
             if (System.getenv('OSS_INDEX_PASSWORD')) {
-                user = System.getenv('OSS_INDEX_PASSWORD')
+                password = System.getenv('OSS_INDEX_PASSWORD')
             }
         }
     }

--- a/build-base/src/main/groovy/readonlyrest.base-common-conventions.gradle
+++ b/build-base/src/main/groovy/readonlyrest.base-common-conventions.gradle
@@ -65,6 +65,17 @@ dependencyCheck {
         // Disable Maven Central checksum lookups (we already have Maven coords from Gradle).
         // Avoids flaky network calls to Central search.
         centralEnabled = false
+
+        ossIndex {
+            // Configure the OSS Index analyzer. If no credentials are supplied,
+            // dependency-check will skip this analyzer and log a warning.
+            if (System.getenv('OSS_INDEX_USER')) {
+                user = System.getenv('OSS_INDEX_USER')
+            }
+            if (System.getenv('OSS_INDEX_PASSWORD')) {
+                user = System.getenv('OSS_INDEX_PASSWORD')
+            }
+        }
     }
     data {
         if (System.getenv('DEPENDENCY_CHECK_DATA_DIR')) {  // We want to fall back to the default path for local builds

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.66.1
-pluginVersion=1.67.0-pre5
+pluginVersion=1.67.0-pre6
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/tests-utils/build.gradle
+++ b/tests-utils/build.gradle
@@ -81,3 +81,15 @@ dependencies {
     api group: 'com.lihaoyi',                    name: 'upickle_3',                         version: '4.2.1'
     api group: 'com.github.tomakehurst',         name: 'wiremock-jre8',                     version: '2.35.0'
 }
+
+dependencyCheck {
+    /*
+       Severity	Base Score
+       None     0
+       Low      0.1-3.9
+       Medium   4.0-6.9
+       High     7.0-8.9
+       Critical 9.0-10.0
+     */
+    failBuildOnCVSS = 11 // report only, don't fail the build
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optionally enriches vulnerability scans with OSS Index when credentials are present, improving coverage.
  * CI now forwards OSS Index credentials into the security scan step for non-fork runs, maintaining safety for forks.
  * Updated dependency-analysis plugin to the latest patch release for more accurate and stable scans.
  * Bumped plugin pre-release version.

* **Tests**
  * Added configuration to tests utilities to emit dependency-check reports (report-only threshold).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->