### PR TITLE
[RORDEV-2042] Restrict `allowed_api_paths` to `access: api_only`

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/rules/kibana/KibanaUserDataRuleDecoder.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/decoders/rules/kibana/KibanaUserDataRuleDecoder.scala
@@ -33,6 +33,7 @@ import tech.beshu.ror.accesscontrol.factory.RawRorSettingsBasedCoreFactory.CoreC
 import tech.beshu.ror.accesscontrol.factory.decoders.common.*
 import tech.beshu.ror.accesscontrol.factory.decoders.rules.RuleBaseDecoder.RuleBaseDecoderWithoutAssociatedFields
 import tech.beshu.ror.accesscontrol.utils.CirceOps.*
+import tech.beshu.ror.accesscontrol.utils.CirceOps.DecodingFailureUtils.decodingFailureFrom
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.js.JsCompiler
@@ -57,11 +58,8 @@ class KibanaUserDataRuleDecoder(settingsIndex: RorSettingsIndex,
           kibanaIndex <- c.downField("index").as[Option[RuntimeSingleResolvableVariable[KibanaIndexName]]]
           kibanaTemplateIndex <- c.downField("template_index").as[Option[RuntimeSingleResolvableVariable[KibanaIndexName]]]
           appsToHide <- c.downField("hide_apps").as[Option[Set[KibanaApp]]]
-          allowedApiPaths <- c.downField("allowed_api_paths").as[Option[Set[KibanaAllowedApiPath]]]
-          metadataResolvableJsonRepresentation <- c.keys.flatMap(_.find(_ == "metadata")) match {
-            case Some(_) => c.downField("metadata").as[ResolvableJsonRepresentation].map(Some.apply)
-            case None => Right(None)
-          }
+          allowedApiPaths <- allowedApiPathsDecoder(access).apply(c)
+          metadataResolvableJsonRepresentation <- metadataDecoder.apply(c)
         } yield new KibanaUserDataRule(KibanaUserDataRule.Settings(
           access = access,
           kibanaIndex = kibanaIndex.getOrElse(RuntimeSingleResolvableVariable.AlreadyResolved(KibanaIndexName.default)),
@@ -78,7 +76,7 @@ class KibanaUserDataRuleDecoder(settingsIndex: RorSettingsIndex,
       .decoder
   }
 
-  private implicit lazy val kibanaAllowedApiPathLikeDecoder: Decoder[KibanaAllowedApiPath] = {
+  private implicit lazy val kibanaAllowedApiPathDecoder: Decoder[KibanaAllowedApiPath] = {
     implicit val simpleKibanaAllowedApiPathDecoder: Decoder[KibanaAllowedApiPath] =
       pathRegexDecoder.map(KibanaAllowedApiPath(AllowedHttpMethod.Any, _))
 
@@ -91,6 +89,21 @@ class KibanaUserDataRuleDecoder(settingsIndex: RorSettingsIndex,
 
     extendedKibanaAllowedApiDecoder.or(simpleKibanaAllowedApiPathDecoder)
   }
+
+  private def allowedApiPathsDecoder(access: KibanaAccess): Decoder[Option[Set[KibanaAllowedApiPath]]] =
+    Decoder.instance { c =>
+      val allowedApiPathsField = c.downField("allowed_api_paths")
+      access match {
+        case KibanaAccess.ApiOnly =>
+          allowedApiPathsField.as[Option[Set[KibanaAllowedApiPath]]]
+        case _ if allowedApiPathsField.succeeded =>
+          Left(decodingFailureFrom(RulesLevelCreationError(Message(
+            "'allowed_api_paths' can only be used with 'access: api_only'"
+          ))))
+        case _ =>
+          Right(None)
+      }
+    }
 
   private implicit lazy val pathRegexDecoder: Decoder[JavaRegex] =
     Decoder
@@ -133,4 +146,12 @@ class KibanaUserDataRuleDecoder(settingsIndex: RorSettingsIndex,
       Right(JavaRegex.buildFromLiteral(str.value))
     }
   }
+
+  private val metadataDecoder: Decoder[Option[ResolvableJsonRepresentation]] =
+    Decoder.instance { c =>
+      c.keys.flatMap(_.find(_ == "metadata")) match {
+        case Some(_) => c.downField("metadata").as[ResolvableJsonRepresentation].map(Some.apply)
+        case None => Right(None)
+      }
+    }
 }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaUserDataRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaUserDataRuleSettingsTests.scala
@@ -607,6 +607,73 @@ class KibanaUserDataRuleSettingsTests
             }
           )
         }
+        "its value is a scalar string" in {
+          assertDecodingSuccess(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block1
+                |    auth_key: user:pass
+                |    kibana:
+                |      access: "ro"
+                |      metadata: "hello"
+                |""".stripMargin,
+            assertion = rule => {
+              rule.settings.genericMetadata should be(Some(JsonTree.Value(AlreadyResolved(StringValue("hello")))))
+            }
+          )
+        }
+        "its value is a top-level array" in {
+          assertDecodingSuccess(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block1
+                |    auth_key: user:pass
+                |    kibana:
+                |      access: "ro"
+                |      metadata: ["a", "b"]
+                |""".stripMargin,
+            assertion = rule => {
+              rule.settings.genericMetadata should be(Some(JsonTree.Array(List(
+                JsonTree.Value(AlreadyResolved(StringValue("a"))),
+                JsonTree.Value(AlreadyResolved(StringValue("b")))
+              ))))
+            }
+          )
+        }
+        "its value contains variable expressions" in {
+          assertDecodingSuccess(
+            yaml =
+              """
+                |readonlyrest:
+                |  access_control_rules:
+                |
+                |  - name: test_block1
+                |    auth_key: user:pass
+                |    kibana:
+                |      access: "ro"
+                |      metadata:
+                |        username: "@{user}"
+                |        static: "literal"
+                |""".stripMargin,
+            assertion = rule => {
+              rule.settings.genericMetadata.value match {
+                case JsonTree.Object(fields) =>
+                  fields("username") match {
+                    case JsonTree.Value(v) => v shouldBe a[ToBeResolved[_]]
+                    case other => fail(s"Expected JsonTree.Value but got $other")
+                  }
+                  fields("static") should be(JsonTree.Value(AlreadyResolved(StringValue("literal"))))
+                case other => fail(s"Expected JsonTree.Object but got $other")
+              }
+            }
+          )
+        }
       }
     }
     "not be able to be loaded from settings" when {

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaUserDataRuleSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/rules/kibana/KibanaUserDataRuleSettingsTests.scala
@@ -77,7 +77,6 @@ class KibanaUserDataRuleSettingsTests
               |      index: ".kibana_custom"
               |      template_index: ".kibana_template"
               |      hide_apps: ["app1", "app2"]
-              |      allowed_api_paths: ["^/api/spaces/.*$"]
               |
               |""".stripMargin,
           assertion = rule => {
@@ -85,9 +84,7 @@ class KibanaUserDataRuleSettingsTests
             rule.settings.kibanaIndex should be(AlreadyResolved(kibanaIndexName(".kibana_custom")))
             rule.settings.kibanaTemplateIndex should be(Some(AlreadyResolved(kibanaIndexName(".kibana_template"))))
             rule.settings.appsToHide should be(Set(FullNameKibanaApp("app1"), FullNameKibanaApp("app2")))
-            rule.settings.allowedApiPaths should be(
-              Set(KibanaAllowedApiPath(AllowedHttpMethod.Any, JavaRegex.compile("""^/api/spaces/.*$""").get))
-            )
+            rule.settings.allowedApiPaths should be(Set.empty)
             rule.settings.genericMetadata should be(None)
             rule.settings.rorIndex should be(RorSettingsIndex(IndexName.Full(".readonlyrest")))
           }
@@ -345,12 +342,12 @@ class KibanaUserDataRuleSettingsTests
                 |
                 |  - name: test_block1
                 |    kibana:
-                |      access: "ro"
+                |      access: "api_only"
                 |      allowed_api_paths: ["^/api/spaces/.*$"]
                 |
                 |""".stripMargin,
             assertion = rule => {
-              rule.settings.access should be(KibanaAccess.RO)
+              rule.settings.access should be(KibanaAccess.ApiOnly)
               rule.settings.kibanaIndex should be(AlreadyResolved(kibanaIndexName(".kibana")))
               rule.settings.kibanaTemplateIndex should be(None)
               rule.settings.appsToHide should be(Set.empty)
@@ -371,12 +368,12 @@ class KibanaUserDataRuleSettingsTests
                 |
                 |  - name: test_block1
                 |    kibana:
-                |      access: "ro"
+                |      access: "api_only"
                 |      allowed_api_paths: ["/api/spaces?test=12.2"]
                 |
                 |""".stripMargin,
             assertion = rule => {
-              rule.settings.access should be(KibanaAccess.RO)
+              rule.settings.access should be(KibanaAccess.ApiOnly)
               rule.settings.kibanaIndex should be(AlreadyResolved(kibanaIndexName(".kibana")))
               rule.settings.kibanaTemplateIndex should be(None)
               rule.settings.appsToHide should be(Set.empty)
@@ -400,14 +397,14 @@ class KibanaUserDataRuleSettingsTests
                 |
                 |  - name: test_block1
                 |    kibana:
-                |      access: "ro"
+                |      access: "api_only"
                 |      allowed_api_paths:
                 |        - http_method: GET
                 |          http_path: "/api/spaces?test=12.2"
                 |
                 |""".stripMargin,
             assertion = rule => {
-              rule.settings.access should be(KibanaAccess.RO)
+              rule.settings.access should be(KibanaAccess.ApiOnly)
               rule.settings.kibanaIndex should be(AlreadyResolved(kibanaIndexName(".kibana")))
               rule.settings.kibanaTemplateIndex should be(None)
               rule.settings.appsToHide should be(Set.empty)
@@ -431,7 +428,7 @@ class KibanaUserDataRuleSettingsTests
                 |
                 |  - name: test_block1
                 |    kibana:
-                |      access: "ro"
+                |      access: "api_only"
                 |      allowed_api_paths:
                 |        - "^/api/spaces/.*$"
                 |        - http_method: GET
@@ -439,7 +436,7 @@ class KibanaUserDataRuleSettingsTests
                 |
                 |""".stripMargin,
             assertion = rule => {
-              rule.settings.access should be(KibanaAccess.RO)
+              rule.settings.access should be(KibanaAccess.ApiOnly)
               rule.settings.kibanaIndex should be(AlreadyResolved(kibanaIndexName(".kibana")))
               rule.settings.kibanaTemplateIndex should be(None)
               rule.settings.appsToHide should be(Set.empty)
@@ -467,12 +464,12 @@ class KibanaUserDataRuleSettingsTests
                 |
                 |  - name: test_block1
                 |    kibana:
-                |      access: "ro"
+                |      access: "api_only"
                 |      allowed_api_paths: []
                 |
                 |""".stripMargin,
             assertion = rule => {
-              rule.settings.access should be(KibanaAccess.RO)
+              rule.settings.access should be(KibanaAccess.ApiOnly)
               rule.settings.kibanaIndex should be(AlreadyResolved(kibanaIndexName(".kibana")))
               rule.settings.kibanaTemplateIndex should be(None)
               rule.settings.appsToHide should be(Set.empty)
@@ -702,6 +699,28 @@ class KibanaUserDataRuleSettingsTests
                 |  - "app1"
                 |  - "app2"
                 |""".stripMargin)))
+          }
+        )
+      }
+      "'allowed_api_paths' is used with non-api_only access" in {
+        assertDecodingFailure(
+          yaml =
+            """
+              |readonlyrest:
+              |
+              |  access_control_rules:
+              |
+              |  - name: test_block1
+              |    kibana:
+              |      access: ro
+              |      allowed_api_paths: ["^/api/spaces/.*$"]
+              |
+              |""".stripMargin,
+          assertion = errors => {
+            errors should have size 1
+            errors.head should be(RulesLevelCreationError(Message(
+              "'allowed_api_paths' can only be used with 'access: api_only'"
+            )))
           }
         )
       }

--- a/docs/api/ror-internal-api-swagger.yaml
+++ b/docs/api/ror-internal-api-swagger.yaml
@@ -783,7 +783,7 @@ components:
             $ref: '#/components/schemas/KibanaHiddenAppLike'
         allowed_api_paths:
           type: array
-          description: Kibana API paths allowed (supports regexes). Available for all license types.
+          description: Kibana API paths allowed (supports regexes). Only present when access is 'api_only'. Available for all license types.
           items:
             $ref: '#/components/schemas/KibanaAllowedApiPath'
         metadata:
@@ -1653,11 +1653,6 @@ components:
               index: .kibana_7.17_admin
               template_index: .kibana_7.17_template
               hidden_apps: []
-              allowed_api_paths:
-                - http_method: ANY
-                  path_regex: "^/api/index_management/indices$"
-                - http_method: GET
-                  path_regex: "^/api/saved_objects/.*$"
               metadata:
                 role: superuser
                 department: IT
@@ -1666,13 +1661,17 @@ components:
               name: management
             username: admin
             kibana:
-              access: rw
+              access: api_only
               index: .kibana_7.17_management
               template_index: .kibana_7.17_management_template
               hidden_apps:
                 - "Enterprise Search|Overview"
                 - "Observability"
-              allowed_api_paths: []
+              allowed_api_paths:
+                - http_method: ANY
+                  path_regex: "^/api/index_management/indices$"
+                - http_method: GET
+                  path_regex: "^/api/saved_objects/.*$"
               metadata:
                 role: manager
           - group:
@@ -1688,12 +1687,11 @@ components:
                 - "Enterprise Search|Overview"
                 - "Observability"
                 - "/^Analytics\\|(?!(Maps)$).*$/"
-              allowed_api_paths: []
               metadata: {}
 
     GetUserWithoutGroupsMetadataResponseExample:
       summary: User metadata (free license)
-      description: Response when X-ROR-KBN-License-Type is 'free'. Shows only basic fields (access, index, allowed_api_paths). No enterprise-only or pro features.
+      description: Response when X-ROR-KBN-License-Type is 'free'. Shows only basic fields (access, index). No enterprise-only or pro features.
       value:
         type: USER_WITHOUT_GROUPS
         correlation_id: 7D2695DF-C2CC-419A-9D0D-8A309D429786
@@ -1701,9 +1699,6 @@ components:
         kibana:
           access: admin
           index: .kibana_7.17_admin
-          allowed_api_paths:
-            - http_method: ANY
-              path_regex: "^/api/index_management/indices$"
 
     GetUserMetadataResponseProExample:
       summary: User metadata (pro license)
@@ -1718,11 +1713,6 @@ components:
           hidden_apps:
             - "Enterprise Search|Overview"
             - "Observability"
-          allowed_api_paths:
-            - http_method: ANY
-              path_regex: "^/api/index_management/indices$"
-            - http_method: GET
-              path_regex: "^/api/saved_objects/.*$"
 
     GetUserMetadataResponseEntDisabledMultitenancyExample:
       summary: User metadata (ent-disabled-multitenancy license)
@@ -1738,11 +1728,6 @@ components:
           template_index: .kibana_7.17_template
           hidden_apps:
             - "Enterprise Search|Overview"
-          allowed_api_paths:
-            - http_method: ANY
-              path_regex: "^/api/index_management/indices$"
-            - http_method: GET
-              path_regex: "^/api/saved_objects/.*$"
           metadata:
             role: superuser
             department: IT

--- a/docs/api/ror-internal-api-swagger.yaml
+++ b/docs/api/ror-internal-api-swagger.yaml
@@ -1619,14 +1619,6 @@ components:
             name: users
         x-ror-kibana_index: .kibana_7.17_admin
         x-ror-kibana_access: admin
-        x-ror-kibana-allowed-api-paths:
-          - http_method: ANY
-            path_regex: "^/api/index_management/indices$"
-          - http_method: ANY
-            path_regex: >-
-              ^\/api\/spaces\/.*$
-          - http_method: GET
-            path_regex: "^/api/saved_objects/.*$"
         x-ror-kibana-metadata:
           key1: string
           key2: 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.69.1
-pluginVersion=1.70.0-pre8
+pluginVersion=1.70.0-pre9
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/resources/user_metadata/readonlyrest.yml
+++ b/integration-tests/src/test/resources/user_metadata/readonlyrest.yml
@@ -22,7 +22,7 @@ readonlyrest:
       users: ["user2"]
       groups: [group2, group3]
       kibana:
-        access: ro
+        access: api_only
         index: "user2_kibana_index"
         hide_apps: ["user2_app1", "user2_app2", "/^Analytics\\|(?!(Maps)$).*$/"]
         allowed_api_paths:

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/UserMetadataSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/UserMetadataSuite.scala
@@ -115,7 +115,7 @@ class UserMetadataSuite
                |      "group":{"id":"group2","name":"group2"},
                |      "username":"user2",
                |      "kibana":{
-               |        "access":"ro",
+               |        "access":"api_only",
                |        "index":"user2_kibana_index",
                |        "hidden_apps":["user2_app1","user2_app2","/^Analytics\\\\|(?!(Maps)$$).*$$/"],
                |        "allowed_api_paths":[
@@ -295,7 +295,7 @@ class UserMetadataSuite
                |      "group":{"id":"group2","name":"group2"},
                |      "username":"user2",
                |      "kibana":{
-               |        "access":"ro",
+               |        "access":"api_only",
                |        "index":"user2_kibana_index",
                |        "hidden_apps":["user2_app1","user2_app2","/^Analytics\\\\|(?!(Maps)$$).*$$/"],
                |        "allowed_api_paths":[


### PR DESCRIPTION
## Summary

`allowed_api_paths` in the `kibana` rule is now only valid when `access: api_only` is set. Using it with any other access level now produces a configuration error.

Updated tests, Swagger docs, and user documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced that allowed_api_paths can only be used with api_only access; invalid combinations now fail validation.

* **Tests**
  * Updated unit and integration tests to reflect api_only requirement and expanded metadata decoding coverage (strings, arrays, objects with variables).

* **Documentation**
  * Updated API schema and examples to show allowed_api_paths only appears when access is api_only.

* **Chores**
  * Bumped plugin version to 1.70.0-pre9.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sscarduzio/elasticsearch-readonlyrest-plugin/pull/1253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->