### PR TITLE
[ci] Concise Claude PR reviews: findings only (what to do + why), hard 350-word cap

### DIFF
--- a/.claude/skills/ror-pr-review/SKILL.md
+++ b/.claude/skills/ror-pr-review/SKILL.md
@@ -51,19 +51,17 @@ Hunt for these categories on **every** PR, not just security-flagged ones:
 
 ## Output format
 
-Structure the review as:
+**BE CONCISE.** The review is read by a busy maintainer. Every finding = what to do + why. Nothing else.
 
-1. **What I checked** — a short list (3–8 bullets) of the actual files, lines, and call sites you examined. This is your audit trail.
-2. **Findings** — issues found, ordered by severity (`🚨 Critical` → `⚠️ Warning` → `Nit`). Each finding has:
-   - File and line number(s)
-   - One-sentence summary
-   - Reproduction or evidence (a regex test, a grep result, a call site, a benchmark)
-   - Concrete suggestion (with code where helpful)
-3. **What looks good** — one or two sentences crediting the parts that are notably well done (good test coverage, nice refactor, useful ADR). Genuine, not boilerplate.
-4. **Open questions** — anything you couldn't determine from the diff alone, phrased as a question to the contributor.
-
-**Do not** post `"No issues found"` without backing. If after thorough investigation there genuinely are no issues, the response must enumerate what you checked and *why* each area passed.
+- **Findings only**, ordered by severity (`🚨 Critical` → `⚠️ Warning` → `Nit`). Each finding, max 4 lines:
+  - `file:line` — imperative one-liner: what to change.
+  - Why, in 1–2 sentences, with the single strongest piece of evidence (a grep hit, a failing input, a call site) — not the full investigation.
+  - A code snippet ONLY when the fix isn't obvious from the one-liner.
+- NO "What I checked" narrative, NO "What looks good" section, NO methodology recap, NO restating the PR description. Do the investigation; don't serialize it.
+- **Open questions**: only if the answer would change a finding; max 2.
+- Genuinely no issues? One line: `No issues found — verified <the 3–5 highest-risk things you checked>.` That line IS the required backing; never a bare "No issues found".
+- **Hard cap: ~30 lines / ~350 words total.** With many findings, keep every Critical/Warning full and compress Nits to one line each.
 
 ## When the PR is small / docs-only
 
-A 2-line README change does not need a full audit. But the **"What I checked"** section must still appear (even if it's one bullet) so a maintainer can see your scope. The threshold for the canned "No issues found" response is: only when the diff is purely additive prose and you have read it in full.
+Same rules, shorter: the no-issues one-liner (with what you verified) is a complete review for a docs-only diff you read in full.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -71,17 +71,13 @@ jobs:
             or `scala-cli` (see the "What to actively hunt for" section in the skill).
 
             **Step 4 — post the review** using `gh pr comment ${{ github.event.pull_request.number }} --body-file <path>`.
-            Format strictly per the "Output format" section of the skill:
+            Format strictly per the "Output format" section of the skill — BE CONCISE:
+            findings only (severity, `file:line`, what to change, why in 1–2 sentences),
+            open questions only if they'd change a finding, and a HARD CAP of ~30 lines /
+            ~350 words for the whole review. No audit-trail narrative, no praise section.
 
-            1. **What I checked** — your audit trail (3–8 bullets)
-            2. **Findings** — ordered by severity, with file:line, evidence, suggestion
-            3. **What looks good** — one or two genuine sentences
-            4. **Open questions** — anything you couldn't determine from the diff alone
-
-            **Hard rule:** do NOT post `"No issues found"` without backing. If after
-            thorough investigation there genuinely are no issues, your response must
-            enumerate what you checked and why each area passed. A bare "No issues
-            found" response will be treated as a failed review.
+            **Hard rule:** never a bare `"No issues found"` — the no-issues form is ONE
+            line naming the 3–5 highest-risk things you verified.
 
             **Hard rule:** if you hit an obstacle (tool error, file too large, ambiguous
             code), say so explicitly in the review. Never silently skip.


### PR DESCRIPTION
**Changelog:** [ci] The automated Claude review now posts terse, action-oriented reviews.

Reviews had grown to multi-page reports (audit trail, methodology recap, praise section). New output contract in both the workflow prompt and the `ror-pr-review` skill:

- **Findings only**, by severity: `file:line` + what to change + why in 1–2 sentences; nits one line each.
- No "What I checked" narrative, no "What looks good" section — investigation depth unchanged, only the serialization shrinks.
- No-issues form is ONE line naming the 3–5 highest-risk things verified.
- Hard cap: ~30 lines / ~350 words per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnbjCKssA9ZWrCFmuDXmFA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated automated code review guidance to produce shorter, more consistent review summaries.
  * Standardized no-issues responses to include a brief verification note instead of a bare “No issues found.”
* **Chores**
  * Adjusted the review workflow to enforce stricter output limits and severity-ordered findings only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->