### PR TITLE
[RORDEV-2087] Fix TSVB visualizations not showing for kibana_access: ro users (ES/Kibana 9.x)

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/BaseKibanaRule.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/blocks/rules/kibana/BaseKibanaRule.scala
@@ -104,8 +104,24 @@ abstract class BaseKibanaRule(val settings: Settings)
     isTargetingKibana &&
       isAccessOtherThanRoStrictConfigured &&
       kibanaCannotBeModified &&
-      isNonStrictAllowedPath &&
+      (isNonStrictAllowedPath || isMetricsVisDataRequest) &&
       isNonStrictAction
+  }
+
+  // TSVB / legacy visualizations issue a `.kibana` write while rendering (resolving or
+  // persisting the data view). That write arrives as a batched POST /_bulk, so it cannot
+  // match the per-document non-strict allowed paths above; recognise the originating Kibana
+  // endpoint via the request-path header instead.
+  private lazy val isMetricsVisDataRequest = ProcessingContext.create { (bc, _) =>
+    val result = bc
+      .requestContext
+      .restRequest
+      .allHeaders
+      .find(_.name === Header.Name.kibanaRequestPath)
+      .exists(_.value.value.contains("/internal/metrics/vis/data"))
+    given BlockContext = bc
+    logger.debug(s"Is Kibana TSVB metrics/vis/data request? ${result.show}")
+    result
   }
 
   private lazy val isAccessOtherThanRoStrictConfigured = ProcessingContext.create { (bc, _) =>

--- a/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/BaseKibanaAccessBasedTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/blocks/rules/kibana/BaseKibanaAccessBasedTests.scala
@@ -217,6 +217,49 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
         uriPath = UriPath.from("/.custom_kibana/_create/url:710d2a92ef849fc282bcb8a216f39046")
       )
     }
+    "allows a .kibana _bulk write for RO when it originates from the TSVB metrics/vis/data Kibana endpoint" in {
+      assertMatchRuleUsingIndicesRequest(
+        settingsOf(RO),
+        Action("indices:data/write/bulk"),
+        requestedIndices = Set(requestedIndex(".kibana")),
+        uriPath = Some(UriPath.from("/_bulk")),
+        headers = Set(headerFrom("x-ror-kibana-request-path" -> "/s/default/internal/metrics/vis/data"))
+      ) {
+        assertBlockContext(_)(
+          kibanaPolicy = Some(KibanaPolicy.default.copy(
+            access = RO,
+            index = Some(kibanaIndexName(".kibana"))
+          )),
+          indices = Set(requestedIndex(".kibana"))
+        )
+      }
+    }
+    "forbids the .kibana _bulk write from the TSVB metrics/vis/data endpoint for ROStrict" in {
+      assertNotMatchRuleUsingIndicesRequest(
+        settingsOf(ROStrict),
+        Action("indices:data/write/bulk"),
+        requestedIndices = Set(requestedIndex(".kibana")),
+        uriPath = Some(UriPath.from("/_bulk")),
+        headers = Set(headerFrom("x-ror-kibana-request-path" -> "/s/default/internal/metrics/vis/data"))
+      )
+    }
+    "forbids a plain .kibana _bulk write for RO when the TSVB metrics/vis/data header is absent" in {
+      assertNotMatchRuleUsingIndicesRequest(
+        settingsOf(RO),
+        Action("indices:data/write/bulk"),
+        requestedIndices = Set(requestedIndex(".kibana")),
+        uriPath = Some(UriPath.from("/_bulk"))
+      )
+    }
+    "forbids a _bulk write for RO from the TSVB metrics/vis/data endpoint when it does not target the Kibana index" in {
+      assertNotMatchRuleUsingIndicesRequest(
+        settingsOf(RO),
+        Action("indices:data/write/bulk"),
+        requestedIndices = Set(requestedIndex("not_kibana")),
+        uriPath = Some(UriPath.from("/_bulk")),
+        headers = Set(headerFrom("x-ror-kibana-request-path" -> "/s/default/internal/metrics/vis/data"))
+      )
+    }
     "RW can change cluster settings" in {
       assertNotMatchRuleUsingIndicesRequest(
         settingsOf(RO),
@@ -432,9 +475,10 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
                                                  action: Action,
                                                  requestedIndices: Set[RequestedIndex[ClusterIndexName]] = Set.empty,
                                                  customKibanaIndex: Option[KibanaIndexName] = None,
-                                                 uriPath: Option[UriPath] = None)
+                                                 uriPath: Option[UriPath] = None,
+                                                 headers: Set[Header] = Set.empty)
                                                 (blockContextAssertion: BlockContext => Unit = defaultOutputBlockContextAssertion(settings, requestedIndices, Set.empty, customKibanaIndex)) =
-    assertRuleUsingIndicesRequest(settings, action, customKibanaIndex, requestedIndices, uriPath, Some(blockContextAssertion))
+    assertRuleUsingIndicesRequest(settings, action, customKibanaIndex, requestedIndices, uriPath, headers, Some(blockContextAssertion))
 
   private def assertMatchRuleUsingDataStreamsRequest(settings: SETTINGS,
                                                      action: Action,
@@ -447,17 +491,19 @@ abstract class BaseKibanaAccessBasedTests[RULE <: Rule : RuleName, SETTINGS]
                                                     action: Action,
                                                     customKibanaIndex: Option[KibanaIndexName] = None,
                                                     requestedIndices: Set[RequestedIndex[ClusterIndexName]],
-                                                    uriPath: Option[UriPath] = None) =
-    assertRuleUsingIndicesRequest(settings, action, customKibanaIndex, requestedIndices, uriPath, blockContextAssertion = None)
+                                                    uriPath: Option[UriPath] = None,
+                                                    headers: Set[Header] = Set.empty) =
+    assertRuleUsingIndicesRequest(settings, action, customKibanaIndex, requestedIndices, uriPath, headers, blockContextAssertion = None)
 
   private def assertRuleUsingIndicesRequest(settings: SETTINGS,
                                             action: Action,
                                             customKibanaIndex: Option[KibanaIndexName],
                                             requestedIndices: Set[RequestedIndex[ClusterIndexName]],
                                             uriPath: Option[UriPath],
+                                            headers: Set[Header],
                                             blockContextAssertion: Option[BlockContext => Unit]) = {
     val requestContext = MockRequestContext.indices.copy(
-      restRequest = MockRestRequest(path = uriPath.getOrElse(UriPath.from("/undefined"))),
+      restRequest = MockRestRequest(path = uriPath.getOrElse(UriPath.from("/undefined")), allHeaders = headers),
       action = action,
       filteredIndices = requestedIndices,
     )

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.70.1
-pluginVersion=1.70.1
+pluginVersion=1.71.0-pre1
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.70.1
-pluginVersion=1.70.2
+pluginVersion=1.71.2
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.70.1
-pluginVersion=1.71.0-pre1
+pluginVersion=1.70.2
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m


### PR DESCRIPTION
🐞Fix (ES/KBN) Fix TSVB visualizations not showing for `kibana_access: ro` users for ES/KBN 9.x

---

## Problem
On all ES/Kibana 9.x versions, TSVB / legacy visualization panels are not shown for read-only Kibana users (`kibana_access: ro`). The panel renders empty and Kibana reports `"Could not find the data view"`. RW/admin users are unaffected.

## Root cause
Kibana's TSVB backend route `/internal/metrics/vis/data` issues an `indices:data/write/bulk` against the `.kibana` index while rendering (to resolve/persist the data view). `BaseKibanaRule` only permits RO writes to `.kibana` whose REST path (`/.kibana/url/...`, `/doc/index-pattern...`) and can never match a batched `POST /_bulk`. ROR denies the write (`FORBIDDEN by default`); "Could not find the data view" is just the secondary symptom Kibana surfaces.
  
## Fix
Treat the TSVB write as another non-strict location RO may write to: recognize the originating Kibana endpoint via the trusted `x-ror-kibana-request-path` header and OR it into `isRoNonStrictCase`. The allowance stays narrow — only `.kibana`, only RO(`ROStrict` still locked), only `indices:data/write/*`, and only from that specific endpoint. No new matcher, no extra `shouldMatch` branch, no ES-module changes; both `KibanaAccessRule` and `KibanaUserDataRule` inherit the fix.
  