### PR TITLE
[RORDEV-2081] Always return Kibana index in user metadata response

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/EnabledAccessControlList.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/EnabledAccessControlList.scala
@@ -166,7 +166,7 @@ class EnabledAccessControlList(val blocks: NonEmptyList[Block],
     if (ignoreGroupsHandling || withGroups.isEmpty) {
       val firstFittingMatch = withLoggedUsers
         .allowedThroughFirstForbidden()
-        .firstAllowedWithKibanaIndexOrHead()
+        .firstAllowedWithKibanaPolicyOrHead()
 
       firstFittingMatch match {
         case Some(m) if m.result.context._1.policy == Policy.Allow =>
@@ -181,7 +181,7 @@ class EnabledAccessControlList(val blocks: NonEmptyList[Block],
         .flatMap { case (group, metadataCollection) =>
           metadataCollection
             .allowedThroughFirstForbidden()
-            .firstAllowedWithKibanaIndexOrHead()
+            .firstAllowedWithKibanaPolicyOrHead()
             .map(group -> _)
         }
         .values
@@ -244,7 +244,7 @@ class EnabledAccessControlList(val blocks: NonEmptyList[Block],
       allowed ++ rest.headOption.toList
     }
 
-    private def firstAllowedWithKibanaIndexOrHead(): Option[PermittedWithUser[UserMetadataRequestBlockContext]] = {
+    private def firstAllowedWithKibanaPolicyOrHead(): Option[PermittedWithUser[UserMetadataRequestBlockContext]] = {
       blockResults
         .find { m =>
           val context = m.result.context
@@ -260,7 +260,7 @@ class EnabledAccessControlList(val blocks: NonEmptyList[Block],
       allowed ++ rest.headOption.toList
     }
 
-    private def firstAllowedWithKibanaIndexOrHead(): Option[GroupMetadata] = {
+    private def firstAllowedWithKibanaPolicyOrHead(): Option[GroupMetadata] = {
       metadata
         .find(m => m.metadataOrigin.blockContext.block.policy == Policy.Allow && m.kibanaPolicy.isDefined)
         .orElse(metadata.headOption)

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/EnabledAccessControlList.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/EnabledAccessControlList.scala
@@ -248,7 +248,7 @@ class EnabledAccessControlList(val blocks: NonEmptyList[Block],
       blockResults
         .find { m =>
           val context = m.result.context
-          context.block.policy == Policy.Allow && context.blockMetadata.kibanaPolicy.flatMap(_.index).isDefined
+          context.block.policy == Policy.Allow && context.blockMetadata.kibanaPolicy.isDefined
         }
         .orElse(blockResults.headOption)
     }
@@ -262,7 +262,7 @@ class EnabledAccessControlList(val blocks: NonEmptyList[Block],
 
     private def firstAllowedWithKibanaIndexOrHead(): Option[GroupMetadata] = {
       metadata
-        .find(m => m.metadataOrigin.blockContext.block.policy == Policy.Allow && m.kibanaPolicy.flatMap(_.index).isDefined)
+        .find(m => m.metadataOrigin.blockContext.block.policy == Policy.Allow && m.kibanaPolicy.isDefined)
         .orElse(metadata.headOption)
     }
   }

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/BlockMetadata.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/BlockMetadata.scala
@@ -52,7 +52,7 @@ final case class BlockMetadata private(loggedUser: Option[LoggedUser],
   )
 
   def withKibanaIndex(index: KibanaIndexName): BlockMetadata = {
-    this.copy(kibanaPolicy = Some(currentKibanaPolicyOrDefault.copy(index = Some(index))))
+    this.copy(kibanaPolicy = Some(currentKibanaPolicyOrDefault.copy(index = index)))
   }
 
   def withKibanaTemplateIndex(index: KibanaIndexName): BlockMetadata = {

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/KibanaPolicy.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/metadata/KibanaPolicy.scala
@@ -21,7 +21,7 @@ import tech.beshu.ror.accesscontrol.domain.{KibanaAccess, KibanaAllowedApiPath, 
 import tech.beshu.ror.syntax.Set
 
 final case class KibanaPolicy(access: KibanaAccess,
-                              index: Option[KibanaIndexName],
+                              index: KibanaIndexName,
                               templateIndex: Option[KibanaIndexName],
                               hiddenApps: Set[KibanaApp],
                               allowedApiPaths: Set[KibanaAllowedApiPath],
@@ -29,7 +29,7 @@ final case class KibanaPolicy(access: KibanaAccess,
 object KibanaPolicy {
   def default: KibanaPolicy = KibanaPolicy(
     access = KibanaAccess.Unrestricted,
-    index = None,
+    index = KibanaIndexName.default,
     templateIndex = None,
     hiddenApps = Set.empty,
     allowedApiPaths = Set.empty,

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/elasticsearch/indices/IndicesRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/elasticsearch/indices/IndicesRule.scala
@@ -192,7 +192,7 @@ class IndicesRule(override val settings: Settings,
   }
 
   private def kibanaIndexFrom(blockContext: BlockContext) = {
-    blockContext.blockMetadata.kibanaPolicy.flatMap(_.index)
+    blockContext.blockMetadata.kibanaPolicy.map(_.index)
   }
 
   private val matchAll = settings.allowedIndices.exists {

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaAccessRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/KibanaAccessRule.scala
@@ -51,7 +51,7 @@ class KibanaAccessRule(override val settings: Settings)
   }
 
   private def kibanaIndexFrom(blockContext: BlockContext): KibanaIndexName = {
-    blockContext.blockMetadata.kibanaPolicy.flatMap(_.index).getOrElse(KibanaIndexName.default)
+    blockContext.blockMetadata.kibanaPolicy.map(_.index).getOrElse(KibanaIndexName.default)
   }
 }
 

--- a/core/src/main/scala/tech/beshu/ror/implicits.scala
+++ b/core/src/main/scala/tech/beshu/ror/implicits.scala
@@ -308,7 +308,7 @@ trait LogsShowInstances
         showOption("group", bc.blockMetadata.currentGroupId) ::
         showNamedIterable("av_groups", bc.blockMetadata.availableGroups.toList.map(_.id)) ::
         showNamedIterable("indices", bc.indices) :: // todo: for sure it's ok?
-        showOption("kibana_idx", bc.blockMetadata.kibanaPolicy.flatMap(_.index)) ::
+        showOption("kibana_idx", bc.blockMetadata.kibanaPolicy.map(_.index)) ::
         showOption("fls", bc.fieldLevelSecurity) ::
         showNamedIterable("response_hdr", bc.responseHeaders) ::
         showNamedIterable("repositories", bc.repositories) ::

--- a/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/integration/KibanaIndexAndAccessYamlLoadedAccessControlTests.scala
@@ -112,7 +112,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
               indices = Set(requestedIndex(".readonlyrest")),
               kibanaPolicy = Some(KibanaPolicy.default.copy(
                 access = KibanaAccess.Admin,
-                index = Some(kibanaIndexName(".kibana_template")),
+                index = kibanaIndexName(".kibana_template"),
               )),
             )
           }
@@ -134,7 +134,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
               loggedUser = Some(DirectlyLoggedUser(User.Id("john"))),
               kibanaPolicy = Some(KibanaPolicy.default.copy(
                 access = KibanaAccess.Admin,
-                index = Some(kibanaIndexName(".kibana_template")),
+                index = kibanaIndexName(".kibana_template"),
               )),
             )
           }
@@ -158,7 +158,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
               availableGroups = UniqueList.of(group("RW_ror_custom")),
               kibanaPolicy = Some(KibanaPolicy.default.copy(
                 access = KibanaAccess.RW,
-                index = Some(kibanaIndexName(".kibana_ror_custom")),
+                index = kibanaIndexName(".kibana_ror_custom"),
               )),
             )
           }
@@ -180,7 +180,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
               loggedUser = Some(DirectlyLoggedUser(User.Id("john"))),
               kibanaPolicy = Some(KibanaPolicy.default.copy(
                 access = KibanaAccess.Admin,
-                index = Some(kibanaIndexName(".kibana_template")),
+                index = kibanaIndexName(".kibana_template"),
               )),
             )
           }
@@ -209,7 +209,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
             indices = Set(requestedIndex(".kibana_ror_custom")),
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = KibanaAccess.RW,
-              index = Some(kibanaIndexName(".kibana_ror_custom")),
+              index = kibanaIndexName(".kibana_ror_custom"),
             )),
           )
         }
@@ -230,7 +230,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
           adminMetadata.userOrigin should be(None)
           adminMetadata.kibanaPolicy should be(Some(KibanaPolicy(
             access = KibanaAccess.Admin,
-            index = Some(kibanaIndexName(".kibana_admins")),
+            index = kibanaIndexName(".kibana_admins"),
             templateIndex = None,
             hiddenApps = Set(
               FullNameKibanaApp("Enterprise Search|Overview"),
@@ -247,7 +247,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
           infosecMetadata.userOrigin should be(None)
           infosecMetadata.kibanaPolicy should be(Some(KibanaPolicy(
             access = KibanaAccess.RW,
-            index = Some(kibanaIndexName(".kibana_infosec")),
+            index = kibanaIndexName(".kibana_infosec"),
             templateIndex = None,
             hiddenApps = Set(
               FullNameKibanaApp("Enterprise Search|Overview"),
@@ -279,7 +279,7 @@ class KibanaIndexAndAccessYamlLoadedAccessControlTests extends AnyWordSpec
             indices = Set(requestedIndex(".kibana_admins")),
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = KibanaAccess.Admin,
-              index = Some(kibanaIndexName(".kibana_admins")),
+              index = kibanaIndexName(".kibana_admins"),
               hiddenApps = Set(
                 FullNameKibanaApp("Observability"),
                 FullNameKibanaApp("Enterprise Search|Overview"),

--- a/core/src/test/scala/tech/beshu/ror/mocks/MockRuleFactory.scala
+++ b/core/src/test/scala/tech/beshu/ror/mocks/MockRuleFactory.scala
@@ -25,7 +25,7 @@ import tech.beshu.ror.accesscontrol.blocks.{BlockContext, BlockContextUpdater, D
 import tech.beshu.ror.accesscontrol.blocks.Decision.{Denied, Permitted}
 import tech.beshu.ror.accesscontrol.blocks.Decision.Denied.Cause
 import tech.beshu.ror.accesscontrol.domain.LoggedUser.DirectlyLoggedUser
-import tech.beshu.ror.accesscontrol.domain.{CaseSensitivity, Group, LocalUsers, User}
+import tech.beshu.ror.accesscontrol.domain.{CaseSensitivity, Group, KibanaAccess, KibanaIndexName, LocalUsers, User}
 import tech.beshu.ror.utils.TestsUtils.{*, given}
 import tech.beshu.ror.utils.uniquelist.UniqueList
 
@@ -100,6 +100,20 @@ trait MockRuleFactory {
           )
         ))
     }
+
+  protected def kibanaAccessRule(ruleName: String, access: KibanaAccess): RegularRule = new RegularRule {
+    override val name: Rule.Name = Rule.Name(ruleName)
+
+    override protected def regularCheck[B <: BlockContext : BlockContextUpdater](blockContext: B): Task[Decision[B]] =
+      Task.now(Permitted(blockContext.withBlockMetadata(_.withKibanaAccess(access))))
+  }
+
+  protected def kibanaIndexRule(ruleName: String, index: KibanaIndexName): RegularRule = new RegularRule {
+    override val name: Rule.Name = Rule.Name(ruleName)
+
+    override protected def regularCheck[B <: BlockContext : BlockContextUpdater](blockContext: B): Task[Decision[B]] =
+      Task.now(Permitted(blockContext.withBlockMetadata(_.withKibanaIndex(index))))
+  }
 
   protected def perGroupKibanaIndexRule(ruleName: String): RegularRule = new RegularRule {
     override val name: Rule.Name = Rule.Name(ruleName)

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/EnabledAccessControlListTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/EnabledAccessControlListTests.scala
@@ -131,9 +131,9 @@ class EnabledAccessControlListTests extends AnyWordSpec with MockFactory with In
               case Allowed(UserMetadata.WithGroups(groupsMetadata)) =>
                 groupsMetadata.keys.toList should be(GroupId("g1") :: GroupId("g2") :: GroupId("g3") :: Nil)
 
-                groupsMetadata(GroupId("g1")).kibanaPolicy.flatMap(_.index) should be(Some(kibanaIndexName("kibana_g1")))
-                groupsMetadata(GroupId("g2")).kibanaPolicy.flatMap(_.index) should be(Some(kibanaIndexName("kibana_g2")))
-                groupsMetadata(GroupId("g3")).kibanaPolicy.flatMap(_.index) should be(Some(kibanaIndexName("kibana_g3")))
+                groupsMetadata(GroupId("g1")).kibanaPolicy.map(_.index) should be(Some(kibanaIndexName("kibana_g1")))
+                groupsMetadata(GroupId("g2")).kibanaPolicy.map(_.index) should be(Some(kibanaIndexName("kibana_g2")))
+                groupsMetadata(GroupId("g3")).kibanaPolicy.map(_.index) should be(Some(kibanaIndexName("kibana_g3")))
             }
           }
         }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/EnabledAccessControlListTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/EnabledAccessControlListTests.scala
@@ -29,6 +29,7 @@ import tech.beshu.ror.accesscontrol.EnabledAccessControlList.AccessControlListSt
 import tech.beshu.ror.accesscontrol.blocks.Block
 import tech.beshu.ror.accesscontrol.blocks.Block.Policy
 import tech.beshu.ror.accesscontrol.blocks.BlockContext.UserMetadataRequestBlockContext
+import tech.beshu.ror.accesscontrol.blocks.rules.Rule
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata.MetadataOrigin
 import tech.beshu.ror.accesscontrol.blocks.metadata.UserMetadata.WithGroups.GroupMetadata
 import tech.beshu.ror.accesscontrol.blocks.metadata.{BlockMetadata, UserMetadata}
@@ -345,6 +346,27 @@ class EnabledAccessControlListTests extends AnyWordSpec with MockFactory with In
                 blockContext.block.policy should be(Policy.Forbid(Some("forbidden msg 1")))
             }
           }
+          "prefer the first allowed block that established a kibana policy over an earlier block without one" in {
+            val acl = createAcl(
+              block("b1", Policy.Allow, result = Matched(userId("u1"), UniqueList.empty)),
+              blockWithKibanaRule("b2", Policy.Allow, userId("u1"), kibanaAccessRule("kibana_access", KibanaAccess.RO)),
+              blockWithKibanaRule("b3", Policy.Allow, userId("u1"), kibanaIndexRule("kibana_index", kibanaIndexName("custom_kibana"))),
+            )
+
+            val (userMetadataRequestResult, _) = acl
+              .handleMetadataRequest(mockUserMetadataRequestContext(getLicenseType))
+              .runSyncUnsafe()
+
+            inside(userMetadataRequestResult) {
+              case Allowed(UserMetadata.WithoutGroups(loggedUser, None, Some(kibanaPolicy), MetadataOrigin(blockContext))) =>
+                loggedUser.id should be(userId("u1"))
+                // b2 is the first allowed block with a kibana policy - it wins even though it has no
+                // explicit kibana index and a later block (b3) declares one. Selection prioritises
+                // "block established a kibana policy", not "block has an explicit kibana index".
+                blockContext.block.name should be(Block.Name("b2"))
+                kibanaPolicy.index should be(KibanaIndexName.default)
+            }
+          }
         }
         "some matched blocks have groups, some - don't" should {
           "return allow with the first block matched (case 1)" in {
@@ -479,6 +501,16 @@ class EnabledAccessControlListTests extends AnyWordSpec with MockFactory with In
         case MockedBlockResult.Matched(userId, groups) => passingAuthRule("auth", userId, groups)
         case MockedBlockResult.Mismatched => notPassingAuthRule("auth")
       })
+    )
+  }
+
+  private def blockWithKibanaRule(name: String, policy: Block.Policy, userId: User.Id, kibanaRule: Rule) = {
+    new Block(
+      name = Block.Name(name),
+      policy = policy,
+      verbosity = Block.Verbosity.Info,
+      audit = Block.Audit.Enabled,
+      rules = NonEmptyList.of(passingAuthRule("auth", userId, UniqueList.empty), kibanaRule)
     )
   }
 

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/BlockTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/BlockTests.scala
@@ -303,7 +303,7 @@ class BlockTests extends AnyWordSpec with BlockContextAssertion with Inside with
       val result = block.evaluateForMetadataRequest(MockRequestContext.metadata).runSyncUnsafe(1 second)
 
       val resolvedKibanaIndices = result.toList.collect {
-        case (Decision.Permitted(blockContext), _) => blockContext.blockMetadata.kibanaPolicy.flatMap(_.index)
+        case (Decision.Permitted(blockContext), _) => blockContext.blockMetadata.kibanaPolicy.map(_.index)
       }
       resolvedKibanaIndices should be(List(
         Some(kibanaIndexName(NonEmptyString.unsafeFrom("kibana_g1"))),

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/metadata/MetadataResponseTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/metadata/MetadataResponseTest.scala
@@ -160,7 +160,8 @@ class MetadataResponseTest extends AnyWordSpec with Matchers with MockFactory {
             |  "correlation_id": "test-id",
             |  "username": "admin",
             |  "kibana": {
-            |    "access": "unrestricted"
+            |    "access": "unrestricted",
+            |    "index": ".kibana"
             |  }
             |}""".stripMargin)
       }
@@ -180,12 +181,12 @@ class MetadataResponseTest extends AnyWordSpec with Matchers with MockFactory {
             |    {
             |      "group": { "id": "admins", "name": "Administrators" },
             |      "username": "admin",
-            |      "kibana": { "access": "unrestricted" }
+            |      "kibana": { "access": "unrestricted", "index": ".kibana" }
             |    },
             |    {
             |      "group": { "id": "users", "name": "Users" },
             |      "username": "admin",
-            |      "kibana": { "access": "unrestricted" }
+            |      "kibana": { "access": "unrestricted", "index": ".kibana" }
             |    }
             |  ]
             |}""".stripMargin)

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/metadata/MetadataResponseTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/metadata/MetadataResponseTest.scala
@@ -200,7 +200,7 @@ class MetadataResponseTest extends AnyWordSpec with Matchers with MockFactory {
       userOrigin = Some(UserOrigin(nes("jwt-issuer"))),
       kibanaPolicy = Some(KibanaPolicy(
         access = KibanaAccess.Admin,
-        index = Some(kibanaIndexName(nes(".kibana"))),
+        index = kibanaIndexName(nes(".kibana")),
         templateIndex = Some(kibanaIndexName(nes(".kibana_template"))),
         hiddenApps = Set(KibanaApp.FullNameKibanaApp(nes("Enterprise Search"))),
         allowedApiPaths = Set.empty,
@@ -219,7 +219,7 @@ class MetadataResponseTest extends AnyWordSpec with Matchers with MockFactory {
       userOrigin = Some(UserOrigin(nes("jwt-issuer"))),
       kibanaPolicy = Some(KibanaPolicy(
         access = KibanaAccess.Admin,
-        index = Some(kibanaIndexName(nes(".kibana"))),
+        index = kibanaIndexName(nes(".kibana")),
         templateIndex = Some(kibanaIndexName(nes(".kibana_template"))),
         hiddenApps = Set(KibanaApp.FullNameKibanaApp(nes("Enterprise Search"))),
         allowedApiPaths = Set.empty,
@@ -236,7 +236,7 @@ class MetadataResponseTest extends AnyWordSpec with Matchers with MockFactory {
       userOrigin = None,
       kibanaPolicy = Some(KibanaPolicy(
         access = KibanaAccess.Admin,
-        index = Some(kibanaIndexName(nes(".kibana_users"))),
+        index = kibanaIndexName(nes(".kibana_users")),
         templateIndex = Some(kibanaIndexName(nes(".kibana_users_template"))),
         hiddenApps = Set.empty,
         allowedApiPaths = Set.empty,

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/BaseKibanaAccessBasedTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/BaseKibanaAccessBasedTests.scala
@@ -74,7 +74,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = RW,
-              index = Some(kibanaIndexName(".kibana"))
+              index = kibanaIndexName(".kibana")
             )),
             indices = Set(requestedIndex(".kibana"))
           )
@@ -133,7 +133,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = RW,
-              index = Some(customKibanaIndex)
+              index = customKibanaIndex
             )),
             indices = Set(RequestedIndex(customKibanaIndex.underlying, excluded = false))
           )
@@ -233,7 +233,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
         assertBlockContext(_)(
           kibanaPolicy = Some(KibanaPolicy.default.copy(
             access = RW,
-            index = Some(kibanaIndexFrom(None))
+            index = kibanaIndexFrom(None)
           )),
         )
       }
@@ -249,7 +249,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = access,
-              index = Some(kibanaIndexFrom(None))
+              index = kibanaIndexFrom(None)
             )),
           )
         }
@@ -293,7 +293,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = RW,
-              index = Some(kibanaIndexName(".kibana"))
+              index = kibanaIndexName(".kibana")
             )),
             indices = Set(requestedIndex(".kibana_8.8.0"))
           )
@@ -309,7 +309,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = RW,
-              index = Some(kibanaIndexName(".kibana"))
+              index = kibanaIndexName(".kibana")
             )),
             indices = Set(requestedIndex(".kibana_analytics_8.8.0"))
           )
@@ -325,7 +325,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = RW,
-              index = Some(kibanaIndexName(".kibana"))
+              index = kibanaIndexName(".kibana")
             )),
             indices = Set(requestedIndex(".kibana"), requestedIndex(".kibana_analytics_8.8.0")),
           )
@@ -343,7 +343,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = RW,
-              index = Some(kibanaIndexName(".kibana-admin"))
+              index = kibanaIndexName(".kibana-admin")
             )),
             indices = Set(requestedIndex(".ds-.kibana-reporting-.kibana-admin-2025.01.01-000001"))
           )
@@ -361,7 +361,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = RW,
-              index = Some(kibanaIndexName(".kibana-admin"))
+              index = kibanaIndexName(".kibana-admin")
             )),
             indices = Set(requestedIndex(".kibana-reporting-.kibana-admin"))
           )
@@ -379,7 +379,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
           assertBlockContext(_)(
             kibanaPolicy = Some(KibanaPolicy.default.copy(
               access = RW,
-              index = Some(kibanaIndexName(".kibana"))
+              index = kibanaIndexName(".kibana")
             )),
             dataStreams = Set(fullDataStreamName("kibana_sample_data_logs"))
           )
@@ -406,7 +406,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
       assertBlockContext(_)(
         kibanaPolicy = Some(KibanaPolicy.default.copy(
           access = RO,
-          index = Some(customKibanaIndex)
+          index = customKibanaIndex
         )),
         indices = Set(RequestedIndex(customKibanaIndex.underlying, excluded = false))
       )
@@ -421,7 +421,7 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
       assertBlockContext(_)(
         kibanaPolicy = Some(KibanaPolicy.default.copy(
           access = RW,
-          index = Some(customKibanaIndex)
+          index = customKibanaIndex
         )),
         indices = Set(RequestedIndex(customKibanaIndex.underlying, excluded = false))
       )

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/KibanaAccessRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/KibanaAccessRuleTests.scala
@@ -42,7 +42,7 @@ class KibanaAccessRuleTests
         dataStreams = dataStreams,
         kibanaPolicy = Some(KibanaPolicy.default.copy(
           access = settings.access,
-          index = Some(kibanaIndexFrom(customKibanaIndex)),
+          index = kibanaIndexFrom(customKibanaIndex),
         )),
       )
     }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/KibanaIndexRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/KibanaIndexRuleTests.scala
@@ -46,7 +46,7 @@ class KibanaIndexRuleTests
         inside(result) {
           case Permitted(blockContext: UserMetadataRequestBlockContext) =>
             assertBlockContext(blockContext)(
-              kibanaPolicy = Some(KibanaPolicy.default.copy(index = Some(kibanaIndexName("kibana_index"))))
+              kibanaPolicy = Some(KibanaPolicy.default.copy(index = kibanaIndexName("kibana_index")))
             )
         }
       }

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/KibanaUserDataRuleTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/KibanaUserDataRuleTests.scala
@@ -242,7 +242,7 @@ class KibanaUserDataRuleTests
         dataStreams = dataStreams,
         kibanaPolicy = Some(KibanaPolicy.default.copy(
           access = settings.access,
-          index = Some(kibanaIndexFrom(customKibanaIndex)),
+          index = kibanaIndexFrom(customKibanaIndex),
         )),
       )
     }

--- a/docs/api/ror-internal-api-swagger.yaml
+++ b/docs/api/ror-internal-api-swagger.yaml
@@ -759,6 +759,7 @@ components:
       description: Kibana-related metadata for the user/group
       required:
         - access
+        - index
       properties:
         access:
           type: string

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-publishedPluginVersion=1.70.0
-pluginVersion=1.70.1-pre1
+publishedPluginVersion=1.70.1
+pluginVersion=1.71.0-pre1
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/UserMetadataSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/UserMetadataSuite.scala
@@ -56,7 +56,7 @@ class UserMetadataSuite
                |        "name":"group1"
                |        },
                |      "username":"user1",
-               |      "kibana":{"access":"unrestricted"}
+               |      "kibana":{"access":"unrestricted","index":".kibana"}
                |    }
                |  ]
                |}
@@ -351,7 +351,7 @@ class UserMetadataSuite
                |        "name":"group1"
                |        },
                |      "username":"user1",
-               |      "kibana":{"access":"unrestricted"}
+               |      "kibana":{"access":"unrestricted","index":".kibana"}
                |    }
                |  ]
                |}

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/audit/QueryAuditLogSerializerSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/audit/QueryAuditLogSerializerSuite.scala
@@ -84,7 +84,8 @@ class QueryAuditLogSerializerSuite
              |        "name": "group1"
              |      },
              |      "kibana": {
-             |        "access":"unrestricted"
+             |        "access":"unrestricted",
+             |        "index":".kibana"
              |      }
              |    }
              |  ]


### PR DESCRIPTION
The `/_readonlyrest/metadata/user` endpoint did not always include the kibana.index field. When a user was authenticated by a block that did not explicitly declare a Kibana index (for example, a block with only `auth_key` and no Kibana rule), the response omitted the index entirely:

```
  "kibana": {
    "access": "unrestricted"
  }
```

This was inconsistent with ROR's actual behavior: when no Kibana index is declared, ROR already falls back to the default index (.kibana) internally. Only the metadata response failed to reflect that, leaving the ROR Kibana plugin without an index to rely on.

With this change, kibana.index is always present in the response, defaulting to .kibana when not explicitly configured. The API contract has been updated to mark the field as required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kibana index metadata is now always included in access control responses and authorization results; defaults to ".kibana" when not specified.

* **New Features**
  * Selection now prefers the first allowed block that establishes a Kibana policy when resolving the Kibana index.

* **Refactor**
  * Kibana policy/index handling standardized across evaluation paths and rules.

* **Documentation**
  * Internal API version and changelog updated to mark kibana.index as required.

* **Tests**
  * Test expectations updated for guaranteed kibana.index presence and new selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->