### PR TITLE
[RORDEV-1837] Handle global_checkpoint_sync as an internal action

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/domain/elasticsearch.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/domain/elasticsearch.scala
@@ -43,6 +43,7 @@ object Action {
     val getSettingsAction: Action = EsAction("indices:monitor/settings/get")
     val monitorStateAction: Action = EsAction("cluster:monitor/state")
     val restoreSnapshotAction: Action = EsAction("cluster:admin/snapshot/restore")
+    val globalCheckpointSyncAction: Action = EsAction("indices:admin/seq_no/global_checkpoint_sync")
   }
 
   abstract sealed class RorAction(override val value: String) extends Action with EnumEntry
@@ -109,7 +110,19 @@ object Action {
       .getOrElse(EsAction(value))
   }
 
-  def isInternal(actionString: String): Boolean = actionString.startsWith("internal:")
+  def isInternal(actionString: String): Boolean =
+    actionString.startsWith("internal:") ||
+      // This operation is called by the TransportReplicationAction (optionally, controlled by syncGlobalCheckpointAfterOperation toggle).
+      // When called, it is executed directly in the calling thread's context, which means that it would go through ACL.
+      // It would have to be explicitly added to the list of allowed actions in order to work.
+      // It is treated as an internal action instead, so it does not have to be manually added to ACL rules.
+      //
+      // It can be considered as a bug, or at least a discrepancy, in ES logic:
+      //   - in a similar situation, the 'retention_lease_background_sync' action is explicitly wrapped in empty system context
+      //   - which means that action is treated correctly by default
+      //   - 'indices:admin/seq_no/global_checkpoint_sync' should be likely treated the same, but it is not, so we have to handle it here
+      actionString == EsAction.globalCheckpointSyncAction.value
+
   def isMonitorState(actionString: String): Boolean = actionString == EsAction.monitorStateAction.value
   def isXpackSecurity(actionString: String): Boolean = actionString.startsWith("cluster:admin/xpack/security/")
   def isRollupAction(actionString: String): Boolean = actionString.startsWith("cluster:admin/xpack/rollup/")

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/domain/ActionTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/domain/ActionTests.scala
@@ -94,4 +94,29 @@ class ActionTests extends AnyWordSpec with Matchers {
       }
     }
   }
+
+  "Action.isInternal" when {
+    "action starts with 'internal:'" should {
+      "be treated as internal" in {
+        Action("internal:cluster/shard/search/rewrite/context").isInternal should be(true)
+      }
+    }
+    "action is global_checkpoint_sync" should {
+      "be treated as internal" in {
+        Action("indices:admin/seq_no/global_checkpoint_sync").isInternal should be(true)
+      }
+    }
+    "action is a regular user-facing action" should {
+      "not be treated as internal" in {
+        Action("indices:data/write/bulk").isInternal should be(false)
+      }
+    }
+    "action is another seq_no action" should {
+      "not be treated as internal" in {
+        Action("indices:admin/seq_no/add_retention_lease").isInternal should be(false)
+        Action("indices:admin/seq_no/renew_retention_lease").isInternal should be(false)
+        Action("indices:admin/seq_no/remove_retention_lease").isInternal should be(false)
+      }
+    }
+  }
 }


### PR DESCRIPTION
🐞 Fix (ES) The ES action `indices:admin/seq_no/global_checkpoint_sync` is now treated as an internal action and bypasses ACL evaluation. This action is dispatched by Elasticsearch internally after write operations and should never
  require explicit user permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Elasticsearch global checkpoint synchronization as an internal operation, enhancing access control handling for background maintenance activities.

* **Tests**
  * Expanded test coverage for action classification to verify proper identification of internal operations, including global checkpoint synchronization and retention lease actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->