### PR TITLE
[ci] Fix BUILD_* legs on all PR builds: configuration-time quiet() log pollutes the printEsModules parse

### DIFF
--- a/ci/publish-ror-plugins.sh
+++ b/ci/publish-ror-plugins.sh
@@ -20,9 +20,10 @@ cleanup_docker_and_build() {
 }
 
 # Emits one ES module name per line for the given generation (newest module first).
+# grep guards against configuration-time build-script output leaking into --quiet stdout.
 list_es_modules() {
   local es_major=$1
-  ./gradlew printEsModules "-PesMajor=$es_major" --quiet </dev/null
+  ./gradlew printEsModules "-PesMajor=$es_major" --quiet </dev/null | grep -E '^es[0-9]+x$'
 }
 
 # Emits two lines: the base ES version on line 1, all supported versions space-separated on line 2.

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -133,8 +133,9 @@ test {
     // maxParallelForks=1 always — forks can't split the scalatest engine (gradle#8632), so a 2nd fork
     // gets no work. Parallelism = sharding (multiple -PshardCount invocations), not forks.
     maxParallelForks = 1
-    // Logged loud (quiet() survives -q) so the per-JVM fork count is never a mystery.
-    logger.quiet(">>> integration-tests maxParallelForks=${maxParallelForks} (1 ES/JVM; parallelism via -PshardCount)")
+    // lifecycle, NOT quiet(): this runs at configuration time, so quiet() pollutes the stdout that
+    // list_es_modules (publish-ror-plugins.sh) parses from `printEsModules --quiet`.
+    logger.lifecycle(">>> integration-tests maxParallelForks=${maxParallelForks} (1 ES/JVM; parallelism via -PshardCount)")
     // Per worker JVM. The JVM only orchestrates (streams small HTTP to ES, no bulk data); measured peak
     // live heap is ~50MB, so 512m is ~10x headroom. Overridable via -PitTestHeap for outlier suites.
     maxHeapSize = project.findProperty('itTestHeap') ?: '512m'


### PR DESCRIPTION
**Changelog:** [ci] fix all-PR BUILD_[6-9]xx failures caused by a semantic conflict between #1263 and #1279.

## What broke

Every PR build now fails all four `BUILD_[6-9]xx` legs with:

```
Cannot locate tasks that match ':>>> integration-tests maxParallelForks=1 (1 ES/JVM; parallelism via -PshardCount):verifyRepackageBytecodeNewest'
```

First seen on #1269 (build 10700) — but it will hit **every** PR.

## Why

A semantic conflict between two individually-green PRs merged 7 minutes apart this morning:

- #1263 added `logger.quiet(">>> integration-tests maxParallelForks…")` inside the eager `test {}` block of `integration-tests/build.gradle`. It fires at **configuration time** and, being `quiet()`, **survives `--quiet`** (that was the deliberate point — keep the fork count visible).
- #1279 added `list_es_modules()` = parse the stdout of `./gradlew printEsModules --quiet` into module names.

Neither PR's CI ever saw the other's change, and develop pushes don't run the BUILD legs (only `AUDIT_BUILD_CHECK`) — so the combination was first exercised by the next PR merge build.

## Fix

1. `logger.quiet` → `logger.lifecycle`: still printed in normal IT runs (verified — it shows in a default-log-level gradle run), suppressed under `-q`, so machine-parsed output stays clean.
2. Defense in depth: `list_es_modules()` filters `printEsModules --quiet` output through `grep -E '^es[0-9]+x$'`, so any future configuration-time output can't re-poison the module list.

Verified locally: `./gradlew printEsModules -PesMajor=8 --quiet` emits exactly the 17 `es8xx` module names.

This PR's own BUILD legs are the end-to-end proof — they run `build_ror_plugins` against the merged tree containing the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyUyjGmV6wXtn3TPbxUbh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command output handling so only the intended module names are returned, preventing extra build messages from affecting publishing workflows.

* **Chores**
  * Adjusted logging during test setup to better support quieter, more reliable automated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->