### PR TITLE
[ci] printEsModules: file handshake instead of stdout parse (follow-up to #1287 review)

### DIFF
--- a/build-base/src/main/java/tech/beshu/ror/gradle/PrintEsModulesTask.java
+++ b/build-base/src/main/java/tech/beshu/ror/gradle/PrintEsModulesTask.java
@@ -22,16 +22,22 @@ import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskAction;
 import tech.beshu.ror.gradle.utils.EsModuleFinder;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Prints the names of all {@code esXXx} modules for one ES generation (major) to stdout, newest
- * module first. Invoke with {@code --quiet} to suppress Gradle's own output so only module names
- * come through. Pair with {@code :esXXx:printEsVersionsForModule} to get each module's versions.
+ * Lists the names of all {@code esXXx} modules for one ES generation (major), newest module
+ * first: printed to stdout for humans, AND written to {@code build/es-modules/es<major>x.txt}
+ * (one per line) for scripts. Scripts must read the file — never parse the stdout, which any
+ * configuration-time build-script logging can pollute even under {@code --quiet}.
+ * Pair with {@code :esXXx:printEsVersionsForModule} to get each module's versions.
  *
  * <p>Input (project property): {@code -PesMajor=<n>}.
- * Usage: {@code ./gradlew printEsModules -PesMajor=8 --quiet}
+ * Usage: {@code ./gradlew printEsModules -PesMajor=8}
  */
 public class PrintEsModulesTask extends DefaultTask {
 
@@ -39,15 +45,32 @@ public class PrintEsModulesTask extends DefaultTask {
   public void printModules() {
     int esMajor = Integer.parseInt(requiredProperty("esMajor"));
 
-    List<Project> modules =
+    List<String> moduleNames =
         EsModuleFinder.sortedEsModules(
                 getProject(), EsModuleFinder.newestEsVersionComparator().reversed())
             .stream()
             .filter(module -> majorVersionOf(EsModuleFinder.newestEsVersionFor(module)) == esMajor)
+            .map(Project::getName)
             .collect(Collectors.toList());
 
-    for (Project module : modules) {
-      System.out.println(module.getName());
+    moduleNames.forEach(System.out::println);
+    writeModulesFile(esMajor, moduleNames);
+  }
+
+  private void writeModulesFile(int esMajor, List<String> moduleNames) {
+    Path outputFile =
+        getProject()
+            .getLayout()
+            .getBuildDirectory()
+            .file("es-modules/es" + esMajor + "x.txt")
+            .get()
+            .getAsFile()
+            .toPath();
+    try {
+      Files.createDirectories(outputFile.getParent());
+      Files.write(outputFile, moduleNames);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Cannot write " + outputFile, e);
     }
   }
 

--- a/ci/publish-ror-plugins.sh
+++ b/ci/publish-ror-plugins.sh
@@ -24,8 +24,11 @@ cleanup_docker_and_build() {
 # (configuration-time build-script logging can pollute it even under --quiet).
 list_es_modules() {
   local es_major=$1
-  ./gradlew printEsModules "-PesMajor=$es_major" --quiet </dev/null >&2
-  cat "build/es-modules/es${es_major}x.txt"
+  local modules_file="build/es-modules/es${es_major}x.txt"
+  # rm first: a failed gradle run must yield an error, never a stale list from a previous run.
+  rm -f "$modules_file"
+  ./gradlew printEsModules "-PesMajor=$es_major" --quiet </dev/null >&2 || return 1
+  cat "$modules_file"
 }
 
 # Emits two lines: the base ES version on line 1, all supported versions space-separated on line 2.
@@ -174,6 +177,10 @@ publish_ror_plugins() {
 
   export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log -1 --format=%ct 2>/dev/null || echo 1704067200)}"
 
+  # Capture first (process substitution would swallow a module-discovery failure into plain EOF).
+  local modules
+  modules=$(list_es_modules "$es_major") || { echo "ERROR: cannot list es${es_major}x modules"; return 1; }
+
   local module
   while IFS= read -r module; do
     [ -z "$module" ] && continue
@@ -193,5 +200,5 @@ publish_ror_plugins() {
         return 1
       fi
     done
-  done < <(list_es_modules "$es_major")
+  done <<< "$modules"
 }

--- a/ci/publish-ror-plugins.sh
+++ b/ci/publish-ror-plugins.sh
@@ -20,10 +20,12 @@ cleanup_docker_and_build() {
 }
 
 # Emits one ES module name per line for the given generation (newest module first).
-# grep guards against configuration-time build-script output leaking into --quiet stdout.
+# The task writes the list to build/es-modules/es<major>x.txt; read THAT, never gradle stdout
+# (configuration-time build-script logging can pollute it even under --quiet).
 list_es_modules() {
   local es_major=$1
-  ./gradlew printEsModules "-PesMajor=$es_major" --quiet </dev/null | grep -E '^es[0-9]+x$'
+  ./gradlew printEsModules "-PesMajor=$es_major" --quiet </dev/null >&2
+  cat "build/es-modules/es${es_major}x.txt"
 }
 
 # Emits two lines: the base ES version on line 1, all supported versions space-separated on line 2.

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -233,13 +233,17 @@ build_ror_plugins() {
 
   local es_major=$1
 
+  # Capture first (process substitution would swallow a module-discovery failure into plain EOF).
+  local modules
+  modules=$(list_es_modules "$es_major") || { echo "ERROR: cannot list es${es_major}x modules"; return 1; }
+
   local module
   while IFS= read -r module; do
     [ -z "$module" ] && continue
     if ! ./gradlew ":${module}:verifyRepackageBytecodeNewest" </dev/null; then
       return 1
     fi
-  done < <(list_es_modules "$es_major")
+  done <<< "$modules"
 }
 
 if [[ $ROR_TASK == "build_es9xx" ]]; then


### PR DESCRIPTION
**Changelog:** [ci] `list_es_modules` no longer parses gradle stdout — `printEsModules` writes `build/es-modules/es<major>x.txt` and the script reads the file.

Follow-up to @coutoPL's review comment on #1287 ("Why didn't we solve it where it's defined, rather than in bash?!"): agreed — the bash `grep -E '^es[0-9]+x$'` duplicated es-module naming knowledge that belongs to the task. Now solved where it's defined:

- `PrintEsModulesTask` writes the module list to `build/es-modules/es<major>x.txt` (still prints to stdout for humans).
- `list_es_modules()` runs the task (stdout → stderr, visible in CI logs but never parsed) and `cat`s the file. The grep is gone.

No configuration-time build-script logging can ever poison the module list again, by construction rather than by filter. (#1287's `logger.quiet` → `logger.lifecycle` root-cause fix stands unchanged.)

Verified locally: `es8x.txt` = 17 modules, `es9x.txt` = es94x/es92x/es91x/es90x; the function emits exactly the module names. The BUILD_* legs of this PR exercise the new handshake end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSyUyjGmV6wXtn3TPbxUbh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build and Release Improvements**
  * Improved generation and handling of Elasticsearch module lists during builds.
  * Module lists are now written to a dedicated build output file (one per ES major version) for dependable use by publishing automation.
  * Publishing and pipeline steps now read the saved module list instead of extracting it from build output, and failures in module discovery are no longer silently ignored.
  * Reduced noisy/irrelevant stdout during module-list generation while preserving error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->