### PR TITLE
[RORDEV-2006] Fix JDK-related issues in es83x module after replacing HTTP client

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -461,15 +461,15 @@ stages:
               ROR_TASK: integration_es810x
             IT_es80x:
               ROR_TASK: integration_es80x
-            IT_es80x:
+            IT_es81x:
               ROR_TASK: integration_es81x
-            IT_es80x:
+            IT_es82x:
               ROR_TASK: integration_es82x
-            IT_es80x:
+            IT_es83x:
               ROR_TASK: integration_es83x
-            IT_es80x:
+            IT_es84x:
               ROR_TASK: integration_es84x
-            IT_es80x:
+            IT_es85x:
               ROR_TASK: integration_es85x
 
 #######################################################

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -461,16 +461,6 @@ stages:
               ROR_TASK: integration_es810x
             IT_es80x:
               ROR_TASK: integration_es80x
-            IT_es81x:
-              ROR_TASK: integration_es81x
-            IT_es82x:
-              ROR_TASK: integration_es82x
-            IT_es83x:
-              ROR_TASK: integration_es83x
-            IT_es84x:
-              ROR_TASK: integration_es84x
-            IT_es85x:
-              ROR_TASK: integration_es85x
 
 #######################################################
 ##### Integration tests for ES <= 7.x on PRs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -461,6 +461,16 @@ stages:
               ROR_TASK: integration_es810x
             IT_es80x:
               ROR_TASK: integration_es80x
+            IT_es80x:
+              ROR_TASK: integration_es81x
+            IT_es80x:
+              ROR_TASK: integration_es82x
+            IT_es80x:
+              ROR_TASK: integration_es83x
+            IT_es80x:
+              ROR_TASK: integration_es84x
+            IT_es80x:
+              ROR_TASK: integration_es85x
 
 #######################################################
 ##### Integration tests for ES <= 7.x on PRs

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/ApacheBasedSimpleHttpClient.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/ApacheBasedSimpleHttpClient.scala
@@ -34,6 +34,7 @@ import tech.beshu.ror.accesscontrol.utils.AsyncOps.deferFuture
 import tech.beshu.ror.utils.RequestIdAwareLogging
 
 import scala.concurrent.{Future, Promise}
+import scala.util.control.Exception.catching
 import scala.util.control.NonFatal
 import scala.language.postfixOps
 
@@ -94,6 +95,7 @@ private class ApacheBasedSimpleHttpClientCreator[F[_] : Async : ContextShift]
 
   private def newCloseableHttpAsyncClient(config: Config): CloseableHttpAsyncClient = {
     try {
+      checkJdkNetAvailability()
       val connectionConfig =
         ConnectionConfig.custom()
           .setConnectTimeout(Timeout.ofMilliseconds(config.connectionTimeout.value.toMillis))
@@ -135,6 +137,21 @@ private class ApacheBasedSimpleHttpClientCreator[F[_] : Async : ContextShift]
         noRequestIdLogger.error("Failed to create Apache HttpAsyncClient", ex)
         throw ex
     }
+  }
+
+  private def checkJdkNetAvailability(): Unit = {
+    catching(classOf[ClassNotFoundException], classOf[NoClassDefFoundError])
+      .either(Class.forName("jdk.net.Sockets"))
+      .left
+      .foreach { ex =>
+        val message =
+          "jdk.net module is not accessible (jdk.net.Sockets cannot be loaded). " +
+          "Apache HttpClient 5 requires it. " +
+          "Add '--add-modules=jdk.net' to JVM startup options " +
+          "(ES_JAVA_OPTS environment variable or jvm.options.d/ror.options file)."
+        noRequestIdLogger.error(message)
+        throw new RuntimeException(message, ex)
+      }
   }
 
 }

--- a/es717x/Dockerfile
+++ b/es717x/Dockerfile
@@ -51,7 +51,13 @@ RUN chmod +x /usr/local/bin/gosu \
          && rm -rf /usr/share/elasticsearch/jdk \
          && mkdir -p /usr/share/elasticsearch/jdk \
          && tar xzf /tmp/jdk.tar.gz -C /usr/share/elasticsearch/jdk --strip-components=1 \
-         && rm /tmp/jdk.tar.gz; \
+         && rm /tmp/jdk.tar.gz \
+         # Ensure jdk.net module is available after replacing bundled Oracle JDK 18 with Corretto 19, \
+         # so Apache HttpClient 5's ReflectionUtils can access jdk.net.Sockets without throwing \
+         # NoClassDefFoundError (which is not caught by its static initializer). \
+         && mkdir -p /usr/share/elasticsearch/config/jvm.options.d \
+         && echo "--add-modules=jdk.net" > /usr/share/elasticsearch/config/jvm.options.d/ror.options \
+         && chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/jvm.options.d/ror.options; \
        fi
 
 USER elasticsearch

--- a/es82x/Dockerfile
+++ b/es82x/Dockerfile
@@ -40,7 +40,13 @@ RUN chmod +x /usr/local/bin/gosu \
     && rm -rf /usr/share/elasticsearch/jdk \
     && mkdir -p /usr/share/elasticsearch/jdk \
     && tar xzf /tmp/jdk.tar.gz -C /usr/share/elasticsearch/jdk --strip-components=1 \
-    && rm /tmp/jdk.tar.gz
+    && rm /tmp/jdk.tar.gz \
+    # Ensure jdk.net module is available after replacing bundled Oracle JDK 18 with Corretto 19, \
+    # so Apache HttpClient 5's ReflectionUtils can access jdk.net.Sockets without throwing \
+    # NoClassDefFoundError (which is not caught by its static initializer). \
+    && mkdir -p /usr/share/elasticsearch/config/jvm.options.d \
+    && echo "--add-modules=jdk.net" > /usr/share/elasticsearch/config/jvm.options.d/ror.options \
+    && chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/jvm.options.d/ror.options
 
 USER elasticsearch
 

--- a/es83x/Dockerfile
+++ b/es83x/Dockerfile
@@ -40,7 +40,13 @@ RUN chmod +x /usr/local/bin/gosu \
     && rm -rf /usr/share/elasticsearch/jdk \
     && mkdir -p /usr/share/elasticsearch/jdk \
     && tar xzf /tmp/jdk.tar.gz -C /usr/share/elasticsearch/jdk --strip-components=1 \
-    && rm /tmp/jdk.tar.gz
+    && rm /tmp/jdk.tar.gz \
+    # Ensure jdk.net module is available after replacing bundled Oracle JDK 18 with Corretto 19, \
+    # so Apache HttpClient 5's ReflectionUtils can access jdk.net.Sockets without throwing \
+    # NoClassDefFoundError (which is not caught by its static initializer). \
+    && mkdir -p /usr/share/elasticsearch/config/jvm.options.d \
+    && echo "--add-modules=jdk.net" > /usr/share/elasticsearch/config/jvm.options.d/ror.options \
+    && chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/jvm.options.d/ror.options
 
 USER elasticsearch
 

--- a/es84x/Dockerfile
+++ b/es84x/Dockerfile
@@ -40,7 +40,13 @@ RUN chmod +x /usr/local/bin/gosu \
     && rm -rf /usr/share/elasticsearch/jdk \
     && mkdir -p /usr/share/elasticsearch/jdk \
     && tar xzf /tmp/jdk.tar.gz -C /usr/share/elasticsearch/jdk --strip-components=1 \
-    && rm /tmp/jdk.tar.gz
+    && rm /tmp/jdk.tar.gz \
+    # Ensure jdk.net module is available after replacing bundled Oracle JDK 18 with Corretto 19, \
+    # so Apache HttpClient 5's ReflectionUtils can access jdk.net.Sockets without throwing \
+    # NoClassDefFoundError (which is not caught by its static initializer). \
+    && mkdir -p /usr/share/elasticsearch/config/jvm.options.d \
+    && echo "--add-modules=jdk.net" > /usr/share/elasticsearch/config/jvm.options.d/ror.options \
+    && chown elasticsearch:elasticsearch /usr/share/elasticsearch/config/jvm.options.d/ror.options
 
 USER elasticsearch
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.69.1
-pluginVersion=1.70.0-pre3
+pluginVersion=1.70.0-pre4
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/Elasticsearch.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/Elasticsearch.scala
@@ -315,15 +315,17 @@ class Elasticsearch(val esVersion: String,
     (Version.greaterOrEqualThan(esVersion, 7, 15, 1) && Version.lowerThan(esVersion, 7, 17, 7)) ||
     (Version.greaterOrEqualThan(esVersion, 8, 0, 0) && Version.lowerThan(esVersion, 8, 5, 0))
 
+  // ES versions that bundle JDK 18, which we replace with Corretto 19 to fix JDK-8287073.
+  private def needsCorretto19: Boolean =
+    (Version.greaterOrEqualThan(esVersion, 7, 17, 3) && Version.lowerThan(esVersion, 7, 17, 7)) ||
+      (Version.greaterOrEqualThan(esVersion, 8, 2, 0) && Version.lowerThan(esVersion, 8, 5, 0))
+
   // Replace the bundled JDK in-place with the cached custom JDK tarball.
   private def replaceBundledJdk(image: DockerImageDescription): DockerImageDescription = {
     // JDK 17.0.0–17.0.4 and JDK 18 have cgroup v2 bug JDK-8287073 (NPE in CgroupV2Subsystem).
     // JDK-17 builds (ES 7.15.1–7.15.2, 7.16.x, 7.17.0–7.17.2, 8.0.x–8.1.x) → Corretto 17.0.5 (backport JDK-8288308).
     // JDK-18 builds (ES 7.17.3–7.17.6, 8.2.x–8.4.x) → Corretto 19.0.0 (first JDK 19 with the fix).
     // Downloaded once per JVM process and reused across all container builds.
-    val needsCorretto19 =
-      (Version.greaterOrEqualThan(esVersion, 7, 17, 3) && Version.lowerThan(esVersion, 7, 17, 7)) ||
-      (Version.greaterOrEqualThan(esVersion, 8, 2, 0) && Version.lowerThan(esVersion, 8, 5, 0))
     val tarball =
       if (needsCorretto19) JDK.AmazonCorretto1900jdk.tarball
       else JDK.AmazonCorretto1705jdk.tarball
@@ -350,6 +352,7 @@ class Elasticsearch(val esVersion: String,
       .add("-Xmx512m")
       .add("-Djava.security.egd=file:/dev/./urandoms")
       .add("-Xdebug", s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${xDebugAddressBasedOn(esVersion)}")
+      .addWhen(needsCorretto19, "--add-modules=jdk.net")
   }
 
   private def xDebugAddressBasedOn(esVersion: String) = {
@@ -390,6 +393,10 @@ final case class EsJavaOptsBuilder(options: Seq[String]) {
 
   def add(option: String*): EsJavaOptsBuilder = {
     this.copy(options = this.options ++ option.toSeq)
+  }
+
+  def addWhen(condition: Boolean, option: => String): EsJavaOptsBuilder = {
+    if (condition) add(option) else this
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced JVM compatibility for newer Elasticsearch versions by configuring required platform modules during container initialization.
  * Added runtime validation to detect and report missing JDK module dependencies with clear guidance.

* **Chores**
  * Version bump to 1.70.0-pre4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->