### PR TITLE
[RORDEV-1229] CI: extract pre-build Docker image publishing to a dedicated Azure pipeline

### DIFF
--- a/.azure/publish-pre-builds.yml
+++ b/.azure/publish-pre-builds.yml
@@ -29,7 +29,6 @@ stages:
             clean: false
             persistCredentials: true
           - bash: |
-              TARGET_BRANCH="${{ parameters.targetBranch }}"
               if [ -n "$(echo "$TARGET_BRANCH" | tr -d '[:space:]')" ]; then
                 if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
                   echo "Branch '$TARGET_BRANCH' found, checking out"
@@ -40,6 +39,8 @@ stages:
                 fi
               fi
             displayName: 'Checkout target branch'
+            env:
+              TARGET_BRANCH: ${{ parameters.targetBranch }}
           - task: JavaToolInstaller@0
             inputs:
               versionSpec: '17'
@@ -57,7 +58,7 @@ stages:
           - script: |
               set -ex
 
-              if [ -z "$(echo "${{ parameters.esVersions }}" | tr -d '[:space:],')" ]; then
+              if [ -z "$(echo "$ES_VERSIONS" | tr -d '[:space:],')" ]; then
                 echo "Error: esVersions parameter is required"
                 exit 1
               fi
@@ -67,13 +68,14 @@ stages:
                 exit 1
               fi
 
-              export BUILD_ROR_ES_VERSIONS="${{ parameters.esVersions }}"
+              export BUILD_ROR_ES_VERSIONS="$ES_VERSIONS"
 
               echo ">>> Publishing pre-build docker images for: $BUILD_ROR_ES_VERSIONS"
               ci/run-pipeline.sh
-            timeoutInMinutes: 60
+            timeoutInMinutes: 600
             env:
               ROR_TASK: publish_pre_builds_docker_images
+              ES_VERSIONS: ${{ parameters.esVersions }}
               var_docker_registry_user: $(DOCKER_REGISTRY_USER)
               var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)
               GRADLE_USER_HOME: $(GRADLE_USER_HOME)

--- a/.azure/publish-pre-builds.yml
+++ b/.azure/publish-pre-builds.yml
@@ -1,0 +1,79 @@
+trigger: none
+
+parameters:
+  - name: esVersions
+    type: string
+    displayName: 'Space or comma-separated list of ES versions (e.g., "9.4.2" or "9.4.2 8.19.16")'
+    default: ' '
+  - name: targetBranch
+    type: string
+    displayName: 'Branch to build from (falls back to develop if not found, builds from current branch if empty)'
+    default: ' '
+
+variables:
+  GRADLE_USER_HOME: '$(Pipeline.Workspace)/.gradle'
+
+pool:
+  vmImage: 'ubuntu-24.04'
+
+stages:
+  - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
+    displayName: 'Publish docker images for specified pre-builds'
+    jobs:
+      - job: PUBLISH
+        displayName: 'Publishing'
+        timeoutInMinutes: 600
+        steps:
+          - checkout: self
+            fetchDepth: 0
+            clean: false
+            persistCredentials: true
+          - bash: |
+              TARGET_BRANCH="${{ parameters.targetBranch }}"
+              if [ -n "$(echo "$TARGET_BRANCH" | tr -d '[:space:]')" ]; then
+                if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
+                  echo "Branch '$TARGET_BRANCH' found, checking out"
+                  git checkout "$TARGET_BRANCH"
+                else
+                  echo "Branch '$TARGET_BRANCH' not found, falling back to develop"
+                  git checkout develop
+                fi
+              fi
+            displayName: 'Checkout target branch'
+          - task: JavaToolInstaller@0
+            inputs:
+              versionSpec: '17'
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'PreInstalled'
+          - task: Cache@2
+            displayName: 'Restore Gradle cache'
+            inputs:
+              key: 'gradle | "$(Agent.OS)" | **/gradle/wrapper/gradle-wrapper.properties | **/settings.gradle* | **/build.gradle* | **/gradle.properties'
+              restoreKeys: |
+                gradle | "$(Agent.OS)"
+                gradle
+              path: $(GRADLE_USER_HOME)
+              cacheHitVar: GRADLE_CACHE_HIT
+          - script: |
+              set -ex
+
+              if [ -z "$(echo "${{ parameters.esVersions }}" | tr -d '[:space:],')" ]; then
+                echo "Error: esVersions parameter is required"
+                exit 1
+              fi
+
+              if ! docker login -u $var_docker_registry_user -p $var_docker_registry_password; then
+                echo "Error: Failed to login to Docker registry"
+                exit 1
+              fi
+
+              export BUILD_ROR_ES_VERSIONS="${{ parameters.esVersions }}"
+
+              echo ">>> Publishing pre-build docker images for: $BUILD_ROR_ES_VERSIONS"
+              ci/run-pipeline.sh
+            timeoutInMinutes: 60
+            env:
+              ROR_TASK: publish_pre_builds_docker_images
+              var_docker_registry_user: $(DOCKER_REGISTRY_USER)
+              var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)
+              GRADLE_USER_HOME: $(GRADLE_USER_HOME)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,24 +34,10 @@ parameters:
   - name: actionToPerform
     type: string
     displayName: '(Manual) action to perform'
-    default: 'publish_docker_image_pre_builds'
+    default: 'run_all_tests_on_linux'
     values:
-      - 'publish_docker_image_pre_builds'
-      - 'publish_dev_docker_image'
       - 'run_all_tests_on_linux'
       - 'run_all_tests_on_windows'
-  - name: preBuildVersionsForPublishingToDockerHub
-    type: string
-    displayName: 'Space or comma-separated list of ES version numbers (e.g., "7.17.20 8.15.0")'
-    default: ' '
-  - name: targetBranch
-    type: string
-    displayName: 'Target branch to checkout and build from (for publish_dev_docker_image)'
-    default: ' '
-  - name: esVersion
-    type: string
-    displayName: 'ES version to build and publish to dev DockerHub (e.g., "9.4.2")'
-    default: ' '
 
 pool:
   vmImage: 'ubuntu-24.04'
@@ -1013,80 +999,3 @@ stages:
               VAR_GPG_KEY_ID: $(GPG_KEY_ID)
               GRADLE_USER_HOME: $(GRADLE_USER_HOME)
             condition: eq(404, variables.mvn_status)
-
-  - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
-    displayName: 'Publish docker images for specified pre-builds'
-    dependsOn: [ ]
-    condition:
-      and(
-        succeeded(),
-        eq(variables['Build.Reason'], 'Manual'),
-        or(
-          eq('${{ parameters.actionToPerform }}', 'publish_docker_image_pre_builds'),
-          eq('${{ parameters.actionToPerform }}', 'publish_dev_docker_image')
-        )
-      )
-    jobs:
-      - job: PUBLISH
-        displayName: 'Publishing'
-        timeoutInMinutes: 600
-        steps:
-          - checkout: self
-            fetchDepth: 0
-            clean: false
-            persistCredentials: true
-          - bash: |
-              TARGET_BRANCH="${{ parameters.targetBranch }}"
-              if [ -n "$(echo "$TARGET_BRANCH" | tr -d '[:space:]')" ]; then
-                if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
-                  echo "Branch '$TARGET_BRANCH' found, checking out"
-                  git checkout "$TARGET_BRANCH"
-                else
-                  echo "Branch '$TARGET_BRANCH' not found, falling back to develop"
-                  git checkout develop
-                fi
-              fi
-            displayName: 'Checkout target branch'
-          - task: JavaToolInstaller@0
-            inputs:
-              versionSpec: '17'
-              jdkArchitectureOption: 'x64'
-              jdkSourceOption: 'PreInstalled'
-          - task: Cache@2
-            displayName: 'Restore Gradle cache'
-            inputs:
-              key: 'gradle | "$(Agent.OS)" | **/gradle/wrapper/gradle-wrapper.properties | **/settings.gradle* | **/build.gradle* | **/gradle.properties'
-              restoreKeys: |
-                gradle | "$(Agent.OS)"
-                gradle
-              path: $(GRADLE_USER_HOME)
-              cacheHitVar: GRADLE_CACHE_HIT
-          - script: |
-              set -ex
-
-              VERSIONS="${{ parameters.preBuildVersionsForPublishingToDockerHub }}"
-              if [ -z "$(echo "$VERSIONS" | tr -d '[:space:],')" ]; then
-                VERSIONS="${{ parameters.esVersion }}"
-              fi
-
-              if [ -z "$(echo "$VERSIONS" | tr -d '[:space:],')" ]; then
-                echo "Error: No ES versions specified for publishing"
-                exit 1
-              fi
-
-              if ! docker login -u $var_docker_registry_user -p $var_docker_registry_password; then
-                echo "Error: Failed to login to Docker registry"
-                exit 1
-              fi
-
-              export BUILD_ROR_ES_VERSIONS="$VERSIONS"
-
-              echo "[PRE_BUILDS_DOCKER_IMAGE_PUBLISHING] executing ROR_TASK = $ROR_TASK"
-              echo ">>> ($ROR_TASK) Publish docker images for specified pre-builds" && ci/run-pipeline.sh
-            timeoutInMinutes: 600
-            condition: succeeded()
-            env:
-              ROR_TASK: publish_pre_builds_docker_images
-              var_docker_registry_user: $(DOCKER_REGISTRY_USER)
-              var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)
-              GRADLE_USER_HOME: $(GRADLE_USER_HOME)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,11 +37,20 @@ parameters:
     default: 'publish_docker_image_pre_builds'
     values:
       - 'publish_docker_image_pre_builds'
+      - 'publish_dev_docker_image'
       - 'run_all_tests_on_linux'
       - 'run_all_tests_on_windows'
   - name: preBuildVersionsForPublishingToDockerHub
     type: string
     displayName: 'Space or comma-separated list of ES version numbers (e.g., "7.17.20 8.15.0")'
+    default: ' '
+  - name: targetBranch
+    type: string
+    displayName: 'Target branch to checkout and build from (for publish_dev_docker_image)'
+    default: ' '
+  - name: esVersion
+    type: string
+    displayName: 'ES version to build and publish to dev DockerHub (e.g., "9.4.2")'
     default: ' '
 
 pool:
@@ -1004,6 +1013,72 @@ stages:
               VAR_GPG_KEY_ID: $(GPG_KEY_ID)
               GRADLE_USER_HOME: $(GRADLE_USER_HOME)
             condition: eq(404, variables.mvn_status)
+
+  - stage: PUBLISH_DEV_DOCKER_IMAGE
+    displayName: 'Build and publish dev docker image for a given branch and ES version'
+    dependsOn: []
+    condition:
+      and(
+        succeeded(),
+        eq(variables['Build.Reason'], 'Manual'),
+        eq('${{ parameters.actionToPerform }}', 'publish_dev_docker_image')
+      )
+    jobs:
+      - job: PUBLISH_DEV
+        displayName: 'Build and publish'
+        timeoutInMinutes: 600
+        steps:
+          - checkout: self
+            fetchDepth: 0
+            clean: false
+            persistCredentials: true
+          - bash: |
+              TARGET_BRANCH="${{ parameters.targetBranch }}"
+              if [ -z "$(echo "$TARGET_BRANCH" | tr -d '[:space:]')" ]; then
+                echo "Error: targetBranch parameter is required"
+                exit 1
+              fi
+              echo "Checking out branch: $TARGET_BRANCH"
+              git fetch origin "$TARGET_BRANCH"
+              git checkout "$TARGET_BRANCH"
+            displayName: 'Checkout target branch'
+          - task: JavaToolInstaller@0
+            inputs:
+              versionSpec: '17'
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'PreInstalled'
+          - task: Cache@2
+            displayName: 'Restore Gradle cache'
+            inputs:
+              key: 'gradle | "$(Agent.OS)" | **/gradle/wrapper/gradle-wrapper.properties | **/settings.gradle* | **/build.gradle* | **/gradle.properties'
+              restoreKeys: |
+                gradle | "$(Agent.OS)"
+                gradle
+              path: $(GRADLE_USER_HOME)
+              cacheHitVar: GRADLE_CACHE_HIT
+          - script: |
+              set -e
+
+              ES_VERSION="${{ parameters.esVersion }}"
+              if [ -z "$(echo "$ES_VERSION" | tr -d '[:space:],')" ]; then
+                echo "Error: esVersion parameter is required"
+                exit 1
+              fi
+
+              if ! docker login -u $var_docker_registry_user -p $var_docker_registry_password; then
+                echo "Error: Failed to login to Docker registry"
+                exit 1
+              fi
+
+              export BUILD_ROR_ES_VERSIONS="$ES_VERSION"
+
+              echo "[PUBLISH_DEV_DOCKER_IMAGE] executing ROR_TASK = $ROR_TASK"
+              echo ">>> ($ROR_TASK) Building and publishing dev docker image" && ci/run-pipeline.sh
+            env:
+              ROR_TASK: publish_dev_docker_image
+              var_docker_registry_user: $(DOCKER_REGISTRY_USER)
+              var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)
+              GRADLE_USER_HOME: $(GRADLE_USER_HOME)
 
   - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
     displayName: 'Publish docker images for specified pre-builds'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1034,13 +1034,17 @@ stages:
             persistCredentials: true
           - bash: |
               TARGET_BRANCH="${{ parameters.targetBranch }}"
-              if [ -z "$(echo "$TARGET_BRANCH" | tr -d '[:space:]')" ]; then
-                echo "Error: targetBranch parameter is required"
-                exit 1
+              if [ -n "$(echo "$TARGET_BRANCH" | tr -d '[:space:]')" ]; then
+                if git ls-remote --exit-code --heads origin "$TARGET_BRANCH" > /dev/null 2>&1; then
+                  echo "Branch '$TARGET_BRANCH' found, checking out"
+                  git fetch origin "$TARGET_BRANCH"
+                  git checkout "$TARGET_BRANCH"
+                else
+                  echo "Branch '$TARGET_BRANCH' not found, falling back to develop"
+                  git fetch origin develop
+                  git checkout develop
+                fi
               fi
-              echo "Checking out branch: $TARGET_BRANCH"
-              git fetch origin "$TARGET_BRANCH"
-              git checkout "$TARGET_BRANCH"
             displayName: 'Checkout target branch'
           - task: JavaToolInstaller@0
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1014,18 +1014,21 @@ stages:
               GRADLE_USER_HOME: $(GRADLE_USER_HOME)
             condition: eq(404, variables.mvn_status)
 
-  - stage: PUBLISH_DEV_DOCKER_IMAGE
-    displayName: 'Build and publish dev docker image for a given branch and ES version'
-    dependsOn: []
+  - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
+    displayName: 'Publish docker images for specified pre-builds'
+    dependsOn: [ ]
     condition:
       and(
         succeeded(),
         eq(variables['Build.Reason'], 'Manual'),
-        eq('${{ parameters.actionToPerform }}', 'publish_dev_docker_image')
+        or(
+          eq('${{ parameters.actionToPerform }}', 'publish_docker_image_pre_builds'),
+          eq('${{ parameters.actionToPerform }}', 'publish_dev_docker_image')
+        )
       )
     jobs:
-      - job: PUBLISH_DEV
-        displayName: 'Build and publish'
+      - job: PUBLISH
+        displayName: 'Publishing'
         timeoutInMinutes: 600
         steps:
           - checkout: self
@@ -1035,13 +1038,11 @@ stages:
           - bash: |
               TARGET_BRANCH="${{ parameters.targetBranch }}"
               if [ -n "$(echo "$TARGET_BRANCH" | tr -d '[:space:]')" ]; then
-                if git ls-remote --exit-code --heads origin "$TARGET_BRANCH" > /dev/null 2>&1; then
+                if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
                   echo "Branch '$TARGET_BRANCH' found, checking out"
-                  git fetch origin "$TARGET_BRANCH"
                   git checkout "$TARGET_BRANCH"
                 else
                   echo "Branch '$TARGET_BRANCH' not found, falling back to develop"
-                  git fetch origin develop
                   git checkout develop
                 fi
               fi
@@ -1061,68 +1062,31 @@ stages:
               path: $(GRADLE_USER_HOME)
               cacheHitVar: GRADLE_CACHE_HIT
           - script: |
-              set -e
-
-              ES_VERSION="${{ parameters.esVersion }}"
-              if [ -z "$(echo "$ES_VERSION" | tr -d '[:space:],')" ]; then
-                echo "Error: esVersion parameter is required"
-                exit 1
-              fi
-
-              if ! docker login -u $var_docker_registry_user -p $var_docker_registry_password; then
-                echo "Error: Failed to login to Docker registry"
-                exit 1
-              fi
-
-              export BUILD_ROR_ES_VERSIONS="$ES_VERSION"
-
-              echo "[PUBLISH_DEV_DOCKER_IMAGE] executing ROR_TASK = $ROR_TASK"
-              echo ">>> ($ROR_TASK) Building and publishing dev docker image" && ci/run-pipeline.sh
-            env:
-              ROR_TASK: publish_dev_docker_image
-              var_docker_registry_user: $(DOCKER_REGISTRY_USER)
-              var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)
-              GRADLE_USER_HOME: $(GRADLE_USER_HOME)
-
-  - stage: PRE_BUILDS_DOCKER_IMAGE_PUBLISHING
-    displayName: 'Publish docker images for specified pre-builds'
-    dependsOn: [ ]
-    condition:
-      and(
-        succeeded(),
-        eq(variables['Build.Reason'], 'Manual'),
-        eq('${{ parameters.actionToPerform }}', 'publish_docker_image_pre_builds')
-      )
-    jobs:
-      - job: PUBLISH
-        displayName: 'Publishing'
-        timeoutInMinutes: "600"
-        steps:
-          - checkout: self
-            fetchDepth: 1
-            clean: false
-            persistCredentials: true
-          - script: |
               set -ex
 
-              docker login -u $var_docker_registry_user -p $var_docker_registry_password
+              VERSIONS="${{ parameters.preBuildVersionsForPublishingToDockerHub }}"
+              if [ -z "$(echo "$VERSIONS" | tr -d '[:space:],')" ]; then
+                VERSIONS="${{ parameters.esVersion }}"
+              fi
+
+              if [ -z "$(echo "$VERSIONS" | tr -d '[:space:],')" ]; then
+                echo "Error: No ES versions specified for publishing"
+                exit 1
+              fi
+
               if ! docker login -u $var_docker_registry_user -p $var_docker_registry_password; then
                 echo "Error: Failed to login to Docker registry"
                 exit 1
               fi
 
-              export BUILD_ROR_ES_VERSIONS="${{ parameters.preBuildVersionsForPublishingToDockerHub }}"
+              export BUILD_ROR_ES_VERSIONS="$VERSIONS"
 
-              if [ -z "$(echo "$BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],')" ]; then
-                echo "Error: No ES versions specified for publishing ROR pre-builds"
-                exit 1
-              fi
-
-              echo "[RELEASE_ROR] executing ROR_TASK = $ROR_TASK"
+              echo "[PRE_BUILDS_DOCKER_IMAGE_PUBLISHING] executing ROR_TASK = $ROR_TASK"
               echo ">>> ($ROR_TASK) Publish docker images for specified pre-builds" && ci/run-pipeline.sh
-            timeoutInMinutes: "600"
+            timeoutInMinutes: 600
             condition: succeeded()
             env:
               ROR_TASK: publish_pre_builds_docker_images
               var_docker_registry_user: $(DOCKER_REGISTRY_USER)
               var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)
+              GRADLE_USER_HOME: $(GRADLE_USER_HOME)

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -465,17 +465,6 @@ fi
 
 if [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
 
-  IFS=', ' read -r -a VERSIONS <<< "$BUILD_ROR_ES_VERSIONS"
-  for VERSION in "${VERSIONS[@]}"; do
-    if [ -n "$VERSION" ]; then
-      public_ror_prebuild_plugin "$VERSION"
-    fi
-  done
-
-fi
-
-if [[ $ROR_TASK == "publish_dev_docker_image" ]]; then
-
   if [ -z "$(echo "$BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],')" ]; then
     echo "Error: BUILD_ROR_ES_VERSIONS is required"
     exit 1

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -473,3 +473,19 @@ if [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
   done
 
 fi
+
+if [[ $ROR_TASK == "publish_dev_docker_image" ]]; then
+
+  if [ -z "$(echo "$BUILD_ROR_ES_VERSIONS" | tr -d '[:space:],')" ]; then
+    echo "Error: BUILD_ROR_ES_VERSIONS is required"
+    exit 1
+  fi
+
+  IFS=', ' read -r -a VERSIONS <<< "$BUILD_ROR_ES_VERSIONS"
+  for VERSION in "${VERSIONS[@]}"; do
+    if [ -n "$VERSION" ]; then
+      public_ror_prebuild_plugin "$VERSION"
+    fi
+  done
+
+fi


### PR DESCRIPTION
### Summary

- Removed publish_docker_image_pre_builds action from the main azure-pipelines.yml — it polluted the action dropdown with publishing-specific parameters irrelevant to test runs
- Created .azure/publish-pre-builds.yml as a focused standalone pipeline with two parameters: esVersions (space/comma-separated list) and targetBranch (optional; checks out the branch if it exists, falls back to develop)
- Added BUILD_ROR_ES_VERSIONS empty-check validation to publish_pre_builds_docker_images task in run-pipeline.sh
- Fixed duplicate docker login call that was present in the old stage