### PR TITLE
[RORDEV-2008] Use HTTP Maven repo for public artifact storage instead of Gradle s3 transport

### DIFF
--- a/build-base/src/main/groovy/readonlyrest.plugin-common-conventions.gradle
+++ b/build-base/src/main/groovy/readonlyrest.plugin-common-conventions.gradle
@@ -24,30 +24,16 @@ project.ext {
     publishedPluginVersion = rootProject.properties['pluginVersion']
     pluginVersion = rootProject.properties['pluginVersion']
     esVersion = project.hasProperty('esVersion') ? project.property('esVersion') : project.property('latestSupportedEsVersion')
-    s3BucketName = System.env.BUCKET ?: "beshu"
+    s3BucketName = System.getenv('BUCKET') ?: 'beshu'
+    s3StoreAddress = System.getenv('ROR_LIBS_STORE_URL') ?: 'https://dgp.serve.beshu.tech'
 }
 
 group = 'org.elasticsearch.plugin'
-version = pluginVersion + '_es' + project.ext.esVersion
-
-def storeAddress = System.env.ROR_LIBS_STORE_URL ?: ""
-if (storeAddress.startsWith("http")) {
-    System.setProperty("org.gradle.s3.endpoint", storeAddress)
-}
+version = "${pluginVersion}_es${project.ext.esVersion}"
 
 repositories {
     maven {
-        url = "s3://" + project.s3BucketName + "/ror/libs"
-        if (storeAddress.startsWith("http")) {
-            credentials(AwsCredentials) {
-                accessKey = System.env.ROR_LIBS_STORE_ACCESS_KEY_ID ?: ""
-                secretKey = System.env.ROR_LIBS_STORE_ACCESS_KEY_SECRET ?: ""
-            }
-        } else {
-            authentication {
-                awsIm(AwsImAuthentication)
-            }
-        }
+        url = uri("${project.ext.s3StoreAddress.replaceAll('/+$', '')}/${project.ext.s3BucketName}/ror/libs")
         metadataSources {
             artifact()
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -87,8 +87,10 @@ dependencies {
     api group: 'org.typelevel',                 name: 'squants_3',                           version: '1.8.3'
     api group: 'com.unboundid',                 name: 'unboundid-ldapsdk',                   version: '7.0.4'
     api group: 'com.lihaoyi',                   name: 'upickle_3',                           version: '4.4.2'
-    api group: 'org.bouncycastle',              name: 'bctls-fips',                          version: '2.1.22'
-    api group: 'org.bouncycastle',              name: 'bcpkix-fips',                         version: '2.1.10'
+    api group: 'org.bouncycastle',              name: 'bc-fips',                             version: '2.1.2'
+    api group: 'org.bouncycastle',              name: 'bcpkix-fips',                         version: '2.1.11'
+    api group: 'org.bouncycastle',              name: 'bctls-fips',                          version: '2.1.23'
+    api group: 'org.bouncycastle',              name: 'bcutil-fips',                         version: '2.1.6'
 
     testImplementation  project(':tests-utils')
     testImplementation  group: 'org.apache.logging.log4j',   name: 'log4j-core',                     version: '2.25.3'


### PR DESCRIPTION
Switched public artifact repository resolution from Gradle s3:// transport to a plain HTTP(S) Maven URL built from ROR_LIBS_STORE_URL and BUCKET.

This avoids Gradle S3 authentication requirements for publicly accessible artifacts and makes resolution work consistently with both native public S3 endpoints and S3-compatible public storage. The repo path remains /<bucket>/ror/libs, and dependency resolution continues to use artifact-based metadata lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to source S3 repository settings from environment variables, enabling more flexible deployment setups
  * Simplified repository endpoint configuration logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->