### PR TITLE
[ci] Fix the top CI flake: readiness probe ran on a 60s timeout instead of the configured 5 minutes

### DIFF
--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/ElasticsearchNodeWaitingStrategy.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/ElasticsearchNodeWaitingStrategy.scala
@@ -84,12 +84,15 @@ class ElasticsearchNodeWaitingStrategy(
           .reachableEsChecker(containerName, client)
           .waitForStart()
       case CurrentOs.OtherThanWindows =>
+        // Inherit our timeout: a fresh HttpWaitStrategy defaults to testcontainers' 60s,
+        // which a cold ES boot on a loaded CI runner regularly exceeds (top CI flake).
         val esRestApiWaitStrategy = new HttpWaitStrategy()
           .usingTls()
           .allowInsecure()
           .forPort(esPort)
           .forPath("/")
           .forStatusCodeMatching(_ => true)
+          .withStartupTimeout(startupTimeout)
         Try(esRestApiWaitStrategy.waitUntilReady(waitStrategyTarget)).isSuccess
     }
   }


### PR DESCRIPTION
One-line fix for the most frequent CI flake: `RorStartingResponseCodeSuite` failing with `Cannot start ROR-ES container [startingTest_EsCluster_N_1]`.

## Root cause

`EsContainer` sets `waitStrategy.withStartupTimeout(5 minutes)` — but that lands on the **outer** `ElasticsearchNodeWaitingStrategy`. On Linux, `waitForRestEsApi` builds an **inner** `new HttpWaitStrategy()` and calls `waitUntilReady` on it directly, so the inner strategy runs on testcontainers' **default 60-second** startup timeout.

This suite is the only user of `WaitForEsRestApiResponsive` (it boots ES with deliberately malformed ROR settings, so it can't wait for a green cluster — it waits for the REST API to answer anything). A cold ES boot takes ~35–45 s on an idle runner but 55–75 s when 4 shard JVMs and their ES containers share the box — a coin flip against the 60 s window.

Proof from the develop failure (run 30992947168, es92x): container created 09:43:26, ES transport bound 09:44:37, `Cannot start ROR-ES container` thrown **09:44:38** — ES was seconds from binding HTTP when the 60 s expired. Same signature reproduced 6× in 3 weeks across develop, es816x, es92x and es94x. Ruled out the runner side: no OOM kills, no memory pressure at the failure times.

## Fix

Propagate the configured timeout: `.withStartupTimeout(startupTimeout)` on the inner strategy (`startupTimeout` is the `AbstractWaitStrategy` field the outer 5-minute setting already populates). The Windows path (`reachableEsChecker`) has its own timeout handling and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PziwEHa4skJ4mK1DejQjQZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Elasticsearch startup reliability by applying the configured startup timeout when waiting for the HTTP API to become ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->