### PR TITLE
Claude GH Actions jobs improvements

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,4 +43,6 @@ jobs:
           show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          # Restrict to gh CLI only — prevents prompt injection in PR diffs from running arbitrary shell commands
+          claude_args: '--allowedTools Bash(gh:*)'
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,6 @@ jobs:
           show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # Restrict to gh CLI only — prevents prompt injection in PR diffs from running arbitrary shell commands
-          claude_args: '--allowedTools Bash(gh:*)'
+          # Restrict to read PR diff and post review comments only — prevents prompt injection in PR diffs from running arbitrary shell commands
+          claude_args: '--allowedTools Bash(gh:pr view*),Bash(gh:pr diff*),Bash(gh:pr comment*)'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,4 +60,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowedTools Bash(gh:*)'
+          claude_args: '--allowedTools Bash(gh:pr*),Bash(gh:issue*),Bash(gh:run view*),Bash(gh:run list*)'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,25 @@ on:
 
 jobs:
   claude:
+    # Only run for trusted authors (OWNER/MEMBER/COLLABORATOR) who mention @claude.
+    # Each branch explicitly pairs an event with its own author_association field
+    # to avoid ambiguity about which payload field is being checked.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment'
+        && contains(github.event.comment.body, '@claude')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      ||
+      (github.event_name == 'pull_request_review_comment'
+        && contains(github.event.comment.body, '@claude')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      ||
+      (github.event_name == 'pull_request_review'
+        && contains(github.event.review.body, '@claude')
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
+      ||
+      (github.event_name == 'issues'
+        && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,5 +60,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          claude_args: '--allowedTools Bash(gh:*)'


### PR DESCRIPTION
## Summary

- **`claude.yml`**: Added `author_association` check to every trigger branch (issue comment, PR review comment, PR review, issue open/assign). Without this, any public GitHub user could invoke `@claude` and get a shell session backed by `CLAUDE_CODE_OAUTH_TOKEN`. Allowed associations: `OWNER`, `MEMBER`, `COLLABORATOR`.
- **Both workflows**: Replaced `Bash(gh:*)` with specific subcommand allowlists to close prompt-injection exfiltration paths (`gh auth token`, `gh secret`, `gh workflow run`, etc.):
  - `claude.yml` (interactive): `Bash(gh:pr*),Bash(gh:issue*),Bash(gh:run view*),Bash(gh:run list*)`
  - `claude-code-review.yml` (automated review): `Bash(gh:pr view*),Bash(gh:pr diff*),Bash(gh:pr comment*)`

## Threat model

Before this change, a PR body or issue comment containing a prompt-injection payload could trigger an unrestricted `gh` shell in the CI runner, then call `gh auth token` to print the OAuth token and exfiltrate it (e.g. via a `gh issue comment`). The author-association gate is the primary defence; the narrowed allowlist is a second layer that limits blast radius even if injection bypasses the gate.
