### PR TITLE
[RORDEV-1229] pre-build Docker image publishing CI: optional tag + skip-if-unchanged 

### DIFF
--- a/.azure/publish-pre-builds.yml
+++ b/.azure/publish-pre-builds.yml
@@ -9,6 +9,10 @@ parameters:
     type: string
     displayName: 'Branch to build from (falls back to develop if not found, builds from current branch if empty)'
     default: ' '
+  - name: tag
+    type: string
+    displayName: 'Optional image tag. When set, each image is also published as <esVersion>-ror-<tag> (on top of the canonical <esVersion>-ror-<pluginVersion>)'
+    default: ' '
 
 variables:
   GRADLE_USER_HOME: '$(Pipeline.Workspace)/.gradle'
@@ -76,6 +80,7 @@ stages:
             env:
               ROR_TASK: publish_pre_builds_docker_images
               ES_VERSIONS: ${{ parameters.esVersions }}
+              IMAGE_TAG: ${{ parameters.tag }}
               var_docker_registry_user: $(DOCKER_REGISTRY_USER)
               var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)
               GRADLE_USER_HOME: $(GRADLE_USER_HOME)

--- a/.azure/publish-pre-builds.yml
+++ b/.azure/publish-pre-builds.yml
@@ -13,6 +13,10 @@ parameters:
     type: string
     displayName: 'Optional image tag. When set, each image is also published as <esVersion>-ror-<tag> (on top of the canonical <esVersion>-ror-<pluginVersion>)'
     default: ' '
+  - name: forceRebuild
+    type: boolean
+    displayName: 'Rebuild even if an image for the current commit already exists (skips the unchanged-sources optimization)'
+    default: false
 
 variables:
   GRADLE_USER_HOME: '$(Pipeline.Workspace)/.gradle'
@@ -81,6 +85,7 @@ stages:
               ROR_TASK: publish_pre_builds_docker_images
               ES_VERSIONS: ${{ parameters.esVersions }}
               IMAGE_TAG: ${{ parameters.tag }}
+              FORCE_REBUILD: ${{ parameters.forceRebuild }}
               var_docker_registry_user: $(DOCKER_REGISTRY_USER)
               var_docker_registry_password: $(DOCKER_REGISTRY_PASSWORD)
               GRADLE_USER_HOME: $(GRADLE_USER_HOME)

--- a/.azure/publish-pre-builds.yml
+++ b/.azure/publish-pre-builds.yml
@@ -1,4 +1,6 @@
+# Manual-only pipeline: never triggered by pushes (trigger) or pull requests (pr).
 trigger: none
+pr: none
 
 parameters:
   - name: esVersions

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -33,9 +33,9 @@ function retag_dev_image {
 # bypasses the skip.
 #
 # Tags produced (all but the Gradle push are cheap registry-side manifest copies):
-#   - <esVersion>-ror-<gitShortSha>     immutable source identity (probed for the skip)
-#   - <esVersion>-ror-<pluginVersion>   canonical "latest", always repointed at this source
-#   - <esVersion>-ror-<imageTag>        optional alias, only when an image tag arg is given
+#   - <esVersion>-ror-<pluginVersion>   canonical "latest", pushed by Gradle (only on a real build)
+#   - <esVersion>-ror-<gitShortSha>     immutable source identity, frozen from canonical (probed for the skip)
+#   - <esVersion>-ror-<imageTag>        optional alias to the source image, when an image tag arg is given
 function publish_ror_prebuild_plugin {
   if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
     echo "Usage: publish_ror_prebuild_plugin <ES version> [image tag]"
@@ -83,13 +83,9 @@ function publish_ror_prebuild_plugin {
     fi
   fi
 
-  # Always (re)point the canonical "latest" tag at the source we just identified/built. On the skip path
-  # this is what makes the run idempotent; on the build path it is a no-op (canonical already == source).
-  if ! retag_dev_image "$SOURCE_TAG" "$CANONICAL_TAG"; then
-    echo "Failed to tag prebuild Docker image as ${ES_DEV_IMAGE_REPO}:${CANONICAL_TAG}"
-    return 5
-  fi
-
+  # Apply the optional caller-supplied alias on BOTH paths (built or skipped). The caller fetches the image
+  # by this tag, so it must exist and point at this commit's image: we always derive it from SOURCE_TAG
+  # (the commit identity), and the imagetools exit status guarantees it was created before we return.
   if [ -n "$IMAGE_TAG" ]; then
     if ! retag_dev_image "$SOURCE_TAG" "${ES_VERSION}-ror-${IMAGE_TAG}"; then
       echo "Failed to tag prebuild Docker image as ${ES_DEV_IMAGE_REPO}:${ES_VERSION}-ror-${IMAGE_TAG}"

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -89,7 +89,7 @@ function publish_ror_prebuild_plugin {
   if [ -n "$IMAGE_TAG" ]; then
     if ! retag_dev_image "$SOURCE_TAG" "${ES_VERSION}-ror-${IMAGE_TAG}"; then
       echo "Failed to tag prebuild Docker image as ${ES_DEV_IMAGE_REPO}:${ES_VERSION}-ror-${IMAGE_TAG}"
-      return 5
+      return 6
     fi
   fi
 }

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -2,6 +2,102 @@
 
 CI_DIR=$(dirname "$0")
 
+function docker_image_exists {
+  docker manifest inspect "$1" >/dev/null 2>&1
+}
+
+# Repo of the ROR ES pre-build dev image. Must match each module's `preBuildDockerImageVersion` repo in
+# es<ver>x/build.gradle (that is where Gradle actually pushes the canonical <esVersion>-ror-<pluginVersion>).
+ES_DEV_IMAGE_REPO="beshultd/elasticsearch-readonlyrest-dev"
+
+# Copies a registry image manifest to a new tag without pulling/rebuilding (multi-platform safe).
+function retag_dev_image {
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: retag_dev_image <source tag> <target tag>"
+    return 1
+  fi
+
+  local SOURCE_TAG=$1
+  local TARGET_TAG=$2
+  echo ">>> Tagging ${ES_DEV_IMAGE_REPO}:${SOURCE_TAG} as ${ES_DEV_IMAGE_REPO}:${TARGET_TAG}"
+  docker buildx imagetools create \
+    -t "${ES_DEV_IMAGE_REPO}:${TARGET_TAG}" \
+    "${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}"
+}
+
+# Build & publish the ROR ES pre-build Docker image for the given ES version.
+#
+# To avoid rebuilding when the sources have not changed, every build is frozen under an immutable,
+# source-identified tag <esVersion>-ror-<gitShortSha>. Before building we probe that tag in the registry:
+# if it already exists the Gradle build (the expensive build+push) is skipped. Setting FORCE_REBUILD=true
+# bypasses the skip.
+#
+# Tags produced (all but the Gradle push are cheap registry-side manifest copies):
+#   - <esVersion>-ror-<gitShortSha>     immutable source identity (probed for the skip)
+#   - <esVersion>-ror-<pluginVersion>   canonical "latest", always repointed at this source
+#   - <esVersion>-ror-<imageTag>        optional alias, only when an image tag arg is given
+function publish_ror_prebuild_plugin {
+  if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "Usage: publish_ror_prebuild_plugin <ES version> [image tag]"
+    return 1
+  fi
+
+  local ES_VERSION=$1
+  local IMAGE_TAG="${2:-}"
+
+  if ! [[ $ES_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+    echo "Invalid ES version format. Expected format: X.Y.Z"
+    return 2
+  fi
+
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon not running or not logged in"
+    return 3
+  fi
+
+  local ROR_VERSION GIT_SHA
+  ROR_VERSION=$(grep '^pluginVersion=' gradle.properties | awk -F= '{print $2}')
+  GIT_SHA=$(git rev-parse --short HEAD)
+
+  local CANONICAL_TAG="${ES_VERSION}-ror-${ROR_VERSION}"
+  local SOURCE_TAG="${ES_VERSION}-ror-${GIT_SHA}"
+
+  echo ""
+  echo "PUBLISHING ROR PRE-BUILD for ES $ES_VERSION (source ${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}):"
+
+  # Azure boolean params expand as True/False, so normalize case before comparing.
+  local FORCE_REBUILD_NORM
+  FORCE_REBUILD_NORM=$(echo "${FORCE_REBUILD:-false}" | tr '[:upper:]' '[:lower:]')
+
+  if [ "$FORCE_REBUILD_NORM" != "true" ] && docker_image_exists "${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}"; then
+    echo ">>> Sources unchanged (image for this commit already published), skipping build"
+  else
+    if ! ./gradlew publishEsRorPreBuildDockerImage "-PesVersion=$ES_VERSION" </dev/null; then
+      echo "Failed to publish plugin prebuild Docker image"
+      return 4
+    fi
+    # Freeze this build under its immutable source-identity tag so future runs can detect & skip it.
+    if ! retag_dev_image "$CANONICAL_TAG" "$SOURCE_TAG"; then
+      echo "Failed to tag prebuild Docker image as ${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}"
+      return 5
+    fi
+  fi
+
+  # Always (re)point the canonical "latest" tag at the source we just identified/built. On the skip path
+  # this is what makes the run idempotent; on the build path it is a no-op (canonical already == source).
+  if ! retag_dev_image "$SOURCE_TAG" "$CANONICAL_TAG"; then
+    echo "Failed to tag prebuild Docker image as ${ES_DEV_IMAGE_REPO}:${CANONICAL_TAG}"
+    return 5
+  fi
+
+  if [ -n "$IMAGE_TAG" ]; then
+    if ! retag_dev_image "$SOURCE_TAG" "${ES_VERSION}-ror-${IMAGE_TAG}"; then
+      echo "Failed to tag prebuild Docker image as ${ES_DEV_IMAGE_REPO}:${ES_VERSION}-ror-${IMAGE_TAG}"
+      return 5
+    fi
+  fi
+}
+
 function checkTagNotExist {
   GIT_TAG="$1"
 

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -379,13 +379,23 @@ release_ror_plugin() {
   cleanup_docker_and_build
 }
 
+# Repo of the ROR ES pre-build dev image. Must match each module's `preBuildDockerImageVersion` repo in
+# es<ver>x/build.gradle (that is where Gradle actually pushes the canonical <esVersion>-ror-<pluginVersion>).
+ES_DEV_IMAGE_REPO="beshultd/elasticsearch-readonlyrest-dev"
+
+# Build & publish the ROR ES pre-build Docker image for the given ES version. Gradle publishes it as
+# $ES_DEV_IMAGE_REPO:<esVersion>-ror-<pluginVersion>. If an optional image tag is given, the published
+# image is ALSO tagged as $ES_DEV_IMAGE_REPO:<esVersion>-ror-<imageTag> (a registry-side retag via
+# `docker buildx imagetools create`, no rebuild) so callers can pin a custom/immutable tag (e.g. a commit
+# SHA) on top of the canonical pluginVersion tag.
 public_ror_prebuild_plugin() {
-  if [ "$#" -ne 1 ]; then
-    echo "What ES version should I release plugin for?"
+  if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "Usage: public_ror_prebuild_plugin <ES version> [image tag]"
     return 1
   fi
 
   local ES_VERSION=$1
+  local IMAGE_TAG="${2:-}"
 
   if ! [[ $ES_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
     echo "Invalid ES version format. Expected format: X.Y.Z"
@@ -403,6 +413,18 @@ public_ror_prebuild_plugin() {
   if ! ./gradlew publishEsRorPreBuildDockerImage "-PesVersion=$ES_VERSION" </dev/null; then
     echo "Failed to publish plugin prebuild Docker image"
     return 4
+  fi
+
+  if [ -n "$IMAGE_TAG" ]; then
+    local ROR_VERSION
+    ROR_VERSION=$(grep '^pluginVersion=' gradle.properties | awk -F= '{print $2}')
+    local SOURCE_IMAGE="${ES_DEV_IMAGE_REPO}:${ES_VERSION}-ror-${ROR_VERSION}"
+    local TAGGED_IMAGE="${ES_DEV_IMAGE_REPO}:${ES_VERSION}-ror-${IMAGE_TAG}"
+    echo ">>> Tagging published image $SOURCE_IMAGE as $TAGGED_IMAGE"
+    if ! docker buildx imagetools create -t "$TAGGED_IMAGE" "$SOURCE_IMAGE"; then
+      echo "Failed to tag prebuild Docker image as $TAGGED_IMAGE"
+      return 5
+    fi
   fi
 
   docker system prune -fa
@@ -470,10 +492,13 @@ if [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
     exit 1
   fi
 
+  # IMAGE_TAG is optional; its pipeline default is a single space, so normalize whitespace-only to empty.
+  IMAGE_TAG="$(echo "${IMAGE_TAG:-}" | tr -d '[:space:]')"
+
   IFS=', ' read -r -a VERSIONS <<< "$BUILD_ROR_ES_VERSIONS"
   for VERSION in "${VERSIONS[@]}"; do
     if [ -n "$VERSION" ]; then
-      public_ror_prebuild_plugin "$VERSION"
+      public_ror_prebuild_plugin "$VERSION" "$IMAGE_TAG"
     fi
   done
 

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -379,57 +379,6 @@ release_ror_plugin() {
   cleanup_docker_and_build
 }
 
-# Repo of the ROR ES pre-build dev image. Must match each module's `preBuildDockerImageVersion` repo in
-# es<ver>x/build.gradle (that is where Gradle actually pushes the canonical <esVersion>-ror-<pluginVersion>).
-ES_DEV_IMAGE_REPO="beshultd/elasticsearch-readonlyrest-dev"
-
-# Build & publish the ROR ES pre-build Docker image for the given ES version. Gradle publishes it as
-# $ES_DEV_IMAGE_REPO:<esVersion>-ror-<pluginVersion>. If an optional image tag is given, the published
-# image is ALSO tagged as $ES_DEV_IMAGE_REPO:<esVersion>-ror-<imageTag> (a registry-side retag via
-# `docker buildx imagetools create`, no rebuild) so callers can pin a custom/immutable tag (e.g. a commit
-# SHA) on top of the canonical pluginVersion tag.
-public_ror_prebuild_plugin() {
-  if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
-    echo "Usage: public_ror_prebuild_plugin <ES version> [image tag]"
-    return 1
-  fi
-
-  local ES_VERSION=$1
-  local IMAGE_TAG="${2:-}"
-
-  if ! [[ $ES_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
-    echo "Invalid ES version format. Expected format: X.Y.Z"
-    return 2
-  fi
-
-  if ! docker info >/dev/null 2>&1; then
-    echo "Docker daemon not running or not logged in"
-    return 3
-  fi
-
-  echo ""
-  echo "PUBLISHING ROR PRE-BUILD for ES $ES_VERSION:"
-
-  if ! ./gradlew publishEsRorPreBuildDockerImage "-PesVersion=$ES_VERSION" </dev/null; then
-    echo "Failed to publish plugin prebuild Docker image"
-    return 4
-  fi
-
-  if [ -n "$IMAGE_TAG" ]; then
-    local ROR_VERSION
-    ROR_VERSION=$(grep '^pluginVersion=' gradle.properties | awk -F= '{print $2}')
-    local SOURCE_IMAGE="${ES_DEV_IMAGE_REPO}:${ES_VERSION}-ror-${ROR_VERSION}"
-    local TAGGED_IMAGE="${ES_DEV_IMAGE_REPO}:${ES_VERSION}-ror-${IMAGE_TAG}"
-    echo ">>> Tagging published image $SOURCE_IMAGE as $TAGGED_IMAGE"
-    if ! docker buildx imagetools create -t "$TAGGED_IMAGE" "$SOURCE_IMAGE"; then
-      echo "Failed to tag prebuild Docker image as $TAGGED_IMAGE"
-      return 5
-    fi
-  fi
-
-  docker system prune -fa
-}
-
 if [[ $ROR_TASK == "release_es9xx" ]]; then
   release_ror_plugins "ci/supported-es-versions/es9x.txt"
 fi
@@ -498,7 +447,8 @@ if [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
   IFS=', ' read -r -a VERSIONS <<< "$BUILD_ROR_ES_VERSIONS"
   for VERSION in "${VERSIONS[@]}"; do
     if [ -n "$VERSION" ]; then
-      public_ror_prebuild_plugin "$VERSION" "$IMAGE_TAG"
+      publish_ror_prebuild_plugin "$VERSION" "$IMAGE_TAG"
+      docker system prune -fa
     fi
   done
 


### PR DESCRIPTION
Two additions to the manual pre-build publishing pipeline, plus a refactor:
  
  - **Optional `tag`**: also publishes each image as `<esVersion>-ror-<tag>` pointing at the current commit, so
  consumers can fetch a specific build.
  - **Skip unchanged builds**: tags every build with `<esVersion>-ror-<gitShortSha>` and skips the Gradle
  build+push if that tag already exists (`forceRebuild` overrides).
  - Pipeline made manual-only (`pr: none`); publish logic moved to `ci/ci-lib.sh`.
