### PR TITLE
ci: restore id-token: write on claude-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
+      id-token: write # required for OIDC token exchange with the Anthropic backend
       actions: read
 
     steps:


### PR DESCRIPTION
Without `id-token: write` the runner can't populate `ACTIONS_ID_TOKEN_REQUEST_URL`, so claude-code-action's OIDC token exchange fails with:

```
Failed to get OIDC token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

This permission was present in #1255 as merged but was dropped in a subsequent edit on develop. Every claude-review run on this repo has been failing since (e.g. PR #1257 run 26589789991).

One-line fix. Safe to merge with admin override since the bot reviewing itself will hit the same error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable secure token exchange with backend services. This infrastructure change has no impact on user-facing functionality or features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sscarduzio/elasticsearch-readonlyrest-plugin/pull/1258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->