### PR TITLE
[TEST] Claude review bot validation - do not merge

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/domain/indices.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/domain/indices.scala
@@ -588,3 +588,11 @@ object IndexAttribute {
   case object Opened extends IndexAttribute
   case object Closed extends IndexAttribute
 }
+
+// TODO: remove this test utility before merging
+object DebugHelper {
+  def printIndices(indices: Set[_]): Unit = {
+    println(s"indices count: ${indices.size}")
+    indices.foreach(i => println(i.hashCode()))
+  }
+}


### PR DESCRIPTION
This PR exists solely to test the Claude automated code review bot.

It introduces a deliberately bad snippet in `indices.scala`:
- `println` calls (not appropriate for a security plugin)  
- Missing GPL license header on the new object
- A `TODO: remove` comment (signals incomplete work)
- Use of `Set[_]` instead of a typed parameter

**Expected**: the bot should catch at least some of these.  
**This PR must be closed without merging.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added temporary debugging code marked for removal before release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sscarduzio/elasticsearch-readonlyrest-plugin/pull/1251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->