### PR TITLE
[RORDEV-2107] Return MainSettingsNotFound for missing in-index settings document

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/api/MainSettingsApi.scala
+++ b/core/src/main/scala/tech/beshu/ror/api/MainSettingsApi.scala
@@ -38,7 +38,7 @@ import tech.beshu.ror.boot.{RorInstance, RorSchedulers}
 import tech.beshu.ror.constants
 import tech.beshu.ror.es.interfaces.EsXContentBuilder
 import tech.beshu.ror.implicits.*
-import tech.beshu.ror.settings.ror.source.IndexSettingsSource.LoadingError.IndexNotFound
+import tech.beshu.ror.settings.ror.source.IndexSettingsSource.LoadingError.{DocumentNotFound, IndexNotFound}
 import tech.beshu.ror.settings.ror.source.ReadOnlySettingsSource.SettingsLoadingError.SourceSpecificError
 import tech.beshu.ror.settings.ror.source.{FileSettingsSource, IndexSettingsSource}
 import tech.beshu.ror.settings.ror.{MainRorSettings, RawRorSettings, RawRorSettingsYamlParser}
@@ -141,7 +141,7 @@ class MainSettingsApi(
       .map {
         case Right(settings) =>
           ProvideIndexMainSettings.MainSettings(settings.rawSettings.rawYaml)
-        case Left(SourceSpecificError(error @ IndexNotFound)) =>
+        case Left(SourceSpecificError(error @ (IndexNotFound | DocumentNotFound))) =>
           ProvideIndexMainSettings.MainSettingsNotFound(Show[IndexSettingsSource.LoadingError].show(error))
         case Left(error) =>
           ProvideIndexMainSettings.Failure(error.show)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 publishedPluginVersion=1.70.2
-pluginVersion=1.71.0-pre2
+pluginVersion=1.71.0-pre3
 pluginName=readonlyrest
 
 org.gradle.jvmargs=-Xmx6144m

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseAdminApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseAdminApiSuite.scala
@@ -1235,7 +1235,7 @@ trait BaseAdminApiSuite
       ujson.read(
         """
           |{
-          |  "status": "ko",
+          |  "status": "empty",
           |  "message": "Cannot found document with ReadonlyREST settings"
           |}
           |""".stripMargin


### PR DESCRIPTION
The provide-in-index-settings endpoint only treated a missing settings index as "not found" (status "empty"); a missing settings document (index present, doc absent) fell through to a generic failure (status "ko"). Map DocumentNotFound to MainSettingsNotFound as well so both cases report status "empty". Updated BaseAdminApiSuite accordingly. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings lookup behavior so missing settings are handled correctly in more cases, returning a clearer “not found” outcome.
  * Updated related test expectations to match the revised response format.

* **Chores**
  * Bumped the build plugin version to the latest pre-release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->