### PR TITLE
[RORDEV-2073] CVE-2026-42587, CVE-2026-48043

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,9 +76,9 @@ dependencies {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     }
     api group: 'io.monix',                      name: 'monix_3',                             version: '3.4.1'
-    api group: 'io.netty',                      name: 'netty-codec-http2',                   version: '4.1.133.Final'
-    api group: 'io.netty',                      name: 'netty-handler',                       version: '4.1.133.Final'
-    api group: 'io.netty',                      name: 'netty-transport',                     version: '4.1.133.Final'
+    api group: 'io.netty',                      name: 'netty-codec-http2',                   version: '4.1.135.Final'
+    api group: 'io.netty',                      name: 'netty-handler',                       version: '4.1.135.Final'
+    api group: 'io.netty',                      name: 'netty-transport',                     version: '4.1.135.Final'
     api group: 'eu.timepit',                    name: 'refined_3',                           version: '0.11.3'
     api group: 'org.reflections',               name: 'reflections',                         version: '0.9.11'
     api group: 'org.mozilla',                   name: 'rhino',                               version: '1.8.1'
@@ -104,12 +104,12 @@ dependencies {
     testImplementation  group: 'com.dimafeng',               name: 'testcontainers-scala-core_3',    version: '0.44.0'
 
     constraints {
-        api group: 'io.netty',              name: 'netty-codec-http2',                  version: '4.1.133.Final'
-        api group: 'io.netty',              name: 'netty-handler-proxy',                version: '4.1.133.Final'
-        api group: 'io.netty',              name: 'netty-resolver-dns',                 version: '4.1.133.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-unix-common', version: '4.1.133.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-epoll',       version: '4.1.133.Final'
-        api group: 'io.netty',              name: 'netty-transport-native-kqueue',      version: '4.1.133.Final'
+        api group: 'io.netty',              name: 'netty-codec-http2',                  version: '4.1.135.Final'
+        api group: 'io.netty',              name: 'netty-handler-proxy',                version: '4.1.135.Final'
+        api group: 'io.netty',              name: 'netty-resolver-dns',                 version: '4.1.135.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-unix-common', version: '4.1.135.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-epoll',       version: '4.1.135.Final'
+        api group: 'io.netty',              name: 'netty-transport-native-kqueue',      version: '4.1.135.Final'
         api group: 'com.google.guava',      name: 'guava',                              version: '32.0.1-jre'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.70.0
-pluginVersion=1.70.0
+pluginVersion=1.70.1-pre1
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m


### PR DESCRIPTION
🚨Security Fix (ES) CVE-2026-42587, CVE-2026-48043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Netty library dependencies to a newer compatible release to improve runtime stability and networking.
  * Bumped build plugin version to 1.70.1-pre1 to pick up build tooling updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->