### PR TITLE
[RORDEV-1563] Lookup indices support

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -31,7 +31,7 @@ sealed trait EsqlQueryRewriteResult
 
 object EsqlQueryRewriteResult {
   final case class Rewritten(newQuery: String) extends EsqlQueryRewriteResult
-  case object CannotRewriteQuery extends EsqlQueryRewriteResult
+  final case class CannotRewriteQuery(reason: String) extends EsqlQueryRewriteResult
 }
 
 sealed trait EsqlIndexTable {
@@ -51,8 +51,17 @@ object EsqlIndexTable {
   }
 
   object From {
+
     def parse(tableStringInQuery: String): Option[From] =
       requestedIndicesFrom(tableStringInQuery).map(From(tableStringInQuery, _))
+
+    private def requestedIndicesFrom(
+        tableStringInQuery: String
+    ): Option[NonEmptyList[RequestedIndex[ClusterIndexName]]] =
+      NonEmptyList.fromList(
+        tableStringInQuery.split(',').asSafeList.filter(_.nonEmpty).flatMap(RequestedIndex.fromString)
+      )
+
   }
 
   final case class LookupJoin(tableStringInQuery: String, index: IndexName.Full) extends EsqlIndexTable {
@@ -71,7 +80,7 @@ object EsqlIndexTable {
 
   }
 
-  final case class Replacement(table: EsqlIndexTable, newIndices: NonEmptyList[ClusterIndexName])
+  private[ror] final case class Replacement(table: EsqlIndexTable, newIndices: NonEmptyList[ClusterIndexName])
 
   def requestedIndicesOf(tables: NonEmptyList[EsqlIndexTable]): Set[RequestedIndex[ClusterIndexName]] =
     tables.toList.flatMap(_.requestedIndices.toList).toCovariantSet
@@ -84,37 +93,37 @@ object EsqlIndexTable {
     newQueryFrom(oldQuery, buildReplacements(tables, allowedIndices))
   }
 
-  def buildReplacements(
+  private[ror] def buildReplacements(
       tables: NonEmptyList[EsqlIndexTable],
       allowedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): NonEmptyList[Replacement] = {
     val allowedIndexNames: Set[ClusterIndexName] = allowedIndices.includedOnly
     val fromTables = tables.collect { case table: From => table }
 
-    val lookupOnlyNames: Set[ClusterIndexName] =
+    val lookupOnlyIndexNames: Set[ClusterIndexName] =
       tables.collect { case table: LookupJoin => table.clusterIndexName }.toCovariantSet --
         fromTables.flatMap(_.requestedIndices.includedOnly).toCovariantSet
 
-    val matchedNamesByFromTable: Map[From, Set[ClusterIndexName]] =
+    val matchedIndexNamesByFromTable: Map[From, Set[ClusterIndexName]] =
       fromTables.map(table => (table, table.matcher.filter(allowedIndexNames))).toMap
 
     // an alias the ACL replaced with its backing index matches no FROM pattern, and nothing left in the
     // request says which table it came from
-    val unattributedNames: Set[ClusterIndexName] =
-      allowedIndexNames -- lookupOnlyNames -- matchedNamesByFromTable.values.flatten.toCovariantSet
+    val unattributedIndexNames: Set[ClusterIndexName] =
+      allowedIndexNames -- lookupOnlyIndexNames -- matchedIndexNamesByFromTable.values.flatten.toCovariantSet
 
-    def authorizedNamesFor(table: EsqlIndexTable): Option[NonEmptyList[ClusterIndexName]] = table match {
+    def authorizedIndexNamesFor(table: EsqlIndexTable): Option[NonEmptyList[ClusterIndexName]] = table match {
       case table: LookupJoin =>
         Option.when(allowedIndexNames.contains(table.clusterIndexName))(NonEmptyList.one(table.clusterIndexName))
       case table: From =>
-        NonEmptyList.fromList((matchedNamesByFromTable(table) ++ unattributedNames).toList)
+        NonEmptyList.fromList((matchedIndexNamesByFromTable(table) ++ unattributedIndexNames).toList)
     }
 
-    val authorizedNamesByTable: Map[EsqlIndexTable, Option[NonEmptyList[ClusterIndexName]]] =
-      tables.toList.map(table => (table, authorizedNamesFor(table))).toMap
+    val authorizedIndexNamesByTable: Map[EsqlIndexTable, Option[NonEmptyList[ClusterIndexName]]] =
+      tables.toList.map(table => (table, authorizedIndexNamesFor(table))).toMap
 
     val nonexistentIndexByTableText: Map[String, ClusterIndexName] =
-      authorizedNamesByTable
+      authorizedIndexNamesByTable
         .collect { case (table, None) => table.tableStringInQuery }
         .toList
         .distinct
@@ -122,31 +131,32 @@ object EsqlIndexTable {
         .toMap
 
     tables.map { table =>
-      val newIndices = authorizedNamesByTable(table)
+      val newIndices = authorizedIndexNamesByTable(table)
         .getOrElse(NonEmptyList.one(nonexistentIndexByTableText(table.tableStringInQuery)))
       Replacement(table, newIndices)
     }
   }
 
-  def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): EsqlQueryRewriteResult = {
+  private[ror] def newQueryFrom(
+      oldQuery: String,
+      replacements: NonEmptyList[Replacement]
+  ): EsqlQueryRewriteResult = {
     val scan = QueryScan.of(oldQuery)
     replacements.toList
       .groupBy(_.table)
       .toList
       .traverse { case (table, tableReplacements) =>
         val spans = indexListSpansIn(scan, table)
-        Option.when(spans.size === tableReplacements.size)(spans.zip(tableReplacements))
+        Either.cond(
+          spans.size === tableReplacements.size,
+          spans.zip(tableReplacements),
+          s"the table [${table.show}] cannot be unambiguously located in the query text"
+        )
       }
       .map(_.flatten)
       .flatMap(spliceIndexLists(oldQuery, _))
-      .map(EsqlQueryRewriteResult.Rewritten.apply)
-      .getOrElse(EsqlQueryRewriteResult.CannotRewriteQuery)
+      .fold(EsqlQueryRewriteResult.CannotRewriteQuery.apply, EsqlQueryRewriteResult.Rewritten.apply)
   }
-
-  private def requestedIndicesFrom(tableStringInQuery: String): Option[NonEmptyList[RequestedIndex[ClusterIndexName]]] =
-    NonEmptyList.fromList(
-      tableStringInQuery.split(',').asSafeList.filter(_.nonEmpty).flatMap(RequestedIndex.fromString)
-    )
 
   private def indexListSpansIn(scan: QueryScan, table: EsqlIndexTable): List[(Int, Int)] = {
     val matcher = indexListPatternOf(table).matcher(scan.text)
@@ -284,15 +294,15 @@ object EsqlIndexTable {
 
   }
 
-  private def spliceIndexLists(query: String, spans: List[((Int, Int), Replacement)]): Option[String] = {
+  private def spliceIndexLists(query: String, spans: List[((Int, Int), Replacement)]): Either[String, String] = {
     val sortedSpans = spans.sortBy { case ((start, _), _) => start }
     val overlapping = sortedSpans.sliding(2).exists {
       case List(((_, previousEnd), _), ((start, _), _)) => previousEnd > start
       case _                                            => false
     }
-    if (overlapping) None
+    if (overlapping) Left("the index lists of the tables overlap in the query text")
     else
-      Some {
+      Right {
         sortedSpans.reverse.foldLeft(query) { case (currentQuery, ((start, end), replacement)) =>
           val newIndices = replacement.newIndices.toList.map(_.show).mkString(",")
           s"${currentQuery.substring(0, start)}$newIndices${currentQuery.substring(end)}"

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -26,6 +26,13 @@ import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.regex.Pattern
 
+sealed trait EsqlQueryRewriteResult
+
+object EsqlQueryRewriteResult {
+  final case class Rewritten(newQuery: String) extends EsqlQueryRewriteResult
+  case object CannotRewriteQuery extends EsqlQueryRewriteResult
+}
+
 sealed trait EsqlIndexTable {
   def tableStringInQuery: String
   def requestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
@@ -72,7 +79,7 @@ object EsqlIndexTable {
       oldQuery: String,
       tables: NonEmptyList[EsqlIndexTable],
       allowedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[String] = {
+  ): EsqlQueryRewriteResult = {
     newQueryFrom(oldQuery, buildReplacements(tables, allowedIndices))
   }
 
@@ -102,14 +109,12 @@ object EsqlIndexTable {
     NonEmptyList.fromListUnsafe(fromReplacements ++ lookupReplacements)
   }
 
-  /** `None` when the rewrite cannot be applied. Callers must reject the request rather than skip it - the
-    * query was allowed only on the strength of the narrowed set, so unrewritten it runs against the
-    * user's original indices.
-    */
-  def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): Option[String] = {
+  def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): EsqlQueryRewriteResult = {
     replacements.toList
       .traverse(replacement => indexListSpanIn(oldQuery, replacement.table).map((_, replacement)))
       .flatMap(spliceIndexLists(oldQuery, _))
+      .map(EsqlQueryRewriteResult.Rewritten.apply)
+      .getOrElse(EsqlQueryRewriteResult.CannotRewriteQuery)
   }
 
   private def requestedIndicesFrom(tableStringInQuery: String): Option[NonEmptyList[RequestedIndex[ClusterIndexName]]] =

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -24,7 +24,7 @@ import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
-import java.util.regex.{Matcher, Pattern}
+import java.util.regex.Pattern
 
 sealed trait EsqlIndexTable {
   def tableStringInQuery: String
@@ -72,7 +72,7 @@ object EsqlIndexTable {
       oldQuery: String,
       tables: NonEmptyList[EsqlIndexTable],
       allowedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): String = {
+  ): Option[String] = {
     newQueryFrom(oldQuery, buildReplacements(tables, allowedIndices))
   }
 
@@ -100,21 +100,22 @@ object EsqlIndexTable {
     NonEmptyList.fromListUnsafe(fromReplacements ++ lookupReplacements)
   }
 
-  def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): String = {
-    replacements.toList.foldLeft(oldQuery) { case (currentQuery, replacement) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, replacement.table.tableStringInQuery, replacement.newIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, replacement.table.tableStringInQuery, replacement.newIndices)}"
-      }
-    }
+  /**
+   * `None` whenever a table ES reported cannot be located in the query, or two located index lists overlap.
+   *
+   * The request has already been allowed on the strength of the narrowed index set, so a rewrite that cannot
+   * be performed is not one that can be skipped - forwarding the query untouched would run it against the
+   * user's original, unauthorized indices. Callers turn `None` into a forbidden response.
+   */
+  def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): Option[String] = {
+    replacements.toList
+      .traverse(replacement => indexListSpanIn(oldQuery, replacement.table).map((_, replacement)))
+      .flatMap(spliceIndexLists(oldQuery, _))
   }
 
-  // The returned map is threaded into `buildFromReplacements`: if the same literal text is masked in
-  // both a FROM and a LOOKUP JOIN, `newQueryFrom`'s single per-table substitution needs both to
-  // resolve to the same nonexistent name.
+  // The returned map is threaded into `buildFromReplacements` so that a literal masked in both a FROM and
+  // a LOOKUP JOIN reads as the same nonexistent index in the rewritten query, the way it read as the same
+  // index in the original one.
   private def buildLookupReplacements(
       tables: List[LookupJoin],
       allowedIndices: Set[ClusterIndexName]
@@ -170,17 +171,49 @@ object EsqlIndexTable {
     }
   }
 
-  // Anchored to non-identifier boundaries so `originTable` doesn't match as a substring of a longer
-  // identifier (e.g. "book" inside "book_prices").
-  private def replaceTableNameInQueryPart(
-      currentQuery: String,
-      originTable: String,
-      newIndices: NonEmptyList[ClusterIndexName]
-  ): String = {
-    val nonIdentifierChar = "[^\\w.\\-*:]"
-    val pattern = s"(^|$nonIdentifierChar)${Pattern.quote(originTable)}(?=$nonIdentifierChar|$$)"
-    val replacement = "$1" + Matcher.quoteReplacement(newIndices.toList.map(_.show).mkString(","))
-    currentQuery.replaceAll(pattern, replacement)
+  /** `None` unless the list can be located exactly once - an ambiguous query is rejected, not guessed at. */
+  private def indexListSpanIn(query: String, table: EsqlIndexTable): Option[(Int, Int)] = {
+    val matcher = indexListPatternOf(table).matcher(query)
+    Option.when(matcher.find())((matcher.start(1), matcher.end(1))).filterNot(_ => matcher.find())
+  }
+
+  /**
+   * ES reports an index list normalized - entries joined with `,`, quoting stripped - so `FROM a, b` is
+   * reported as `a,b` and plain text search for it finds nothing. The pattern below matches every spelling
+   * that normalizes to what ES reported, and only where a command can start, so neither an identifier that
+   * merely shares an index's name (`FROM status | WHERE status == "ok"`) nor a keyword inside a string
+   * literal is mistaken for an index list.
+   */
+  private def indexListPatternOf(table: EsqlIndexTable): Pattern = {
+    val keywords = table match {
+      case _: From       => "FROM|TS"
+      case _: LookupJoin => "LOOKUP\\s+JOIN"
+    }
+    val optionalQuote = "(?:\"\"\"|\")?"
+    val indexList = table.tableStringInQuery
+      .split(',')
+      .map(index => s"$optionalQuote${Pattern.quote(index)}$optionalQuote")
+      .mkString("\\s*,\\s*")
+    Pattern.compile(
+      s"(?:^|[|(])\\s*(?:$keywords)\\s+($indexList)(?![\\w.\\-*:])",
+      Pattern.CASE_INSENSITIVE
+    )
+  }
+
+  private def spliceIndexLists(query: String, spans: List[((Int, Int), Replacement)]): Option[String] = {
+    val sortedSpans = spans.sortBy { case ((start, _), _) => start }
+    val overlapping = sortedSpans.sliding(2).exists {
+      case List(((_, previousEnd), _), ((start, _), _)) => previousEnd > start
+      case _                                            => false
+    }
+    if (overlapping) None
+    else
+      Some {
+        sortedSpans.reverse.foldLeft(query) { case (currentQuery, ((start, end), replacement)) =>
+          val newIndices = replacement.newIndices.toList.map(_.show).mkString(",")
+          s"${currentQuery.substring(0, start)}$newIndices${currentQuery.substring(end)}"
+        }
+      }
   }
 
 }

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -18,7 +18,7 @@ package tech.beshu.ror.es
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
 import tech.beshu.ror.accesscontrol.matchers.PatternsMatcher
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
@@ -33,7 +33,6 @@ sealed trait EsqlIndexTable {
 
 object EsqlIndexTable {
 
-  // FROM supports wildcards, comma-separated lists, and `cluster:index` remote references.
   final case class From(
       tableStringInQuery: String,
       requestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
@@ -46,27 +45,28 @@ object EsqlIndexTable {
       requestedIndicesFrom(tableStringInQuery).map(From(tableStringInQuery, _))
   }
 
-  // LOOKUP JOIN's target must be a single, specific index name or alias: no wildcards, no comma
-  // lists, no remote cluster prefix (https://www.elastic.co/docs/reference/query-languages/esql/commands/lookup-join).
-  final case class LookupJoin(tableStringInQuery: String, index: ClusterIndexName) extends EsqlIndexTable {
+  // LOOKUP JOIN's target must be a single, specific index name or alias: no wildcards, no comma lists
+  // https://www.elastic.co/docs/reference/query-languages/esql/commands/lookup-join
+  final case class LookupJoin(tableStringInQuery: String, index: IndexName.Full) extends EsqlIndexTable {
+    val clusterIndexName: ClusterIndexName.Local = ClusterIndexName.Local(index)
+
     override def requestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]] =
-      NonEmptyList.one(RequestedIndex(index, excluded = false))
+      NonEmptyList.one(RequestedIndex(clusterIndexName, excluded = false))
   }
 
   object LookupJoin {
+
     def parse(tableStringInQuery: String): Option[LookupJoin] =
-      requestedIndicesFrom(tableStringInQuery).map(indices => LookupJoin(tableStringInQuery, indices.head.name))
+      ClusterIndexName.fromString(tableStringInQuery).collect { case ClusterIndexName.Local(index: IndexName.Full) =>
+        LookupJoin(tableStringInQuery, index)
+      }
+
   }
 
   final case class Replacement(table: EsqlIndexTable, newIndices: NonEmptyList[ClusterIndexName])
 
   def requestedIndicesOf(tables: NonEmptyList[EsqlIndexTable]): Set[RequestedIndex[ClusterIndexName]] =
     tables.toList.flatMap(_.requestedIndices.toList).toCovariantSet
-
-  private def requestedIndicesFrom(tableStringInQuery: String): Option[NonEmptyList[RequestedIndex[ClusterIndexName]]] =
-    NonEmptyList.fromList(
-      tableStringInQuery.split(',').asSafeList.filter(_.nonEmpty).flatMap(RequestedIndex.fromString)
-    )
 
   def newQueryFrom(
       oldQuery: String,
@@ -92,7 +92,9 @@ object EsqlIndexTable {
 
     // Excludes names a FROM table also asks for, so a shared literal isn't stripped from FROM's replacement.
     val lookupOnlyNames: Set[ClusterIndexName] =
-      lookupTables.map(_.index).toCovariantSet -- fromTables.flatMap(_.requestedIndices.includedOnly).toCovariantSet
+      lookupTables.map(_.clusterIndexName).toCovariantSet -- fromTables
+        .flatMap(_.requestedIndices.includedOnly)
+        .toCovariantSet
 
     val fromReplacements =
       buildFromReplacements(fromTables, allowedIndexNames, lookupOnlyNames, nonexistentIndexByOriginal)
@@ -100,22 +102,22 @@ object EsqlIndexTable {
     NonEmptyList.fromListUnsafe(fromReplacements ++ lookupReplacements)
   }
 
-  /**
-   * `None` whenever a table ES reported cannot be located in the query, or two located index lists overlap.
-   *
-   * The request has already been allowed on the strength of the narrowed index set, so a rewrite that cannot
-   * be performed is not one that can be skipped - forwarding the query untouched would run it against the
-   * user's original, unauthorized indices. Callers turn `None` into a forbidden response.
-   */
+  /** `None` when the rewrite cannot be applied. Callers must reject the request rather than skip it - the
+    * query was allowed only on the strength of the narrowed set, so unrewritten it runs against the
+    * user's original indices.
+    */
   def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): Option[String] = {
     replacements.toList
       .traverse(replacement => indexListSpanIn(oldQuery, replacement.table).map((_, replacement)))
       .flatMap(spliceIndexLists(oldQuery, _))
   }
 
-  // The returned map is threaded into `buildFromReplacements` so that a literal masked in both a FROM and
-  // a LOOKUP JOIN reads as the same nonexistent index in the rewritten query, the way it read as the same
-  // index in the original one.
+  private def requestedIndicesFrom(tableStringInQuery: String): Option[NonEmptyList[RequestedIndex[ClusterIndexName]]] =
+    NonEmptyList.fromList(
+      tableStringInQuery.split(',').asSafeList.filter(_.nonEmpty).flatMap(RequestedIndex.fromString)
+    )
+
+  // The returned map keeps a literal masked in both a FROM and a LOOKUP JOIN masking to the same index.
   private def buildLookupReplacements(
       tables: List[LookupJoin],
       allowedIndices: Set[ClusterIndexName]
@@ -123,8 +125,8 @@ object EsqlIndexTable {
     val (nonexistentIndexByOriginal, reversedReplacements) =
       tables.foldLeft((Map.empty[String, ClusterIndexName], List.empty[Replacement])) {
         case ((nonexistentIndexByOriginal, replacements), table) =>
-          if (allowedIndices.contains(table.index)) {
-            (nonexistentIndexByOriginal, Replacement(table, NonEmptyList.one(table.index)) :: replacements)
+          if (allowedIndices.contains(table.clusterIndexName)) {
+            (nonexistentIndexByOriginal, Replacement(table, NonEmptyList.one(table.clusterIndexName)) :: replacements)
           } else {
             val (updatedMap, nonexistentIndex) =
               nonexistentIndexFor(nonexistentIndexByOriginal, table.tableStringInQuery)
@@ -177,13 +179,10 @@ object EsqlIndexTable {
     Option.when(matcher.find())((matcher.start(1), matcher.end(1))).filterNot(_ => matcher.find())
   }
 
-  /**
-   * ES reports an index list normalized - entries joined with `,`, quoting stripped - so `FROM a, b` is
-   * reported as `a,b` and plain text search for it finds nothing. The pattern below matches every spelling
-   * that normalizes to what ES reported, and only where a command can start, so neither an identifier that
-   * merely shares an index's name (`FROM status | WHERE status == "ok"`) nor a keyword inside a string
-   * literal is mistaken for an index list.
-   */
+  /** ES reports the list normalized - entries joined with `,`, quoting stripped - so `FROM a, b` is reported
+    * as `a,b` and text search for it finds nothing. Matching every spelling that normalizes to it, anchored
+    * to the keyword, also keeps identifiers that merely share an index's name out of the rewrite.
+    */
   private def indexListPatternOf(table: EsqlIndexTable): Pattern = {
     val keywords = table match {
       case _: From       => "FROM|TS"

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -16,6 +16,7 @@
  */
 package tech.beshu.ror.es
 
+import cats.Show
 import cats.data.NonEmptyList
 import cats.implicits.*
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
@@ -40,6 +41,8 @@ sealed trait EsqlIndexTable {
 
 object EsqlIndexTable {
 
+  implicit val esqlIndexTableShow: Show[EsqlIndexTable] = Show.show(_.tableStringInQuery)
+
   final case class From(
       tableStringInQuery: String,
       requestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
@@ -52,8 +55,6 @@ object EsqlIndexTable {
       requestedIndicesFrom(tableStringInQuery).map(From(tableStringInQuery, _))
   }
 
-  // LOOKUP JOIN's target must be a single, specific index name or alias: no wildcards, no comma lists
-  // https://www.elastic.co/docs/reference/query-languages/esql/commands/lookup-join
   final case class LookupJoin(tableStringInQuery: String, index: IndexName.Full) extends EsqlIndexTable {
     val clusterIndexName: ClusterIndexName.Local = ClusterIndexName.Local(index)
 
@@ -89,29 +90,48 @@ object EsqlIndexTable {
   ): NonEmptyList[Replacement] = {
     val allowedIndexNames: Set[ClusterIndexName] = allowedIndices.includedOnly
 
-    val (lookupTables, fromTables) = tables.toList.partitionMap {
-      case table: LookupJoin => Left(table)
-      case table: From       => Right(table)
+    val lookupOnlyNames: Set[ClusterIndexName] =
+      tables.collect { case table: LookupJoin => table.clusterIndexName }.toCovariantSet --
+        tables.collect { case table: From => table }.flatMap(_.requestedIndices.includedOnly).toCovariantSet
+
+    def authorizedNamesFor(table: EsqlIndexTable): Option[NonEmptyList[ClusterIndexName]] = table match {
+      case table: LookupJoin =>
+        Option.when(allowedIndexNames.contains(table.clusterIndexName))(NonEmptyList.one(table.clusterIndexName))
+      case table: From =>
+        // the first term keeps aliases the ACL resolved to a name the table's pattern cannot match
+        NonEmptyList.fromList {
+          ((allowedIndexNames -- lookupOnlyNames) ++ table.matcher.filter(allowedIndexNames)).toList
+        }
     }
 
-    val (nonexistentIndexByOriginal, lookupReplacements) =
-      buildLookupReplacements(lookupTables, allowedIndexNames)
+    val nonexistentIndexFor: String => ClusterIndexName = {
+      val nonexistentIndexByOriginal =
+        tables.toList
+          .filter(authorizedNamesFor(_).isEmpty)
+          .map(_.tableStringInQuery)
+          .distinct
+          .map(originalTableText => (originalTableText, ClusterIndexName.Local.randomNonexistentIndex()))
+          .toMap
+      originalTableText =>
+        nonexistentIndexByOriginal.getOrElse(originalTableText, ClusterIndexName.Local.randomNonexistentIndex())
+    }
 
-    // Excludes names a FROM table also asks for, so a shared literal isn't stripped from FROM's replacement.
-    val lookupOnlyNames: Set[ClusterIndexName] =
-      lookupTables.map(_.clusterIndexName).toCovariantSet -- fromTables
-        .flatMap(_.requestedIndices.includedOnly)
-        .toCovariantSet
-
-    val fromReplacements =
-      buildFromReplacements(fromTables, allowedIndexNames, lookupOnlyNames, nonexistentIndexByOriginal)
-
-    NonEmptyList.fromListUnsafe(fromReplacements ++ lookupReplacements)
+    tables.map { table =>
+      val newIndices = authorizedNamesFor(table)
+        .getOrElse(NonEmptyList.one(nonexistentIndexFor(table.tableStringInQuery)))
+      Replacement(table, newIndices)
+    }
   }
 
   def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): EsqlQueryRewriteResult = {
     replacements.toList
-      .traverse(replacement => indexListSpanIn(oldQuery, replacement.table).map((_, replacement)))
+      .groupBy(_.table)
+      .toList
+      .traverse { case (table, tableReplacements) =>
+        val spans = indexListSpansIn(oldQuery, table)
+        Option.when(spans.size === tableReplacements.size)(spans.zip(tableReplacements))
+      }
+      .map(_.flatten)
       .flatMap(spliceIndexLists(oldQuery, _))
       .map(EsqlQueryRewriteResult.Rewritten.apply)
       .getOrElse(EsqlQueryRewriteResult.CannotRewriteQuery)
@@ -122,75 +142,21 @@ object EsqlIndexTable {
       tableStringInQuery.split(',').asSafeList.filter(_.nonEmpty).flatMap(RequestedIndex.fromString)
     )
 
-  // The returned map keeps a literal masked in both a FROM and a LOOKUP JOIN masking to the same index.
-  private def buildLookupReplacements(
-      tables: List[LookupJoin],
-      allowedIndices: Set[ClusterIndexName]
-  ): (Map[String, ClusterIndexName], List[Replacement]) = {
-    val (nonexistentIndexByOriginal, reversedReplacements) =
-      tables.foldLeft((Map.empty[String, ClusterIndexName], List.empty[Replacement])) {
-        case ((nonexistentIndexByOriginal, replacements), table) =>
-          if (allowedIndices.contains(table.clusterIndexName)) {
-            (nonexistentIndexByOriginal, Replacement(table, NonEmptyList.one(table.clusterIndexName)) :: replacements)
-          } else {
-            val (updatedMap, nonexistentIndex) =
-              nonexistentIndexFor(nonexistentIndexByOriginal, table.tableStringInQuery)
-            (updatedMap, Replacement(table, NonEmptyList.one(nonexistentIndex)) :: replacements)
-          }
-      }
-    (nonexistentIndexByOriginal, reversedReplacements.reverse)
-  }
-
-  // `allowedIndices -- lookupOnlyNames` recovers ACL-resolved alias names that don't textually match
-  // the query (e.g. "bookshop" resolved to "bookstore"); the PatternsMatcher term on top still attributes
-  // wildcard matches (e.g. book_* matching book_prices) that lookupOnlyNames alone would exclude.
-  private def buildFromReplacements(
-      tables: List[From],
-      allowedIndices: Set[ClusterIndexName],
-      lookupOnlyNames: Set[ClusterIndexName],
-      initialNonexistentIndexByOriginal: Map[String, ClusterIndexName]
-  ): List[Replacement] = {
-    val (_, reversedReplacements) =
-      tables.foldLeft((initialNonexistentIndexByOriginal, List.empty[Replacement])) {
-        case ((nonexistentIndexByOriginal, replacements), table) =>
-          val candidateNames = (allowedIndices -- lookupOnlyNames) ++ table.matcher.filter(allowedIndices)
-          NonEmptyList.fromList(candidateNames.toList) match {
-            case Some(newIndices) =>
-              (nonexistentIndexByOriginal, Replacement(table, newIndices) :: replacements)
-            case None =>
-              val (updatedMap, nonexistentIndex) =
-                nonexistentIndexFor(nonexistentIndexByOriginal, table.tableStringInQuery)
-              (updatedMap, Replacement(table, NonEmptyList.one(nonexistentIndex)) :: replacements)
-          }
-      }
-    reversedReplacements.reverse
-  }
-
-  private def nonexistentIndexFor(
-      nonexistentIndexByOriginal: Map[String, ClusterIndexName],
-      originalTableText: String
-  ): (Map[String, ClusterIndexName], ClusterIndexName) = {
-    nonexistentIndexByOriginal.get(originalTableText) match {
-      case Some(existing) => (nonexistentIndexByOriginal, existing)
-      case None           =>
-        val generated = ClusterIndexName.Local.randomNonexistentIndex()
-        (nonexistentIndexByOriginal.updated(originalTableText, generated), generated)
-    }
-  }
-
-  /** `None` unless the list can be located exactly once - an ambiguous query is rejected, not guessed at. */
-  private def indexListSpanIn(query: String, table: EsqlIndexTable): Option[(Int, Int)] = {
+  private def indexListSpansIn(query: String, table: EsqlIndexTable): List[(Int, Int)] = {
     val matcher = indexListPatternOf(table).matcher(query)
-    Option.when(matcher.find())((matcher.start(1), matcher.end(1))).filterNot(_ => matcher.find())
+    Iterator
+      .unfold(())(_ => Option.when(matcher.find())(((matcher.start(1), matcher.end(1)), ())))
+      .toList
   }
 
-  /** ES reports the list normalized - entries joined with `,`, quoting stripped - so `FROM a, b` is reported
-    * as `a,b` and text search for it finds nothing. Matching every spelling that normalizes to it, anchored
-    * to the keyword, also keeps identifiers that merely share an index's name out of the rewrite.
+  private val blank = "(?:\\s|//[^\\n]*|/\\*[\\s\\S]*?\\*/)"
+
+  /** ES reports the list normalized (`FROM a, b` as `a,b`), so instead of searching for it, match every
+    * spelling that normalizes to it.
     */
   private def indexListPatternOf(table: EsqlIndexTable): Pattern = {
     val keywords = table match {
-      case _: From       => "FROM|TS"
+      case _: From       => "FROM|TS|METRICS"
       case _: LookupJoin => "LOOKUP\\s+JOIN"
     }
     val optionalQuote = "(?:\"\"\"|\")?"
@@ -199,7 +165,7 @@ object EsqlIndexTable {
       .map(index => s"$optionalQuote${Pattern.quote(index)}$optionalQuote")
       .mkString("\\s*,\\s*")
     Pattern.compile(
-      s"(?:^|[|(])\\s*(?:$keywords)\\s+($indexList)(?![\\w.\\-*:])",
+      s"(?:^|[|(;])$blank*(?:$keywords)$blank+($indexList)(?![\\w.\\-*:])",
       Pattern.CASE_INSENSITIVE
     )
   }

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -18,7 +18,7 @@ package tech.beshu.ror.es
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.accesscontrol.matchers.PatternsMatcher
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
@@ -28,30 +28,59 @@ import java.util.regex.{Matcher, Pattern}
 
 sealed trait EsqlIndexTable {
   def tableStringInQuery: String
+  def requestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
 }
 
 object EsqlIndexTable {
 
   // FROM supports wildcards, comma-separated lists, and `cluster:index` remote references.
-  final case class From(tableStringInQuery: String, indices: NonEmptyList[IndexName]) extends EsqlIndexTable {
-    lazy val matcher: PatternsMatcher[IndexName] = PatternsMatcher.create(indices.toList)
+  final case class From(
+      tableStringInQuery: String,
+      requestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ) extends EsqlIndexTable {
+    lazy val matcher: PatternsMatcher[ClusterIndexName] = PatternsMatcher.create(requestedIndices.includedOnly)
+  }
+
+  object From {
+    def parse(tableStringInQuery: String): Option[From] =
+      requestedIndicesFrom(tableStringInQuery).map(From(tableStringInQuery, _))
   }
 
   // LOOKUP JOIN's target must be a single, specific index name or alias: no wildcards, no comma
   // lists, no remote cluster prefix (https://www.elastic.co/docs/reference/query-languages/esql/commands/lookup-join).
-  final case class LookupJoin(tableStringInQuery: String, index: IndexName) extends EsqlIndexTable
+  final case class LookupJoin(tableStringInQuery: String, index: ClusterIndexName) extends EsqlIndexTable {
+    override def requestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]] =
+      NonEmptyList.one(RequestedIndex(index, excluded = false))
+  }
 
-  final case class Replacement(table: EsqlIndexTable, newIndices: NonEmptyList[IndexName])
+  object LookupJoin {
+    def parse(tableStringInQuery: String): Option[LookupJoin] =
+      requestedIndicesFrom(tableStringInQuery).map(indices => LookupJoin(tableStringInQuery, indices.head.name))
+  }
+
+  final case class Replacement(table: EsqlIndexTable, newIndices: NonEmptyList[ClusterIndexName])
+
+  def requestedIndicesOf(tables: NonEmptyList[EsqlIndexTable]): Set[RequestedIndex[ClusterIndexName]] =
+    tables.toList.flatMap(_.requestedIndices.toList).toCovariantSet
+
+  private def requestedIndicesFrom(tableStringInQuery: String): Option[NonEmptyList[RequestedIndex[ClusterIndexName]]] =
+    NonEmptyList.fromList(
+      tableStringInQuery.split(',').asSafeList.filter(_.nonEmpty).flatMap(RequestedIndex.fromString)
+    )
+
+  def newQueryFrom(
+      oldQuery: String,
+      tables: NonEmptyList[EsqlIndexTable],
+      allowedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ): String = {
+    newQueryFrom(oldQuery, buildReplacements(tables, allowedIndices))
+  }
 
   def buildReplacements(
       tables: NonEmptyList[EsqlIndexTable],
       allowedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): NonEmptyList[Replacement] = {
-    // Rendering through `.stringify` (rather than pattern-matching out the `IndexName`) keeps a remote
-    // index's `cluster:` qualifier, matching how the query text itself encodes it (there's no dedicated
-    // "cluster + index" parse target here, so `From.indices` also carries it as opaque IndexName text).
-    val allowedIndexNames: Set[IndexName] =
-      allowedIndices.includedOnly.flatMap(name => IndexName.fromString(name.stringify))
+    val allowedIndexNames: Set[ClusterIndexName] = allowedIndices.includedOnly
 
     val (lookupTables, fromTables) = tables.toList.partitionMap {
       case table: LookupJoin => Left(table)
@@ -62,8 +91,8 @@ object EsqlIndexTable {
       buildLookupReplacements(lookupTables, allowedIndexNames)
 
     // Excludes names a FROM table also asks for, so a shared literal isn't stripped from FROM's replacement.
-    val lookupOnlyNames: Set[IndexName] =
-      lookupTables.map(_.index).toCovariantSet -- fromTables.flatMap(_.indices.toList).toCovariantSet
+    val lookupOnlyNames: Set[ClusterIndexName] =
+      lookupTables.map(_.index).toCovariantSet -- fromTables.flatMap(_.requestedIndices.includedOnly).toCovariantSet
 
     val fromReplacements =
       buildFromReplacements(fromTables, allowedIndexNames, lookupOnlyNames, nonexistentIndexByOriginal)
@@ -88,10 +117,10 @@ object EsqlIndexTable {
   // resolve to the same nonexistent name.
   private def buildLookupReplacements(
       tables: List[LookupJoin],
-      allowedIndices: Set[IndexName]
-  ): (Map[String, IndexName], List[Replacement]) = {
+      allowedIndices: Set[ClusterIndexName]
+  ): (Map[String, ClusterIndexName], List[Replacement]) = {
     val (nonexistentIndexByOriginal, reversedReplacements) =
-      tables.foldLeft((Map.empty[String, IndexName], List.empty[Replacement])) {
+      tables.foldLeft((Map.empty[String, ClusterIndexName], List.empty[Replacement])) {
         case ((nonexistentIndexByOriginal, replacements), table) =>
           if (allowedIndices.contains(table.index)) {
             (nonexistentIndexByOriginal, Replacement(table, NonEmptyList.one(table.index)) :: replacements)
@@ -109,9 +138,9 @@ object EsqlIndexTable {
   // wildcard matches (e.g. book_* matching book_prices) that lookupOnlyNames alone would exclude.
   private def buildFromReplacements(
       tables: List[From],
-      allowedIndices: Set[IndexName],
-      lookupOnlyNames: Set[IndexName],
-      initialNonexistentIndexByOriginal: Map[String, IndexName]
+      allowedIndices: Set[ClusterIndexName],
+      lookupOnlyNames: Set[ClusterIndexName],
+      initialNonexistentIndexByOriginal: Map[String, ClusterIndexName]
   ): List[Replacement] = {
     val (_, reversedReplacements) =
       tables.foldLeft((initialNonexistentIndexByOriginal, List.empty[Replacement])) {
@@ -130,13 +159,13 @@ object EsqlIndexTable {
   }
 
   private def nonexistentIndexFor(
-      nonexistentIndexByOriginal: Map[String, IndexName],
+      nonexistentIndexByOriginal: Map[String, ClusterIndexName],
       originalTableText: String
-  ): (Map[String, IndexName], IndexName) = {
+  ): (Map[String, ClusterIndexName], ClusterIndexName) = {
     nonexistentIndexByOriginal.get(originalTableText) match {
       case Some(existing) => (nonexistentIndexByOriginal, existing)
       case None           =>
-        val generated = ClusterIndexName.Local.randomNonexistentIndex().value
+        val generated = ClusterIndexName.Local.randomNonexistentIndex()
         (nonexistentIndexByOriginal.updated(originalTableText, generated), generated)
     }
   }
@@ -146,7 +175,7 @@ object EsqlIndexTable {
   private def replaceTableNameInQueryPart(
       currentQuery: String,
       originTable: String,
-      newIndices: NonEmptyList[IndexName]
+      newIndices: NonEmptyList[ClusterIndexName]
   ): String = {
     val nonIdentifierChar = "[^\\w.\\-*:]"
     val pattern = s"(^|$nonIdentifierChar)${Pattern.quote(originTable)}(?=$nonIdentifierChar|$$)"

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -89,36 +89,41 @@ object EsqlIndexTable {
       allowedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): NonEmptyList[Replacement] = {
     val allowedIndexNames: Set[ClusterIndexName] = allowedIndices.includedOnly
+    val fromTables = tables.collect { case table: From => table }
 
     val lookupOnlyNames: Set[ClusterIndexName] =
       tables.collect { case table: LookupJoin => table.clusterIndexName }.toCovariantSet --
-        tables.collect { case table: From => table }.flatMap(_.requestedIndices.includedOnly).toCovariantSet
+        fromTables.flatMap(_.requestedIndices.includedOnly).toCovariantSet
+
+    val matchedNamesByFromTable: Map[From, Set[ClusterIndexName]] =
+      fromTables.map(table => (table, table.matcher.filter(allowedIndexNames))).toMap
+
+    /* Names the ACL resolved to something no FROM pattern can match - an alias replaced by the index behind it.
+     * They belong to a FROM table, but nothing left in the request says which one, so every FROM table keeps them. */
+    val unattributedNames: Set[ClusterIndexName] =
+      allowedIndexNames -- lookupOnlyNames -- matchedNamesByFromTable.values.flatten.toCovariantSet
 
     def authorizedNamesFor(table: EsqlIndexTable): Option[NonEmptyList[ClusterIndexName]] = table match {
       case table: LookupJoin =>
         Option.when(allowedIndexNames.contains(table.clusterIndexName))(NonEmptyList.one(table.clusterIndexName))
       case table: From =>
-        // the first term keeps aliases the ACL resolved to a name the table's pattern cannot match
-        NonEmptyList.fromList {
-          ((allowedIndexNames -- lookupOnlyNames) ++ table.matcher.filter(allowedIndexNames)).toList
-        }
+        NonEmptyList.fromList((matchedNamesByFromTable(table) ++ unattributedNames).toList)
     }
 
-    val nonexistentIndexFor: String => ClusterIndexName = {
-      val nonexistentIndexByOriginal =
-        tables.toList
-          .filter(authorizedNamesFor(_).isEmpty)
-          .map(_.tableStringInQuery)
-          .distinct
-          .map(originalTableText => (originalTableText, ClusterIndexName.Local.randomNonexistentIndex()))
-          .toMap
-      originalTableText =>
-        nonexistentIndexByOriginal.getOrElse(originalTableText, ClusterIndexName.Local.randomNonexistentIndex())
-    }
+    val authorizedNamesByTable: Map[EsqlIndexTable, Option[NonEmptyList[ClusterIndexName]]] =
+      tables.toList.map(table => (table, authorizedNamesFor(table))).toMap
+
+    val nonexistentIndexByTableText: Map[String, ClusterIndexName] =
+      authorizedNamesByTable
+        .collect { case (table, None) => table.tableStringInQuery }
+        .toList
+        .distinct
+        .map(tableText => (tableText, ClusterIndexName.Local.randomNonexistentIndex()))
+        .toMap
 
     tables.map { table =>
-      val newIndices = authorizedNamesFor(table)
-        .getOrElse(NonEmptyList.one(nonexistentIndexFor(table.tableStringInQuery)))
+      val newIndices = authorizedNamesByTable(table)
+        .getOrElse(NonEmptyList.one(nonexistentIndexByTableText(table.tableStringInQuery)))
       Replacement(table, newIndices)
     }
   }

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -124,11 +124,12 @@ object EsqlIndexTable {
   }
 
   def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): EsqlQueryRewriteResult = {
+    val scan = QueryScan.of(oldQuery)
     replacements.toList
       .groupBy(_.table)
       .toList
       .traverse { case (table, tableReplacements) =>
-        val spans = indexListSpansIn(oldQuery, table)
+        val spans = indexListSpansIn(scan, table)
         Option.when(spans.size === tableReplacements.size)(spans.zip(tableReplacements))
       }
       .map(_.flatten)
@@ -142,17 +143,20 @@ object EsqlIndexTable {
       tableStringInQuery.split(',').asSafeList.filter(_.nonEmpty).flatMap(RequestedIndex.fromString)
     )
 
-  private def indexListSpansIn(query: String, table: EsqlIndexTable): List[(Int, Int)] = {
-    val matcher = indexListPatternOf(table).matcher(query)
+  private def indexListSpansIn(scan: QueryScan, table: EsqlIndexTable): List[(Int, Int)] = {
+    val matcher = indexListPatternOf(table).matcher(scan.text)
     Iterator
-      .unfold(())(_ => Option.when(matcher.find())(((matcher.start(1), matcher.end(1)), ())))
+      .unfold(())(_ => Option.when(matcher.find())(((matcher.start(), matcher.start(1), matcher.end(1)), ())))
+      .collect {
+        case (sourceCommandStart, listStart, listEnd) if !scan.spansLiteral(sourceCommandStart, listStart) =>
+          (listStart, listEnd)
+      }
       .toList
   }
 
-  private val blank = "(?:\\s|//[^\\n]*|/\\*[\\s\\S]*?\\*/)"
-
   /** ES reports the list normalized (`FROM a, b` as `a,b`), so instead of searching for it, match every
-    * spelling that normalizes to it.
+    * spelling that normalizes to it. Comments are already blanked out by [[QueryScan]], hence plain `\s`
+    * suffices here for everything the lexer treats as whitespace.
     */
   private def indexListPatternOf(table: EsqlIndexTable): Pattern = {
     val keywords = table match {
@@ -165,9 +169,117 @@ object EsqlIndexTable {
       .map(index => s"$optionalQuote${Pattern.quote(index)}$optionalQuote")
       .mkString("\\s*,\\s*")
     Pattern.compile(
-      s"(?:^|[|(;])$blank*(?:$keywords)$blank+($indexList)(?![\\w.\\-*:])",
+      s"(?:^|[|(;])\\s*(?:$keywords)\\s+($indexList)(?![\\w.\\-*:])",
       Pattern.CASE_INSENSITIVE
     )
+  }
+
+  /** The query text prepared for pattern matching: comments blanked out (the ESQL lexer sends them to a
+    * hidden channel, so `FROM a, /*c*/ b` is reported as `a,b`), and every string literal and backquoted
+    * identifier marked, so that a source command a user spelled out inside one cannot be mistaken for the
+    * real one and rewritten in its place. Blanking preserves offsets, so spans found here index [[text]]
+    * and the original query alike.
+    */
+  private final class QueryScan(val text: String, literal: Array[Boolean]) {
+    def spansLiteral(from: Int, until: Int): Boolean = (from until until).exists(literal(_))
+  }
+
+  private object QueryScan {
+
+    def of(query: String): QueryScan = {
+      val text = query.toCharArray
+      val literal = new Array[Boolean](query.length)
+      var index = 0
+      while (index < query.length) {
+        index = endOfCommentAt(query, index) match {
+          case Some(end) =>
+            java.util.Arrays.fill(text, index, end, ' ')
+            end
+          case None =>
+            endOfLiteralAt(query, index) match {
+              case Some(end) =>
+                java.util.Arrays.fill(literal, index, end, true)
+                end
+              case None =>
+                index + 1
+            }
+        }
+      }
+      new QueryScan(new String(text), literal)
+    }
+
+    private def endOfCommentAt(query: String, at: Int): Option[Int] = {
+      if (query.startsWith("//", at)) Some(endOfLine(query, at))
+      else if (query.startsWith("/*", at)) Some(endOfBlockComment(query, at))
+      else None
+    }
+
+    private def endOfLine(query: String, at: Int): Int = {
+      query.indexOf('\n', at) match {
+        case -1  => query.length
+        case end => end
+      }
+    }
+
+    private def endOfBlockComment(query: String, at: Int): Int = {
+      var index = at + 2
+      var depth = 1
+      while (index < query.length && depth > 0) {
+        if (query.startsWith("*/", index)) { depth -= 1; index += 2 }
+        else if (query.startsWith("/*", index)) { depth += 1; index += 2 }
+        else index += 1
+      }
+      index
+    }
+
+    private def endOfLiteralAt(query: String, at: Int): Option[Int] = {
+      query.charAt(at) match {
+        case '"' if query.startsWith("\"\"\"", at) => Some(endOfTripleQuoted(query, at))
+        case '"'                                   => Some(endOfQuoted(query, at))
+        case '`'                                   => Some(endOfBackquoted(query, at))
+        case _                                     => None
+      }
+    }
+
+    private def endOfTripleQuoted(query: String, at: Int): Int = {
+      query.indexOf("\"\"\"", at + 3) match {
+        case -1      => query.length
+        case closing =>
+          var end = closing + 3
+          var trailingQuotes = 0
+          while (trailingQuotes < 2 && end < query.length && query.charAt(end) == '"') {
+            end += 1
+            trailingQuotes += 1
+          }
+          end
+      }
+    }
+
+    private def endOfQuoted(query: String, at: Int): Int = {
+      var index = at + 1
+      var closed = false
+      while (!closed && index < query.length) {
+        query.charAt(index) match {
+          case '\\'        => index += 2
+          case '"'         => index += 1; closed = true
+          case '\n' | '\r' => closed = true
+          case _           => index += 1
+        }
+      }
+      math.min(index, query.length)
+    }
+
+    private def endOfBackquoted(query: String, at: Int): Int = {
+      var index = at + 1
+      var closed = false
+      while (!closed && index < query.length) {
+        if (query.charAt(index) != '`') index += 1
+        else if (query.startsWith("``", index)) index += 2
+        else { index += 1; closed = true }
+      }
+      math.min(index, query.length)
+    }
+
   }
 
   private def spliceIndexLists(query: String, spans: List[((Int, Int), Replacement)]): Option[String] = {

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -1,0 +1,157 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+package tech.beshu.ror.es
+
+import cats.data.NonEmptyList
+import cats.implicits.*
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.matchers.PatternsMatcher
+import tech.beshu.ror.implicits.*
+import tech.beshu.ror.syntax.*
+import tech.beshu.ror.utils.ScalaOps.*
+
+import java.util.regex.{Matcher, Pattern}
+
+sealed trait EsqlIndexTable {
+  def tableStringInQuery: String
+}
+
+object EsqlIndexTable {
+
+  // FROM supports wildcards, comma-separated lists, and `cluster:index` remote references.
+  final case class From(tableStringInQuery: String, indices: NonEmptyList[IndexName]) extends EsqlIndexTable {
+    lazy val matcher: PatternsMatcher[IndexName] = PatternsMatcher.create(indices.toList)
+  }
+
+  // LOOKUP JOIN's target must be a single, specific index name or alias: no wildcards, no comma
+  // lists, no remote cluster prefix (https://www.elastic.co/docs/reference/query-languages/esql/commands/lookup-join).
+  final case class LookupJoin(tableStringInQuery: String, index: IndexName) extends EsqlIndexTable
+
+  final case class Replacement(table: EsqlIndexTable, newIndices: NonEmptyList[IndexName])
+
+  def buildReplacements(
+      tables: NonEmptyList[EsqlIndexTable],
+      allowedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ): NonEmptyList[Replacement] = {
+    // Rendering through `.stringify` (rather than pattern-matching out the `IndexName`) keeps a remote
+    // index's `cluster:` qualifier, matching how the query text itself encodes it (there's no dedicated
+    // "cluster + index" parse target here, so `From.indices` also carries it as opaque IndexName text).
+    val allowedIndexNames: Set[IndexName] =
+      allowedIndices.includedOnly.flatMap(name => IndexName.fromString(name.stringify))
+
+    val (lookupTables, fromTables) = tables.toList.partitionMap {
+      case table: LookupJoin => Left(table)
+      case table: From       => Right(table)
+    }
+
+    val (nonexistentIndexByOriginal, lookupReplacements) =
+      buildLookupReplacements(lookupTables, allowedIndexNames)
+
+    // Excludes names a FROM table also asks for, so a shared literal isn't stripped from FROM's replacement.
+    val lookupOnlyNames: Set[IndexName] =
+      lookupTables.map(_.index).toCovariantSet -- fromTables.flatMap(_.indices.toList).toCovariantSet
+
+    val fromReplacements =
+      buildFromReplacements(fromTables, allowedIndexNames, lookupOnlyNames, nonexistentIndexByOriginal)
+
+    NonEmptyList.fromListUnsafe(fromReplacements ++ lookupReplacements)
+  }
+
+  def newQueryFrom(oldQuery: String, replacements: NonEmptyList[Replacement]): String = {
+    replacements.toList.foldLeft(oldQuery) { case (currentQuery, replacement) =>
+      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
+      afterFrom match {
+        case None =>
+          replaceTableNameInQueryPart(currentQuery, replacement.table.tableStringInQuery, replacement.newIndices)
+        case Some(tablesPart) =>
+          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, replacement.table.tableStringInQuery, replacement.newIndices)}"
+      }
+    }
+  }
+
+  // The returned map is threaded into `buildFromReplacements`: if the same literal text is masked in
+  // both a FROM and a LOOKUP JOIN, `newQueryFrom`'s single per-table substitution needs both to
+  // resolve to the same nonexistent name.
+  private def buildLookupReplacements(
+      tables: List[LookupJoin],
+      allowedIndices: Set[IndexName]
+  ): (Map[String, IndexName], List[Replacement]) = {
+    val (nonexistentIndexByOriginal, reversedReplacements) =
+      tables.foldLeft((Map.empty[String, IndexName], List.empty[Replacement])) {
+        case ((nonexistentIndexByOriginal, replacements), table) =>
+          if (allowedIndices.contains(table.index)) {
+            (nonexistentIndexByOriginal, Replacement(table, NonEmptyList.one(table.index)) :: replacements)
+          } else {
+            val (updatedMap, nonexistentIndex) =
+              nonexistentIndexFor(nonexistentIndexByOriginal, table.tableStringInQuery)
+            (updatedMap, Replacement(table, NonEmptyList.one(nonexistentIndex)) :: replacements)
+          }
+      }
+    (nonexistentIndexByOriginal, reversedReplacements.reverse)
+  }
+
+  // `allowedIndices -- lookupOnlyNames` recovers ACL-resolved alias names that don't textually match
+  // the query (e.g. "bookshop" resolved to "bookstore"); the PatternsMatcher term on top still attributes
+  // wildcard matches (e.g. book_* matching book_prices) that lookupOnlyNames alone would exclude.
+  private def buildFromReplacements(
+      tables: List[From],
+      allowedIndices: Set[IndexName],
+      lookupOnlyNames: Set[IndexName],
+      initialNonexistentIndexByOriginal: Map[String, IndexName]
+  ): List[Replacement] = {
+    val (_, reversedReplacements) =
+      tables.foldLeft((initialNonexistentIndexByOriginal, List.empty[Replacement])) {
+        case ((nonexistentIndexByOriginal, replacements), table) =>
+          val candidateNames = (allowedIndices -- lookupOnlyNames) ++ table.matcher.filter(allowedIndices)
+          NonEmptyList.fromList(candidateNames.toList) match {
+            case Some(newIndices) =>
+              (nonexistentIndexByOriginal, Replacement(table, newIndices) :: replacements)
+            case None =>
+              val (updatedMap, nonexistentIndex) =
+                nonexistentIndexFor(nonexistentIndexByOriginal, table.tableStringInQuery)
+              (updatedMap, Replacement(table, NonEmptyList.one(nonexistentIndex)) :: replacements)
+          }
+      }
+    reversedReplacements.reverse
+  }
+
+  private def nonexistentIndexFor(
+      nonexistentIndexByOriginal: Map[String, IndexName],
+      originalTableText: String
+  ): (Map[String, IndexName], IndexName) = {
+    nonexistentIndexByOriginal.get(originalTableText) match {
+      case Some(existing) => (nonexistentIndexByOriginal, existing)
+      case None           =>
+        val generated = ClusterIndexName.Local.randomNonexistentIndex().value
+        (nonexistentIndexByOriginal.updated(originalTableText, generated), generated)
+    }
+  }
+
+  // Anchored to non-identifier boundaries so `originTable` doesn't match as a substring of a longer
+  // identifier (e.g. "book" inside "book_prices").
+  private def replaceTableNameInQueryPart(
+      currentQuery: String,
+      originTable: String,
+      newIndices: NonEmptyList[IndexName]
+  ): String = {
+    val nonIdentifierChar = "[^\\w.\\-*:]"
+    val pattern = s"(^|$nonIdentifierChar)${Pattern.quote(originTable)}(?=$nonIdentifierChar|$$)"
+    val replacement = "$1" + Matcher.quoteReplacement(newIndices.toList.map(_.show).mkString(","))
+    currentQuery.replaceAll(pattern, replacement)
+  }
+
+}

--- a/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
+++ b/core/src/main/scala/tech/beshu/ror/es/EsqlIndexTable.scala
@@ -98,8 +98,8 @@ object EsqlIndexTable {
     val matchedNamesByFromTable: Map[From, Set[ClusterIndexName]] =
       fromTables.map(table => (table, table.matcher.filter(allowedIndexNames))).toMap
 
-    /* Names the ACL resolved to something no FROM pattern can match - an alias replaced by the index behind it.
-     * They belong to a FROM table, but nothing left in the request says which one, so every FROM table keeps them. */
+    // an alias the ACL replaced with its backing index matches no FROM pattern, and nothing left in the
+    // request says which table it came from
     val unattributedNames: Set[ClusterIndexName] =
       allowedIndexNames -- lookupOnlyNames -- matchedNamesByFromTable.values.flatten.toCovariantSet
 
@@ -160,8 +160,7 @@ object EsqlIndexTable {
   }
 
   /** ES reports the list normalized (`FROM a, b` as `a,b`), so instead of searching for it, match every
-    * spelling that normalizes to it. Comments are already blanked out by [[QueryScan]], hence plain `\s`
-    * suffices here for everything the lexer treats as whitespace.
+    * spelling that normalizes to it.
     */
   private def indexListPatternOf(table: EsqlIndexTable): Pattern = {
     val keywords = table match {
@@ -179,11 +178,9 @@ object EsqlIndexTable {
     )
   }
 
-  /** The query text prepared for pattern matching: comments blanked out (the ESQL lexer sends them to a
-    * hidden channel, so `FROM a, /*c*/ b` is reported as `a,b`), and every string literal and backquoted
-    * identifier marked, so that a source command a user spelled out inside one cannot be mistaken for the
-    * real one and rewritten in its place. Blanking preserves offsets, so spans found here index [[text]]
-    * and the original query alike.
+  /** Blanks out comments (ESQL hides them, so `FROM a, /*c*/ b` is reported as `a,b`) and marks string
+    * literals and backquoted identifiers, so a source command spelled out inside one cannot be rewritten in
+    * place of the real one. Blanking keeps offsets, so spans found in [[text]] index the original query too.
     */
   private final class QueryScan(val text: String, literal: Array[Boolean]) {
     def spansLiteral(from: Int, until: Int): Boolean = (from until until).exists(literal(_))

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -20,7 +20,7 @@ import cats.data.NonEmptyList
 import cats.implicits.*
 import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.wordspec.AnyWordSpec
-import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
@@ -188,15 +188,17 @@ class EsqlIndexTableTest extends AnyWordSpec {
   }
 
   private def newFromTable(tableStringInQuery: String): EsqlIndexTable.From = {
-    EsqlIndexTable.From(tableStringInQuery, NonEmptyList.one(indexNameFrom(tableStringInQuery)))
+    EsqlIndexTable.From.parse(tableStringInQuery).getOrElse(fail(s"not a valid FROM table: $tableStringInQuery"))
   }
 
   private def lookupJoinTable(tableStringInQuery: String): EsqlIndexTable.LookupJoin = {
-    EsqlIndexTable.LookupJoin(tableStringInQuery, indexNameFrom(tableStringInQuery))
+    EsqlIndexTable.LookupJoin
+      .parse(tableStringInQuery)
+      .getOrElse(fail(s"not a valid LOOKUP JOIN table: $tableStringInQuery"))
   }
 
-  private def indexNameFrom(value: String): IndexName =
-    IndexName.fromString(value).getOrElse(fail(s"not a valid index name: $value"))
+  private def indexNameFrom(value: String): ClusterIndexName =
+    ClusterIndexName.fromString(value).getOrElse(fail(s"not a valid index name: $value"))
 
   private def authorizedIndicesOf(names: String*): NonEmptyList[RequestedIndex[ClusterIndexName]] = {
     NonEmptyList.fromListUnsafe(names.toList.flatMap(RequestedIndex.fromString))

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -59,17 +59,16 @@ class EsqlIndexTableTest extends AnyWordSpec {
         Rewritten("FROM src | LOOKUP JOIN ROR_nonexistent0001 ON key")
     }
 
-    "rewrite a wildcard-narrowed FROM and a masked LOOKUP JOIN independently, without cross-contaminating" +
-      " each other's replacement text" in {
-        val query = "FROM book* | LOOKUP JOIN book_prices ON isbn"
-        val replacements = NonEmptyList.of(
-          replacementFor(newFromTable("book*"), "bookstore1", "bookstore2"),
-          replacementFor(lookupJoinTable("book_prices"), "ROR_nonexistent0002")
-        )
+    "rewrite a wildcard-narrowed FROM and a masked LOOKUP JOIN without cross-contamination" in {
+      val query = "FROM book* | LOOKUP JOIN book_prices ON isbn"
+      val replacements = NonEmptyList.of(
+        replacementFor(newFromTable("book*"), "bookstore1", "bookstore2"),
+        replacementFor(lookupJoinTable("book_prices"), "ROR_nonexistent0002")
+      )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
-          Rewritten("FROM bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn")
-      }
+      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+        Rewritten("FROM bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn")
+    }
 
     "narrow a comma-separated FROM list, whatever way the user spelled it" when {
       "the entries are separated by a space" in {
@@ -286,13 +285,13 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(lookupJoinTable("prices"), "ROR_nonexistent0004")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe a[CannotRewriteQuery]
       }
       "a FROM table is only spelled as a LOOKUP JOIN target in the query" in {
         val query = "FROM src | LOOKUP JOIN prices ON key"
         val replacements = NonEmptyList.one(replacementFor(newFromTable("prices"), "other"))
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe a[CannotRewriteQuery]
       }
       "the same index list can be located in more than one place" in {
         val query = "FROM logs | LOOKUP JOIN prices ON key | FORK (WHERE a) (FROM logs)"
@@ -301,7 +300,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(lookupJoinTable("prices"), "prices")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe a[CannotRewriteQuery]
       }
       "the query spells the list in a way that doesn't normalize to what ES reported" in {
         val query = "FROM book_catalog | LIMIT 100"
@@ -309,13 +308,13 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe a[CannotRewriteQuery]
       }
       "an unterminated string literal swallows the only index list ES reported" in {
         val query = """FROM logs | WHERE msg == "oops | LIMIT 10"""
         val replacements = NonEmptyList.one(replacementFor(newFromTable("oops"), "other"))
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe a[CannotRewriteQuery]
       }
     }
   }
@@ -360,51 +359,48 @@ class EsqlIndexTableTest extends AnyWordSpec {
       newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("lookup_idx")
     }
 
-    "not strip a literal index name from FROM's replacement just because the same name is also " +
-      "requested by LOOKUP JOIN" in {
-        val fromTable = newFromTable("shared_idx")
-        val lookupTable = lookupJoinTable("shared_idx")
+    "keep a literal index name in FROM's replacement when LOOKUP JOIN requests it too" in {
+      val fromTable = newFromTable("shared_idx")
+      val lookupTable = lookupJoinTable("shared_idx")
 
-        val replacements = EsqlIndexTable.buildReplacements(
-          NonEmptyList.of(fromTable, lookupTable),
-          allowedIndices = authorizedIndicesOf("shared_idx")
-        )
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(fromTable, lookupTable),
+        allowedIndices = authorizedIndicesOf("shared_idx")
+      )
 
-        newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("shared_idx")
-        newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("shared_idx")
-      }
+      newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("shared_idx")
+      newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("shared_idx")
+    }
 
-    "resolve a literal name shared by a forbidden FROM and a forbidden LOOKUP JOIN to the same " +
-      "nonexistent index" in {
-        val fromTable = newFromTable("shared_idx")
-        val lookupTable = lookupJoinTable("shared_idx")
-        val decoyLookupTable = lookupJoinTable("decoy_lookup_only")
+    "mask a name shared by a forbidden FROM and a forbidden LOOKUP JOIN to the same nonexistent index" in {
+      val fromTable = newFromTable("shared_idx")
+      val lookupTable = lookupJoinTable("shared_idx")
+      val decoyLookupTable = lookupJoinTable("decoy_lookup_only")
 
-        val replacements = EsqlIndexTable.buildReplacements(
-          NonEmptyList.of(fromTable, lookupTable, decoyLookupTable),
-          allowedIndices = authorizedIndicesOf("decoy_lookup_only")
-        )
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(fromTable, lookupTable, decoyLookupTable),
+        allowedIndices = authorizedIndicesOf("decoy_lookup_only")
+      )
 
-        val fromMasked = newIndicesOf(replacements, fromTable)
-        val lookupMasked = newIndicesOf(replacements, lookupTable)
-        assertMasked(fromMasked)
-        assertMasked(lookupMasked)
-        fromMasked shouldBe lookupMasked
-      }
+      val fromMasked = newIndicesOf(replacements, fromTable)
+      val lookupMasked = newIndicesOf(replacements, lookupTable)
+      assertMasked(fromMasked)
+      assertMasked(lookupMasked)
+      fromMasked shouldBe lookupMasked
+    }
 
-    "include a LOOKUP JOIN target's name in a wildcard FROM's narrowed list when the wildcard genuinely " +
-      "matches it too" in {
-        val fromTable = newFromTable("book*")
-        val lookupTable = lookupJoinTable("book_prices")
+    "include a LOOKUP JOIN target in a wildcard FROM's narrowed list when the wildcard matches it" in {
+      val fromTable = newFromTable("book*")
+      val lookupTable = lookupJoinTable("book_prices")
 
-        val replacements = EsqlIndexTable.buildReplacements(
-          NonEmptyList.of(fromTable, lookupTable),
-          allowedIndices = authorizedIndicesOf("bookstore1", "bookstore2", "book_prices")
-        )
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(fromTable, lookupTable),
+        allowedIndices = authorizedIndicesOf("bookstore1", "bookstore2", "book_prices")
+      )
 
-        newIndicesOf(replacements, fromTable).toList.sorted shouldBe List("book_prices", "bookstore1", "bookstore2")
-        newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("book_prices")
-      }
+      newIndicesOf(replacements, fromTable).toList.sorted shouldBe List("book_prices", "bookstore1", "bookstore2")
+      newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("book_prices")
+    }
 
     "exclude a LOOKUP JOIN target from a wildcard FROM's narrowed list when the wildcard doesn't match it" in {
       val fromTable = newFromTable("bookstore*")
@@ -445,17 +441,16 @@ class EsqlIndexTableTest extends AnyWordSpec {
       assertMasked(newIndicesOf(replacements, secretTable))
     }
 
-    "resolve a literal FROM alias whose ACL-narrowed concrete index name doesn't textually match the " +
-      "query's own alias text (e.g. the ACL resolved \"bookshop\" to its underlying \"bookstore\")" in {
-        val fromTable = newFromTable("bookshop")
+    "resolve a literal FROM alias to the concrete index name the ACL narrowed it to" in {
+      val fromTable = newFromTable("bookshop")
 
-        val replacements = EsqlIndexTable.buildReplacements(
-          NonEmptyList.one(fromTable),
-          allowedIndices = authorizedIndicesOf("bookstore")
-        )
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.one(fromTable),
+        allowedIndices = authorizedIndicesOf("bookstore")
+      )
 
-        newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("bookstore")
-      }
+      newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("bookstore")
+    }
   }
 
   "EsqlIndexTable.LookupJoin.parse" should {

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -71,7 +71,6 @@ class EsqlIndexTableTest extends AnyWordSpec {
           Rewritten("FROM bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn")
       }
 
-    // ES reports this list as `book_catalog,book_prices`, which no spelling below contains verbatim.
     "narrow a comma-separated FROM list, whatever way the user spelled it" when {
       "the entries are separated by a space" in {
         val query = "FROM book_catalog, book_prices | LIMIT 100"
@@ -162,6 +161,51 @@ class EsqlIndexTableTest extends AnyWordSpec {
       }
     }
 
+    "locate the index list past a prelude or a comment" when {
+      "the query opens with a SET prelude" in {
+        val query = """SET locale = "en"; FROM book_* | LIMIT 10"""
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("book_*"), "book_catalog"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("""SET locale = "en"; FROM book_catalog | LIMIT 10""")
+      }
+      "a line comment precedes the source command" in {
+        val query = "// pick books\nFROM book_* | LIMIT 10"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("book_*"), "book_catalog"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("// pick books\nFROM book_catalog | LIMIT 10")
+      }
+      "a block comment precedes the source command" in {
+        val query = "/* pick books */ FROM book_* | LIMIT 10"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("book_*"), "book_catalog"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("/* pick books */ FROM book_catalog | LIMIT 10")
+      }
+      "the source command is METRICS" in {
+        val query = "METRICS metrics_idx | LIMIT 10"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("metrics_idx"), "metrics_1"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("METRICS metrics_1 | LIMIT 10")
+      }
+    }
+
+    "rewrite every spelling of a table the query repeats" when {
+      "the same lookup index is joined twice" in {
+        val query = "FROM src | LOOKUP JOIN prices ON a | LOOKUP JOIN prices ON b"
+        val lookupTable = lookupJoinTable("prices")
+        val replacements = NonEmptyList.of(
+          replacementFor(newFromTable("src"), "src"),
+          replacementFor(lookupTable, "ROR_nonexistent0005"),
+          replacementFor(lookupTable, "ROR_nonexistent0005")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("FROM src | LOOKUP JOIN ROR_nonexistent0005 ON a | LOOKUP JOIN ROR_nonexistent0005 ON b")
+      }
+    }
+
     "fail closed" when {
       "a table ES reported has no index list in the query" in {
         val query = "FROM logs | LIMIT 10"
@@ -184,6 +228,12 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(newFromTable("logs"), "logs-1"),
           replacementFor(lookupJoinTable("prices"), "prices")
         )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
+      }
+      "a string literal spells out another source command for the same index list" in {
+        val query = """FROM logs | WHERE msg == "| FROM logs" | LIMIT 10"""
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("logs"), "logs-1"))
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
       }
@@ -256,7 +306,6 @@ class EsqlIndexTableTest extends AnyWordSpec {
       "nonexistent index" in {
         val fromTable = newFromTable("shared_idx")
         val lookupTable = lookupJoinTable("shared_idx")
-        // Keeps authorizedIndices non-empty (NonEmptyList can't be) while granting nothing to shared_idx.
         val decoyLookupTable = lookupJoinTable("decoy_lookup_only")
 
         val replacements = EsqlIndexTable.buildReplacements(

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -70,9 +70,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           Some("FROM bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn")
       }
 
-    // ES reports an index list normalized (entries joined with `,`, quoting stripped), so none of the
-    // spellings below contain the reported text verbatim. Searching the query for it used to find nothing,
-    // leaving the user's original - unauthorized - indices in the forwarded query.
+    // ES reports this list as `book_catalog,book_prices`, which no spelling below contains verbatim.
     "narrow a comma-separated FROM list, whatever way the user spelled it" when {
       "the entries are separated by a space" in {
         val query = "FROM book_catalog, book_prices | LIMIT 100"
@@ -161,8 +159,6 @@ class EsqlIndexTableTest extends AnyWordSpec {
       }
     }
 
-    // Forwarding a query ROR could not rewrite would run it against the user's original indices - the
-    // request was already allowed only on the strength of the narrowed set.
     "fail closed" when {
       "a table ES reported has no index list in the query" in {
         val query = "FROM logs | LIMIT 10"
@@ -226,20 +222,18 @@ class EsqlIndexTableTest extends AnyWordSpec {
       assertMasked(newIndicesOf(replacements, lookupTable))
     }
 
-    "mask FROM to a nonexistent index when FROM is fully forbidden but LOOKUP JOIN is allowed " +
-      "(masking FROM to a concrete nonexistent name still 400s the whole query in practice, but " +
-      "buildReplacements' own contract is still to narrow independently per table)" in {
-        val fromTable = newFromTable("forbidden_src")
-        val lookupTable = lookupJoinTable("lookup_idx")
+    "mask FROM to a nonexistent index when FROM is fully forbidden but LOOKUP JOIN is allowed" in {
+      val fromTable = newFromTable("forbidden_src")
+      val lookupTable = lookupJoinTable("lookup_idx")
 
-        val replacements = EsqlIndexTable.buildReplacements(
-          NonEmptyList.of(fromTable, lookupTable),
-          allowedIndices = authorizedIndicesOf("lookup_idx")
-        )
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(fromTable, lookupTable),
+        allowedIndices = authorizedIndicesOf("lookup_idx")
+      )
 
-        assertMasked(newIndicesOf(replacements, fromTable))
-        newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("lookup_idx")
-      }
+      assertMasked(newIndicesOf(replacements, fromTable))
+      newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("lookup_idx")
+    }
 
     "not strip a literal index name from FROM's replacement just because the same name is also " +
       "requested by LOOKUP JOIN" in {
@@ -255,8 +249,8 @@ class EsqlIndexTableTest extends AnyWordSpec {
         newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("shared_idx")
       }
 
-    "resolve a literal name shared by both a forbidden FROM and a forbidden LOOKUP JOIN to the identical " +
-      "nonexistent index, so the rewritten query keeps reading as one index the way the original did" in {
+    "resolve a literal name shared by a forbidden FROM and a forbidden LOOKUP JOIN to the same " +
+      "nonexistent index" in {
         val fromTable = newFromTable("shared_idx")
         val lookupTable = lookupJoinTable("shared_idx")
         // Keeps authorizedIndices non-empty (NonEmptyList can't be) while granting nothing to shared_idx.
@@ -312,6 +306,18 @@ class EsqlIndexTableTest extends AnyWordSpec {
 
         newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("bookstore")
       }
+  }
+
+  "EsqlIndexTable.LookupJoin.parse" should {
+    "accept a concrete local index name" in {
+      EsqlIndexTable.LookupJoin.parse("book_prices").map(_.index.name.value) shouldBe Some("book_prices")
+    }
+    "reject a wildcard target" in {
+      EsqlIndexTable.LookupJoin.parse("book_*") shouldBe None
+    }
+    "reject a remote cluster target" in {
+      EsqlIndexTable.LookupJoin.parse("remote:book_prices") shouldBe None
+    }
   }
 
   private def newFromTable(tableStringInQuery: String): EsqlIndexTable.From = {

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -1,0 +1,223 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+package tech.beshu.ror.unit.es
+
+import cats.data.NonEmptyList
+import cats.implicits.*
+import org.scalatest.matchers.should.Matchers.*
+import org.scalatest.wordspec.AnyWordSpec
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
+import tech.beshu.ror.implicits.*
+import tech.beshu.ror.syntax.*
+
+class EsqlIndexTableTest extends AnyWordSpec {
+
+  "EsqlIndexTable.newQueryFrom" should {
+    "rewrite a single FROM table" in {
+      val query = "FROM logs-* | LIMIT 10"
+      val replacements = NonEmptyList.one(
+        replacementFor(newFromTable("logs-*"), "logs-1", "logs-2")
+      )
+
+      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe "FROM  logs-1,logs-2 | LIMIT 10"
+    }
+
+    "leave an authorized LOOKUP JOIN target untouched" in {
+      val query = "FROM src | LOOKUP JOIN lookup_idx ON key"
+      val replacements = NonEmptyList.of(
+        replacementFor(newFromTable("src"), "src"),
+        replacementFor(lookupJoinTable("lookup_idx"), "lookup_idx")
+      )
+
+      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe "FROM   src | LOOKUP JOIN lookup_idx ON key"
+    }
+
+    "mask an unauthorized LOOKUP JOIN target" in {
+      val query = "FROM src | LOOKUP JOIN secret_idx ON key"
+      val replacements = NonEmptyList.of(
+        replacementFor(newFromTable("src"), "src"),
+        replacementFor(lookupJoinTable("secret_idx"), "ROR_nonexistent0001")
+      )
+
+      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+        "FROM   src | LOOKUP JOIN ROR_nonexistent0001 ON key"
+    }
+
+    "rewrite a wildcard-narrowed FROM and a masked LOOKUP JOIN independently, without cross-contaminating" +
+      " each other's replacement text" in {
+        val query = "FROM book* | LOOKUP JOIN book_prices ON isbn"
+        val replacements = NonEmptyList.of(
+          replacementFor(newFromTable("book*"), "bookstore1", "bookstore2"),
+          replacementFor(lookupJoinTable("book_prices"), "ROR_nonexistent0002")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          "FROM   bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn"
+      }
+  }
+
+  "EsqlIndexTable.buildReplacements" should {
+    "keep both FROM and an authorized LOOKUP JOIN target unchanged" in {
+      val fromTable = newFromTable("src")
+      val lookupTable = lookupJoinTable("lookup_idx")
+
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(fromTable, lookupTable),
+        allowedIndices = authorizedIndicesOf("src", "lookup_idx")
+      )
+
+      newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("src")
+      newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("lookup_idx")
+    }
+
+    "mask an unauthorized LOOKUP JOIN target while leaving FROM's own narrowing untouched" in {
+      val fromTable = newFromTable("src")
+      val lookupTable = lookupJoinTable("secret_idx")
+
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(fromTable, lookupTable),
+        allowedIndices = authorizedIndicesOf("src")
+      )
+
+      newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("src")
+      assertMasked(newIndicesOf(replacements, lookupTable))
+    }
+
+    "mask FROM to a nonexistent index when FROM is fully forbidden but LOOKUP JOIN is allowed " +
+      "(masking FROM to a concrete nonexistent name still 400s the whole query in practice, but " +
+      "buildReplacements' own contract is still to narrow independently per table)" in {
+        val fromTable = newFromTable("forbidden_src")
+        val lookupTable = lookupJoinTable("lookup_idx")
+
+        val replacements = EsqlIndexTable.buildReplacements(
+          NonEmptyList.of(fromTable, lookupTable),
+          allowedIndices = authorizedIndicesOf("lookup_idx")
+        )
+
+        assertMasked(newIndicesOf(replacements, fromTable))
+        newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("lookup_idx")
+      }
+
+    "not strip a literal index name from FROM's replacement just because the same name is also " +
+      "requested by LOOKUP JOIN" in {
+        val fromTable = newFromTable("shared_idx")
+        val lookupTable = lookupJoinTable("shared_idx")
+
+        val replacements = EsqlIndexTable.buildReplacements(
+          NonEmptyList.of(fromTable, lookupTable),
+          allowedIndices = authorizedIndicesOf("shared_idx")
+        )
+
+        newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("shared_idx")
+        newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("shared_idx")
+      }
+
+    "resolve a literal name shared by both a forbidden FROM and a forbidden LOOKUP JOIN to the identical " +
+      "nonexistent index (newQueryFrom's per-table text replace can't tell the two occurrences apart " +
+      "otherwise)" in {
+        val fromTable = newFromTable("shared_idx")
+        val lookupTable = lookupJoinTable("shared_idx")
+        // Keeps authorizedIndices non-empty (NonEmptyList can't be) while granting nothing to shared_idx.
+        val decoyLookupTable = lookupJoinTable("decoy_lookup_only")
+
+        val replacements = EsqlIndexTable.buildReplacements(
+          NonEmptyList.of(fromTable, lookupTable, decoyLookupTable),
+          allowedIndices = authorizedIndicesOf("decoy_lookup_only")
+        )
+
+        val fromMasked = newIndicesOf(replacements, fromTable)
+        val lookupMasked = newIndicesOf(replacements, lookupTable)
+        assertMasked(fromMasked)
+        assertMasked(lookupMasked)
+        fromMasked shouldBe lookupMasked
+      }
+
+    "include a LOOKUP JOIN target's name in a wildcard FROM's narrowed list when the wildcard genuinely " +
+      "matches it too" in {
+        val fromTable = newFromTable("book*")
+        val lookupTable = lookupJoinTable("book_prices")
+
+        val replacements = EsqlIndexTable.buildReplacements(
+          NonEmptyList.of(fromTable, lookupTable),
+          allowedIndices = authorizedIndicesOf("bookstore1", "bookstore2", "book_prices")
+        )
+
+        newIndicesOf(replacements, fromTable).toList.sorted shouldBe List("book_prices", "bookstore1", "bookstore2")
+        newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("book_prices")
+      }
+
+    "exclude a LOOKUP JOIN target from a wildcard FROM's narrowed list when the wildcard doesn't match it" in {
+      val fromTable = newFromTable("bookstore*")
+      val lookupTable = lookupJoinTable("lookup_idx")
+
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(fromTable, lookupTable),
+        allowedIndices = authorizedIndicesOf("bookstore1", "bookstore2", "lookup_idx")
+      )
+
+      newIndicesOf(replacements, fromTable).toList.sorted shouldBe List("bookstore1", "bookstore2")
+      newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("lookup_idx")
+    }
+
+    "resolve a literal FROM alias whose ACL-narrowed concrete index name doesn't textually match the " +
+      "query's own alias text (e.g. the ACL resolved \"bookshop\" to its underlying \"bookstore\")" in {
+        val fromTable = newFromTable("bookshop")
+
+        val replacements = EsqlIndexTable.buildReplacements(
+          NonEmptyList.one(fromTable),
+          allowedIndices = authorizedIndicesOf("bookstore")
+        )
+
+        newIndicesOf(replacements, fromTable) shouldBe NonEmptyList.one("bookstore")
+      }
+  }
+
+  private def newFromTable(tableStringInQuery: String): EsqlIndexTable.From = {
+    EsqlIndexTable.From(tableStringInQuery, NonEmptyList.one(indexNameFrom(tableStringInQuery)))
+  }
+
+  private def lookupJoinTable(tableStringInQuery: String): EsqlIndexTable.LookupJoin = {
+    EsqlIndexTable.LookupJoin(tableStringInQuery, indexNameFrom(tableStringInQuery))
+  }
+
+  private def indexNameFrom(value: String): IndexName =
+    IndexName.fromString(value).getOrElse(fail(s"not a valid index name: $value"))
+
+  private def authorizedIndicesOf(names: String*): NonEmptyList[RequestedIndex[ClusterIndexName]] = {
+    NonEmptyList.fromListUnsafe(names.toList.flatMap(RequestedIndex.fromString))
+  }
+
+  private def replacementFor(table: EsqlIndexTable, newIndices: String*): EsqlIndexTable.Replacement = {
+    EsqlIndexTable.Replacement(table, NonEmptyList.fromListUnsafe(newIndices.toList.map(indexNameFrom)))
+  }
+
+  private def newIndicesOf(
+      replacements: NonEmptyList[EsqlIndexTable.Replacement],
+      table: EsqlIndexTable
+  ): NonEmptyList[String] = {
+    replacements.find(_.table == table).getOrElse(fail(s"no replacement found for $table")).newIndices.map(_.show)
+  }
+
+  private def assertMasked(newIndices: NonEmptyList[String]): Unit = {
+    newIndices.toList match {
+      case single :: Nil => single should startWith("ROR_")
+      case other         => fail(s"expected a single masked index, got $other")
+    }
+  }
+
+}

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -96,6 +96,32 @@ class EsqlIndexTableTest extends AnyWordSpec {
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM book_catalog | LIMIT 100")
       }
+      "a comment sits inside the list" in {
+        val query = "FROM book_catalog, /* and */ book_prices | LIMIT 100"
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM book_catalog | LIMIT 100")
+      }
+      "a nested comment sits inside the list" in {
+        val query = "FROM book_catalog, /* and /* even */ this */ book_prices | LIMIT 100"
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM book_catalog | LIMIT 100")
+      }
+      "a comment splits the LOOKUP JOIN keyword" in {
+        val query = "FROM src | LOOKUP /* really */ JOIN secret_idx ON key"
+        val replacements = NonEmptyList.of(
+          replacementFor(newFromTable("src"), "src"),
+          replacementFor(lookupJoinTable("secret_idx"), "ROR_nonexistent0006")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("FROM src | LOOKUP /* really */ JOIN ROR_nonexistent0006 ON key")
+      }
       "the entries are triple-quoted" in {
         val query = "FROM \"\"\"book_catalog\"\"\",\"\"\"book_prices\"\"\" | LIMIT 100"
         val replacements = NonEmptyList.one(
@@ -158,6 +184,52 @@ class EsqlIndexTableTest extends AnyWordSpec {
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten(
           "FROM book-1 | EVAL x = book_prices | LIMIT 10"
         )
+      }
+    }
+
+    "rewrite the real index list, not a source command the query only spells out" when {
+      "a string literal spells out another source command for the same index list" in {
+        val query = """FROM logs | WHERE msg == "| FROM logs" | LIMIT 10"""
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("logs"), "logs-1"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("""FROM logs-1 | WHERE msg == "| FROM logs" | LIMIT 10""")
+      }
+      "a triple-quoted literal spells out another source command for the same index list" in {
+        val query = "FROM logs | WHERE msg == \"\"\"| FROM logs\"\"\" | LIMIT 10"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("logs"), "logs-1"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("FROM logs-1 | WHERE msg == \"\"\"| FROM logs\"\"\" | LIMIT 10")
+      }
+      "a backquoted identifier spells out another source command for the same index list" in {
+        val query = "FROM logs | RENAME a AS `| FROM logs` | LIMIT 10"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("logs"), "logs-1"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("FROM logs-1 | RENAME a AS `| FROM logs` | LIMIT 10")
+      }
+      "a comment inside the real list would otherwise leave a decoy as the only match" in {
+        val query =
+          """FROM book_catalog, /* and */ book_prices | WHERE msg == "|FROM book_catalog,book_prices " | LIMIT 100"""
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten("""FROM book_catalog | WHERE msg == "|FROM book_catalog,book_prices " | LIMIT 100""")
+      }
+      "a decoy would otherwise mask an unauthorized LOOKUP JOIN target in the literal's place" in {
+        val query = """FROM src | LOOKUP /* really */ JOIN secret ON key | WHERE m == "|LOOKUP JOIN secret " """
+        val replacements = NonEmptyList.of(
+          replacementFor(newFromTable("src"), "src"),
+          replacementFor(lookupJoinTable("secret"), "ROR_nonexistent0007")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Rewritten(
+            """FROM src | LOOKUP /* really */ JOIN ROR_nonexistent0007 ON key | WHERE m == "|LOOKUP JOIN secret " """
+          )
       }
     }
 
@@ -231,17 +303,17 @@ class EsqlIndexTableTest extends AnyWordSpec {
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
       }
-      "a string literal spells out another source command for the same index list" in {
-        val query = """FROM logs | WHERE msg == "| FROM logs" | LIMIT 10"""
-        val replacements = NonEmptyList.one(replacementFor(newFromTable("logs"), "logs-1"))
-
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
-      }
       "the query spells the list in a way that doesn't normalize to what ES reported" in {
-        val query = "FROM book_catalog, /* and */ book_prices | LIMIT 100"
+        val query = "FROM book_catalog | LIMIT 100"
         val replacements = NonEmptyList.one(
           replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
         )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
+      }
+      "an unterminated string literal swallows the only index list ES reported" in {
+        val query = """FROM logs | WHERE msg == "oops | LIMIT 10"""
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("oops"), "other"))
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
       }

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -419,6 +419,32 @@ class EsqlIndexTableTest extends AnyWordSpec {
       newIndicesOf(replacements, lookupTable) shouldBe NonEmptyList.one("lookup_idx")
     }
 
+    "narrow each of two FROM tables to its own indices, without lending one's indices to the other" in {
+      val bookTable = newFromTable("book*")
+      val movieTable = newFromTable("movie*")
+
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(bookTable, movieTable),
+        allowedIndices = authorizedIndicesOf("book_catalog", "movie_catalog")
+      )
+
+      newIndicesOf(replacements, bookTable) shouldBe NonEmptyList.one("book_catalog")
+      newIndicesOf(replacements, movieTable) shouldBe NonEmptyList.one("movie_catalog")
+    }
+
+    "mask only the forbidden one of two FROM tables" in {
+      val bookTable = newFromTable("book*")
+      val secretTable = newFromTable("secret*")
+
+      val replacements = EsqlIndexTable.buildReplacements(
+        NonEmptyList.of(bookTable, secretTable),
+        allowedIndices = authorizedIndicesOf("book_catalog")
+      )
+
+      newIndicesOf(replacements, bookTable) shouldBe NonEmptyList.one("book_catalog")
+      assertMasked(newIndicesOf(replacements, secretTable))
+    }
+
     "resolve a literal FROM alias whose ACL-narrowed concrete index name doesn't textually match the " +
       "query's own alias text (e.g. the ACL resolved \"bookshop\" to its underlying \"bookstore\")" in {
         val fromTable = newFromTable("bookshop")

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -34,7 +34,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
         replacementFor(newFromTable("logs-*"), "logs-1", "logs-2")
       )
 
-      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe "FROM  logs-1,logs-2 | LIMIT 10"
+      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM logs-1,logs-2 | LIMIT 10")
     }
 
     "leave an authorized LOOKUP JOIN target untouched" in {
@@ -44,7 +44,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
         replacementFor(lookupJoinTable("lookup_idx"), "lookup_idx")
       )
 
-      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe "FROM   src | LOOKUP JOIN lookup_idx ON key"
+      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM src | LOOKUP JOIN lookup_idx ON key")
     }
 
     "mask an unauthorized LOOKUP JOIN target" in {
@@ -55,7 +55,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
       )
 
       EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
-        "FROM   src | LOOKUP JOIN ROR_nonexistent0001 ON key"
+        Some("FROM src | LOOKUP JOIN ROR_nonexistent0001 ON key")
     }
 
     "rewrite a wildcard-narrowed FROM and a masked LOOKUP JOIN independently, without cross-contaminating" +
@@ -67,8 +67,136 @@ class EsqlIndexTableTest extends AnyWordSpec {
         )
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
-          "FROM   bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn"
+          Some("FROM bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn")
       }
+
+    // ES reports an index list normalized (entries joined with `,`, quoting stripped), so none of the
+    // spellings below contain the reported text verbatim. Searching the query for it used to find nothing,
+    // leaving the user's original - unauthorized - indices in the forwarded query.
+    "narrow a comma-separated FROM list, whatever way the user spelled it" when {
+      "the entries are separated by a space" in {
+        val query = "FROM book_catalog, book_prices | LIMIT 100"
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book_catalog | LIMIT 100")
+      }
+      "some of the entries are quoted" in {
+        val query = """FROM "book_catalog", book_prices | LIMIT 100"""
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book_catalog | LIMIT 100")
+      }
+      "the whole list is one quoted string" in {
+        val query = """FROM "book_catalog,book_prices" | LIMIT 100"""
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book_catalog | LIMIT 100")
+      }
+      "the entries are triple-quoted" in {
+        val query = "FROM \"\"\"book_catalog\"\"\",\"\"\"book_prices\"\"\" | LIMIT 100"
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book_catalog | LIMIT 100")
+      }
+      "the source command is lowercase" in {
+        val query = "from book_catalog, book_prices | limit 100"
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("from book_catalog | limit 100")
+      }
+    }
+
+    "rewrite only the index list, not identifiers that happen to share an index's name" when {
+      "a column has the same name as the FROM index" in {
+        val query = """FROM status | WHERE status == "ok" | LIMIT 10"""
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("status"), "other"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Some("""FROM other | WHERE status == "ok" | LIMIT 10""")
+      }
+      "the LOOKUP JOIN key has the same name as its target index" in {
+        val query = "FROM src | LOOKUP JOIN prices ON prices"
+        val replacements = NonEmptyList.of(
+          replacementFor(newFromTable("src"), "src"),
+          replacementFor(lookupJoinTable("prices"), "ROR_nonexistent0003")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Some("FROM src | LOOKUP JOIN ROR_nonexistent0003 ON prices")
+      }
+      "an index name also appears inside a string literal" in {
+        val query = """FROM logs | WHERE msg == "read from logs" | LIMIT 10"""
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("logs"), "logs-1"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
+          Some("""FROM logs-1 | WHERE msg == "read from logs" | LIMIT 10""")
+      }
+      "a METADATA clause follows the index list" in {
+        val query = "FROM logs-* METADATA _index | LIMIT 10"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("logs-*"), "logs-1"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM logs-1 METADATA _index | LIMIT 10")
+      }
+      "the index is itself named 'metadata'" in {
+        val query = "FROM metadata | LIMIT 10"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("metadata"), "other"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM other | LIMIT 10")
+      }
+      "an index name is a prefix of another identifier in the query" in {
+        val query = "FROM book | EVAL x = book_prices | LIMIT 10"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("book"), "book-1"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book-1 | EVAL x = book_prices | LIMIT 10")
+      }
+    }
+
+    // Forwarding a query ROR could not rewrite would run it against the user's original indices - the
+    // request was already allowed only on the strength of the narrowed set.
+    "fail closed" when {
+      "a table ES reported has no index list in the query" in {
+        val query = "FROM logs | LIMIT 10"
+        val replacements = NonEmptyList.of(
+          replacementFor(newFromTable("logs"), "logs"),
+          replacementFor(lookupJoinTable("prices"), "ROR_nonexistent0004")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe None
+      }
+      "a FROM table is only spelled as a LOOKUP JOIN target in the query" in {
+        val query = "FROM src | LOOKUP JOIN prices ON key"
+        val replacements = NonEmptyList.one(replacementFor(newFromTable("prices"), "other"))
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe None
+      }
+      "the same index list can be located in more than one place" in {
+        val query = "FROM logs | LOOKUP JOIN prices ON key | FORK (WHERE a) (FROM logs)"
+        val replacements = NonEmptyList.of(
+          replacementFor(newFromTable("logs"), "logs-1"),
+          replacementFor(lookupJoinTable("prices"), "prices")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe None
+      }
+      "the query spells the list in a way that doesn't normalize to what ES reported" in {
+        val query = "FROM book_catalog, /* and */ book_prices | LIMIT 100"
+        val replacements = NonEmptyList.one(
+          replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
+        )
+
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe None
+      }
+    }
   }
 
   "EsqlIndexTable.buildReplacements" should {
@@ -128,8 +256,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
       }
 
     "resolve a literal name shared by both a forbidden FROM and a forbidden LOOKUP JOIN to the identical " +
-      "nonexistent index (newQueryFrom's per-table text replace can't tell the two occurrences apart " +
-      "otherwise)" in {
+      "nonexistent index, so the rewritten query keeps reading as one index the way the original did" in {
         val fromTable = newFromTable("shared_idx")
         val lookupTable = lookupJoinTable("shared_idx")
         // Keeps authorizedIndices non-empty (NonEmptyList can't be) while granting nothing to shared_idx.

--- a/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/es/EsqlIndexTableTest.scala
@@ -22,6 +22,7 @@ import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.wordspec.AnyWordSpec
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsqlIndexTable
+import tech.beshu.ror.es.EsqlQueryRewriteResult.{CannotRewriteQuery, Rewritten}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -34,7 +35,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
         replacementFor(newFromTable("logs-*"), "logs-1", "logs-2")
       )
 
-      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM logs-1,logs-2 | LIMIT 10")
+      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM logs-1,logs-2 | LIMIT 10")
     }
 
     "leave an authorized LOOKUP JOIN target untouched" in {
@@ -44,7 +45,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
         replacementFor(lookupJoinTable("lookup_idx"), "lookup_idx")
       )
 
-      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM src | LOOKUP JOIN lookup_idx ON key")
+      EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM src | LOOKUP JOIN lookup_idx ON key")
     }
 
     "mask an unauthorized LOOKUP JOIN target" in {
@@ -55,7 +56,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
       )
 
       EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
-        Some("FROM src | LOOKUP JOIN ROR_nonexistent0001 ON key")
+        Rewritten("FROM src | LOOKUP JOIN ROR_nonexistent0001 ON key")
     }
 
     "rewrite a wildcard-narrowed FROM and a masked LOOKUP JOIN independently, without cross-contaminating" +
@@ -67,7 +68,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
         )
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
-          Some("FROM bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn")
+          Rewritten("FROM bookstore1,bookstore2 | LOOKUP JOIN ROR_nonexistent0002 ON isbn")
       }
 
     // ES reports this list as `book_catalog,book_prices`, which no spelling below contains verbatim.
@@ -78,7 +79,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book_catalog | LIMIT 100")
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM book_catalog | LIMIT 100")
       }
       "some of the entries are quoted" in {
         val query = """FROM "book_catalog", book_prices | LIMIT 100"""
@@ -86,7 +87,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book_catalog | LIMIT 100")
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM book_catalog | LIMIT 100")
       }
       "the whole list is one quoted string" in {
         val query = """FROM "book_catalog,book_prices" | LIMIT 100"""
@@ -94,7 +95,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book_catalog | LIMIT 100")
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM book_catalog | LIMIT 100")
       }
       "the entries are triple-quoted" in {
         val query = "FROM \"\"\"book_catalog\"\"\",\"\"\"book_prices\"\"\" | LIMIT 100"
@@ -102,7 +103,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book_catalog | LIMIT 100")
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM book_catalog | LIMIT 100")
       }
       "the source command is lowercase" in {
         val query = "from book_catalog, book_prices | limit 100"
@@ -110,7 +111,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("from book_catalog | limit 100")
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("from book_catalog | limit 100")
       }
     }
 
@@ -120,7 +121,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
         val replacements = NonEmptyList.one(replacementFor(newFromTable("status"), "other"))
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
-          Some("""FROM other | WHERE status == "ok" | LIMIT 10""")
+          Rewritten("""FROM other | WHERE status == "ok" | LIMIT 10""")
       }
       "the LOOKUP JOIN key has the same name as its target index" in {
         val query = "FROM src | LOOKUP JOIN prices ON prices"
@@ -130,32 +131,34 @@ class EsqlIndexTableTest extends AnyWordSpec {
         )
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
-          Some("FROM src | LOOKUP JOIN ROR_nonexistent0003 ON prices")
+          Rewritten("FROM src | LOOKUP JOIN ROR_nonexistent0003 ON prices")
       }
       "an index name also appears inside a string literal" in {
         val query = """FROM logs | WHERE msg == "read from logs" | LIMIT 10"""
         val replacements = NonEmptyList.one(replacementFor(newFromTable("logs"), "logs-1"))
 
         EsqlIndexTable.newQueryFrom(query, replacements) shouldBe
-          Some("""FROM logs-1 | WHERE msg == "read from logs" | LIMIT 10""")
+          Rewritten("""FROM logs-1 | WHERE msg == "read from logs" | LIMIT 10""")
       }
       "a METADATA clause follows the index list" in {
         val query = "FROM logs-* METADATA _index | LIMIT 10"
         val replacements = NonEmptyList.one(replacementFor(newFromTable("logs-*"), "logs-1"))
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM logs-1 METADATA _index | LIMIT 10")
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM logs-1 METADATA _index | LIMIT 10")
       }
       "the index is itself named 'metadata'" in {
         val query = "FROM metadata | LIMIT 10"
         val replacements = NonEmptyList.one(replacementFor(newFromTable("metadata"), "other"))
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM other | LIMIT 10")
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten("FROM other | LIMIT 10")
       }
       "an index name is a prefix of another identifier in the query" in {
         val query = "FROM book | EVAL x = book_prices | LIMIT 10"
         val replacements = NonEmptyList.one(replacementFor(newFromTable("book"), "book-1"))
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Some("FROM book-1 | EVAL x = book_prices | LIMIT 10")
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe Rewritten(
+          "FROM book-1 | EVAL x = book_prices | LIMIT 10"
+        )
       }
     }
 
@@ -167,13 +170,13 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(lookupJoinTable("prices"), "ROR_nonexistent0004")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe None
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
       }
       "a FROM table is only spelled as a LOOKUP JOIN target in the query" in {
         val query = "FROM src | LOOKUP JOIN prices ON key"
         val replacements = NonEmptyList.one(replacementFor(newFromTable("prices"), "other"))
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe None
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
       }
       "the same index list can be located in more than one place" in {
         val query = "FROM logs | LOOKUP JOIN prices ON key | FORK (WHERE a) (FROM logs)"
@@ -182,7 +185,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(lookupJoinTable("prices"), "prices")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe None
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
       }
       "the query spells the list in a way that doesn't normalize to what ES reported" in {
         val query = "FROM book_catalog, /* and */ book_prices | LIMIT 100"
@@ -190,7 +193,7 @@ class EsqlIndexTableTest extends AnyWordSpec {
           replacementFor(newFromTable("book_catalog,book_prices"), "book_catalog")
         )
 
-        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe None
+        EsqlIndexTable.newQueryFrom(query, replacements) shouldBe CannotRewriteQuery
       }
     }
   }

--- a/es811x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,12 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -59,7 +64,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -73,8 +78,8 @@ class EsqlIndicesEsRequestContext private (
   ): ModificationResult = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
-          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -93,15 +98,23 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
-      tables: NonEmptyList[IndexTable],
+      tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
-    updatedRequest(request, filter, fieldLevelSecurity)
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def updatedRequest(

--- a/es811x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -34,7 +34,7 @@ import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -60,7 +60,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.indices.flatMap(RequestedIndex.fromString)
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -71,33 +71,47 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
-        } else {
-          request
-        }
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[IndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
+    updatedRequest(request, filter, fieldLevelSecurity)
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es811x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -39,7 +39,7 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[IndexTable],
       finalIndices: Set[String]
-  ): CompositeIndicesRequest = {
+  ): Unit = {
     setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
@@ -69,9 +69,8 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
     on(request).call("query", newQuery)
-    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
@@ -104,11 +103,18 @@ object EsqlRequestHelper {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -278,6 +284,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es811x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -37,10 +39,16 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
-  ): Unit = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ): IndicesModificationResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -69,28 +77,13 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
     on(request).call("query", newQuery)
+    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
     on(request).call("params").get[AnyRef]
-  }
-
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
   }
 
   private final class EsqlParser(
@@ -130,19 +123,10 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val tableInfoList = tableInfosFrom(preAnalyze)
-      tableInfoList
+      tableInfosFrom(preAnalyze)
         .map(tableIdentifierFrom)
         .map(indexStringFrom)
-        .flatMap { tableString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(tableString))
-            .map(IndexTable(tableString, _))
-        }
-    }
-
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+        .flatMap(EsqlIndexTable.From.parse)
     }
 
     private def newPreAnalyzer(
@@ -170,7 +154,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -267,14 +251,14 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification
@@ -285,6 +269,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es812x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,12 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -59,7 +64,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -73,8 +78,8 @@ class EsqlIndicesEsRequestContext private (
   ): ModificationResult = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
-          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -93,15 +98,23 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
-      tables: NonEmptyList[IndexTable],
+      tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
-    updatedRequest(request, filter, fieldLevelSecurity)
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def updatedRequest(

--- a/es812x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -34,7 +34,7 @@ import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -60,7 +60,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.indices.flatMap(RequestedIndex.fromString)
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -71,33 +71,47 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
-        } else {
-          request
-        }
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[IndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
+    updatedRequest(request, filter, fieldLevelSecurity)
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es812x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -39,7 +39,7 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[IndexTable],
       finalIndices: Set[String]
-  ): CompositeIndicesRequest = {
+  ): Unit = {
     setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
@@ -69,9 +69,8 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
     on(request).call("query", newQuery)
-    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
@@ -104,11 +103,18 @@ object EsqlRequestHelper {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -278,6 +284,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es812x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -37,10 +39,16 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
-  ): Unit = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ): IndicesModificationResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -69,28 +77,13 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
     on(request).call("query", newQuery)
+    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
     on(request).call("params").get[AnyRef]
-  }
-
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
   }
 
   private final class EsqlParser(
@@ -130,19 +123,10 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val tableInfoList = tableInfosFrom(preAnalyze)
-      tableInfoList
+      tableInfosFrom(preAnalyze)
         .map(tableIdentifierFrom)
         .map(indexStringFrom)
-        .flatMap { tableString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(tableString))
-            .map(IndexTable(tableString, _))
-        }
-    }
-
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+        .flatMap(EsqlIndexTable.From.parse)
     }
 
     private def newPreAnalyzer(
@@ -170,7 +154,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -267,14 +251,14 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification
@@ -285,6 +269,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es813x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,12 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -59,7 +64,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -73,8 +78,8 @@ class EsqlIndicesEsRequestContext private (
   ): ModificationResult = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
-          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -93,15 +98,23 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
-      tables: NonEmptyList[IndexTable],
+      tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
-    updatedRequest(request, filter, fieldLevelSecurity)
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def updatedRequest(

--- a/es813x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -34,7 +34,7 @@ import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -60,7 +60,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.indices.flatMap(RequestedIndex.fromString)
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -71,33 +71,47 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
-        } else {
-          request
-        }
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[IndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
+    updatedRequest(request, filter, fieldLevelSecurity)
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es813x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -39,7 +39,7 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[IndexTable],
       finalIndices: Set[String]
-  ): CompositeIndicesRequest = {
+  ): Unit = {
     setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
@@ -69,9 +69,8 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
     on(request).call("query", newQuery)
-    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
@@ -104,11 +103,18 @@ object EsqlRequestHelper {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -278,6 +284,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es813x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -37,10 +39,16 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
-  ): Unit = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ): IndicesModificationResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -69,28 +77,13 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
     on(request).call("query", newQuery)
+    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
     on(request).call("params").get[AnyRef]
-  }
-
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
   }
 
   private final class EsqlParser(
@@ -130,19 +123,10 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val tableInfoList = tableInfosFrom(preAnalyze)
-      tableInfoList
+      tableInfosFrom(preAnalyze)
         .map(tableIdentifierFrom)
         .map(indexStringFrom)
-        .flatMap { tableString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(tableString))
-            .map(IndexTable(tableString, _))
-        }
-    }
-
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+        .flatMap(EsqlIndexTable.From.parse)
     }
 
     private def newPreAnalyzer(
@@ -170,7 +154,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -267,14 +251,14 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification
@@ -285,6 +269,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es814x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,12 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -59,7 +64,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -73,8 +78,8 @@ class EsqlIndicesEsRequestContext private (
   ): ModificationResult = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
-          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -93,15 +98,23 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
-      tables: NonEmptyList[IndexTable],
+      tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
-    updatedRequest(request, filter, fieldLevelSecurity)
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def updatedRequest(

--- a/es814x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -34,7 +34,7 @@ import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -60,7 +60,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.indices.flatMap(RequestedIndex.fromString)
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -71,33 +71,47 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
-        } else {
-          request
-        }
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[IndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
+    updatedRequest(request, filter, fieldLevelSecurity)
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es814x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -39,7 +39,7 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[IndexTable],
       finalIndices: Set[String]
-  ): CompositeIndicesRequest = {
+  ): Unit = {
     setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
@@ -69,9 +69,8 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
     on(request).call("query", newQuery)
-    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
@@ -104,11 +103,18 @@ object EsqlRequestHelper {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -278,6 +284,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es814x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -37,10 +39,16 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
-  ): Unit = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ): IndicesModificationResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -69,28 +77,13 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
     on(request).call("query", newQuery)
+    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
     on(request).call("params").get[AnyRef]
-  }
-
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
   }
 
   private final class EsqlParser(
@@ -130,19 +123,10 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val tableInfoList = tableInfosFrom(preAnalyze)
-      tableInfoList
+      tableInfosFrom(preAnalyze)
         .map(tableIdentifierFrom)
         .map(indexStringFrom)
-        .flatMap { tableString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(tableString))
-            .map(IndexTable(tableString, _))
-        }
-    }
-
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+        .flatMap(EsqlIndexTable.From.parse)
     }
 
     private def newPreAnalyzer(
@@ -170,7 +154,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -267,14 +251,14 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification
@@ -285,6 +269,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es815x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,12 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -59,7 +64,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -73,8 +78,8 @@ class EsqlIndicesEsRequestContext private (
   ): ModificationResult = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
-          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -93,15 +98,23 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
-      tables: NonEmptyList[IndexTable],
+      tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
-    updatedRequest(request, filter, fieldLevelSecurity)
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def updatedRequest(

--- a/es815x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -34,7 +34,7 @@ import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -60,7 +60,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.indices.flatMap(RequestedIndex.fromString)
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -71,33 +71,47 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
-        } else {
-          request
-        }
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[IndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
+    updatedRequest(request, filter, fieldLevelSecurity)
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es815x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -39,7 +39,7 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[IndexTable],
       finalIndices: Set[String]
-  ): CompositeIndicesRequest = {
+  ): Unit = {
     setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
@@ -69,9 +69,8 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
     on(request).call("query", newQuery)
-    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
@@ -104,11 +103,18 @@ object EsqlRequestHelper {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -278,6 +284,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es815x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -37,10 +39,16 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
-  ): Unit = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ): IndicesModificationResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -69,28 +77,13 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
     on(request).call("query", newQuery)
+    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
     on(request).call("params").get[AnyRef]
-  }
-
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
   }
 
   private final class EsqlParser(
@@ -130,19 +123,10 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val tableInfoList = tableInfosFrom(preAnalyze)
-      tableInfoList
+      tableInfosFrom(preAnalyze)
         .map(tableIdentifierFrom)
         .map(indexStringFrom)
-        .flatMap { tableString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(tableString))
-            .map(IndexTable(tableString, _))
-        }
-    }
-
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+        .flatMap(EsqlIndexTable.From.parse)
     }
 
     private def newPreAnalyzer(
@@ -170,7 +154,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -267,14 +251,14 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification
@@ -285,6 +269,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es816x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es816x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,12 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -59,7 +64,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -73,8 +78,8 @@ class EsqlIndicesEsRequestContext private (
   ): ModificationResult = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
-          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -93,15 +98,23 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
-      tables: NonEmptyList[IndexTable],
+      tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
-    updatedRequest(request, filter, fieldLevelSecurity)
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def updatedRequest(

--- a/es816x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es816x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -34,7 +34,7 @@ import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -60,7 +60,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.indices.flatMap(RequestedIndex.fromString)
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -71,33 +71,47 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
-        } else {
-          request
-        }
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.stringify.toCovariantSet != r.indices =>
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[IndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices.stringify.toCovariantSet)
+    updatedRequest(request, filter, fieldLevelSecurity)
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es816x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es816x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -39,7 +39,7 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[IndexTable],
       finalIndices: Set[String]
-  ): CompositeIndicesRequest = {
+  ): Unit = {
     setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
@@ -69,9 +69,8 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
     on(request).call("query", newQuery)
-    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
@@ -104,11 +103,18 @@ object EsqlRequestHelper {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -278,6 +284,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es816x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es816x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -37,10 +39,16 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
-  ): Unit = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
+  ): IndicesModificationResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -69,28 +77,13 @@ object EsqlRequestHelper {
     on(request).call("query").get[String]
   }
 
-  private def setQuery(request: CompositeIndicesRequest, newQuery: String): Unit = {
+  private def setQuery(request: CompositeIndicesRequest, newQuery: String): CompositeIndicesRequest = {
     on(request).call("query", newQuery)
+    request
   }
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
     on(request).call("params").get[AnyRef]
-  }
-
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
   }
 
   private final class EsqlParser(
@@ -130,19 +123,10 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val tableInfoList = tableInfosFrom(preAnalyze)
-      tableInfoList
+      tableInfosFrom(preAnalyze)
         .map(tableIdentifierFrom)
         .map(indexStringFrom)
-        .flatMap { tableString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(tableString))
-            .map(IndexTable(tableString, _))
-        }
-    }
-
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+        .flatMap(EsqlIndexTable.From.parse)
     }
 
     private def newPreAnalyzer(
@@ -170,7 +154,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -267,14 +251,14 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification
@@ -285,6 +269,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,6 +29,7 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlQueryRewriteResult
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
@@ -72,37 +73,34 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices) match {
-      case Some(_) =>
-        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-        applyFilterTo(request, filter)
-        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-      case None =>
-        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
-        ModificationResult.ShouldBeInterrupted
-    }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        Some(request)
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
-          esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
-        } else {
-          Some(request)
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        esqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+          case EsqlQueryRewriteResult.Rewritten(_) =>
+            updatedRequest(request, filter, fieldLevelSecurity)
+          case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            ModificationResult.ShouldBeInterrupted
         }
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        Some(request)
+        updatedRequest(request, filter, fieldLevelSecurity)
     }
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -72,31 +72,36 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+    modifyRequestIndices(request, filteredRequestedIndices) match {
+      case Some(_) =>
+        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+        applyFilterTo(request, filter)
+        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+      case None =>
+        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def modifyRequestIndices(
       request: ActionRequest with CompositeIndicesRequest,
       filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
+  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
+        Some(request)
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
-          request
+          Some(request)
         }
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        Some(request)
     }
   }
 

--- a/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -88,7 +88,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
         if (filteredIndicesStrings != r.indices) {
-          esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
+          esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request
         }

--- a/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -62,7 +62,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.requestedIndices
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -80,6 +80,10 @@ class EsqlIndicesEsRequestContext private (
           case EsqlQueryRewriteResult.Rewritten(_) =>
             updatedRequest(request, filter, fieldLevelSecurity)
           case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            logger.warn(
+              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
+                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
+            )
             ModificationResult.ShouldBeInterrupted
         }
       case Right(_) =>
@@ -90,6 +94,13 @@ class EsqlIndicesEsRequestContext private (
           ex
         )
         updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
   }
 

--- a/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -60,7 +60,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -86,8 +86,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
         request
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
+        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request

--- a/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,13 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
-import tech.beshu.ror.es.EsqlQueryRewriteResult
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -76,16 +80,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        esqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
-          case EsqlQueryRewriteResult.Rewritten(_) =>
-            updatedRequest(request, filter, fieldLevelSecurity)
-          case EsqlQueryRewriteResult.CannotRewriteQuery =>
-            logger.warn(
-              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
-                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
-            )
-            ModificationResult.ShouldBeInterrupted
-        }
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -99,6 +94,25 @@ class EsqlIndicesEsRequestContext private (
           s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
             "unknown. The request will be rejected. Cause:",
           ex
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[EsqlIndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    esqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
         )
         ModificationResult.ShouldBeInterrupted
     }

--- a/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -80,7 +80,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -99,7 +99,7 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
       tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],

--- a/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,7 +23,7 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
-import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsVersion
 import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
@@ -45,8 +45,7 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -149,8 +148,8 @@ class EsqlRequestHelper(esVersion: EsVersion) {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      tablesFrom(tableInfosFrom(preAnalyze), fromTableFrom) ++
-        tablesFrom(lookupTableInfosFrom(preAnalyze), lookupJoinTableFrom)
+      tablesFrom(tableInfosFrom(preAnalyze), EsqlIndexTable.From.parse) ++
+        tablesFrom(lookupTableInfosFrom(preAnalyze), EsqlIndexTable.LookupJoin.parse)
     }
 
     private def tablesFrom(tableInfos: List[Any], tableFrom: String => Option[EsqlIndexTable]): List[EsqlIndexTable] = {
@@ -158,20 +157,6 @@ class EsqlRequestHelper(esVersion: EsVersion) {
         .map(tableIdentifierFrom)
         .map(indexStringFrom)
         .flatMap(tableFrom)
-    }
-
-    private def fromTableFrom(tableString: String): Option[EsqlIndexTable] = {
-      NonEmptyList.fromList(splitIntoIndices(tableString)).map(EsqlIndexTable.From(tableString, _))
-    }
-
-    private def lookupJoinTableFrom(tableString: String): Option[EsqlIndexTable] = {
-      NonEmptyList
-        .fromList(splitIntoIndices(tableString))
-        .map(indices => EsqlIndexTable.LookupJoin(tableString, indices.head))
-    }
-
-    private def splitIntoIndices(tableString: String): List[IndexName] = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -310,10 +295,7 @@ object EsqlRequestHelper {
 
     final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
 
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
-        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
-        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
-      }
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
 
     }
 

--- a/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -123,11 +123,18 @@ class EsqlRequestHelper(esVersion: EsVersion) {
         case v if v >= EsVersion(8, 19, 0) => createStatementForEsEqualOrAbove8190(request)
         case v                             => createStatementForEsBelow8190(request)
       }
-      statement.map { s =>
-        NonEmptyList.fromList(indicesFrom(s)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      statement.flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -312,6 +319,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -25,10 +25,10 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsVersion
-import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
 import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
@@ -44,10 +44,14 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
-    EsqlIndexTable
-      .newQueryFrom(getQuery(request), requestTables, finalIndices)
-      .map(setQuery(request, _))
+  ): EsqlQueryRewriteResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        rewritten
+      case EsqlQueryRewriteResult.CannotRewriteQuery =>
+        EsqlQueryRewriteResult.CannotRewriteQuery
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(

--- a/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -27,7 +27,11 @@ import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsVersion
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
@@ -44,13 +48,13 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): EsqlQueryRewriteResult = {
+  ): IndicesModificationResult = {
     EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
-      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
         setQuery(request, newQuery)
-        rewritten
-      case EsqlQueryRewriteResult.CannotRewriteQuery =>
-        EsqlQueryRewriteResult.CannotRewriteQuery
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
     }
   }
 
@@ -320,6 +324,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -44,8 +44,10 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
+  ): Option[CompositeIndicesRequest] = {
+    EsqlIndexTable
+      .newQueryFrom(getQuery(request), requestTables, finalIndices)
+      .map(setQuery(request, _))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -174,7 +176,7 @@ class EsqlRequestHelper(esVersion: EsVersion) {
     }
 
     private def lookupTableInfosFrom(preAnalysis: Any) = {
-      Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+      on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList
     }
 
     private def tableIdentifierFrom(tableInfo: Any) = {

--- a/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es818x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,15 +23,17 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
 import tech.beshu.ror.es.EsVersion
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.time.ZoneOffset
-import java.util.regex.Pattern
 import java.util.{List as JList, Locale}
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
@@ -40,10 +42,11 @@ class EsqlRequestHelper(esVersion: EsVersion) {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -101,22 +104,6 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       .get[AnyRef]()
   }
 
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
-  }
-
   private final class EsqlParser(
       implicit classLoader: ClassLoader
   ) {
@@ -162,19 +149,29 @@ class EsqlRequestHelper(esVersion: EsVersion) {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val tableInfoList = tableInfosFrom(preAnalyze)
-      tableInfoList
-        .map(tableIdentifierFrom)
-        .map(indexStringFrom)
-        .flatMap { tableString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(tableString))
-            .map(IndexTable(tableString, _))
-        }
+      tablesFrom(tableInfosFrom(preAnalyze), fromTableFrom) ++
+        tablesFrom(lookupTableInfosFrom(preAnalyze), lookupJoinTableFrom)
     }
 
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+    private def tablesFrom(tableInfos: List[Any], tableFrom: String => Option[EsqlIndexTable]): List[EsqlIndexTable] = {
+      tableInfos
+        .map(tableIdentifierFrom)
+        .map(indexStringFrom)
+        .flatMap(tableFrom)
+    }
+
+    private def fromTableFrom(tableString: String): Option[EsqlIndexTable] = {
+      NonEmptyList.fromList(splitIntoIndices(tableString)).map(EsqlIndexTable.From(tableString, _))
+    }
+
+    private def lookupJoinTableFrom(tableString: String): Option[EsqlIndexTable] = {
+      NonEmptyList
+        .fromList(splitIntoIndices(tableString))
+        .map(indices => EsqlIndexTable.LookupJoin(tableString, indices.head))
+    }
+
+    private def splitIntoIndices(tableString: String): List[IndexName] = {
+      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -191,6 +188,10 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       on(preAnalysis).get[java.util.List[Any]]("indices").asScala.toList
     }
 
+    private def lookupTableInfosFrom(preAnalysis: Any) = {
+      Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+    }
+
     private def tableIdentifierFrom(tableInfo: Any) = {
       on(tableInfo).call("id").get[Any]()
     }
@@ -202,7 +203,7 @@ class EsqlRequestHelper(esVersion: EsVersion) {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -303,14 +304,17 @@ class EsqlRequestHelper(esVersion: EsVersion) {
 
 object EsqlRequestHelper {
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
+        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
+        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
+      }
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -79,7 +79,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -98,7 +98,7 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
       tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,13 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
-import tech.beshu.ror.es.EsqlQueryRewriteResult
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -75,16 +79,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
-          case EsqlQueryRewriteResult.Rewritten(_) =>
-            updatedRequest(request, filter, fieldLevelSecurity)
-          case EsqlQueryRewriteResult.CannotRewriteQuery =>
-            logger.warn(
-              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
-                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
-            )
-            ModificationResult.ShouldBeInterrupted
-        }
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -98,6 +93,25 @@ class EsqlIndicesEsRequestContext private (
           s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
             "unknown. The request will be rejected. Cause:",
           ex
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[EsqlIndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
         )
         ModificationResult.ShouldBeInterrupted
     }

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,6 +29,7 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlQueryRewriteResult
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
@@ -71,37 +72,34 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices) match {
-      case Some(_) =>
-        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-        applyFilterTo(request, filter)
-        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-      case None =>
-        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
-        ModificationResult.ShouldBeInterrupted
-    }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        Some(request)
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
-        } else {
-          Some(request)
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+          case EsqlQueryRewriteResult.Rewritten(_) =>
+            updatedRequest(request, filter, fieldLevelSecurity)
+          case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            ModificationResult.ShouldBeInterrupted
         }
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        Some(request)
+        updatedRequest(request, filter, fieldLevelSecurity)
     }
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -59,7 +59,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -85,8 +85,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
         request
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
+        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -61,7 +61,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.requestedIndices
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -79,6 +79,10 @@ class EsqlIndicesEsRequestContext private (
           case EsqlQueryRewriteResult.Rewritten(_) =>
             updatedRequest(request, filter, fieldLevelSecurity)
           case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            logger.warn(
+              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
+                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
+            )
             ModificationResult.ShouldBeInterrupted
         }
       case Right(_) =>
@@ -89,6 +93,13 @@ class EsqlIndicesEsRequestContext private (
           ex
         )
         updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
   }
 

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -71,31 +71,36 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+    modifyRequestIndices(request, filteredRequestedIndices) match {
+      case Some(_) =>
+        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+        applyFilterTo(request, filter)
+        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+      case None =>
+        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def modifyRequestIndices(
       request: ActionRequest with CompositeIndicesRequest,
       filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
+  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
+        Some(request)
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
-          request
+          Some(request)
         }
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        Some(request)
     }
   }
 

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -87,7 +87,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
         if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
+          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request
         }

--- a/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -41,8 +41,10 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
+  ): Option[CompositeIndicesRequest] = {
+    EsqlIndexTable
+      .newQueryFrom(getQuery(request), requestTables, finalIndices)
+      .map(setQuery(request, _))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -136,7 +138,7 @@ object EsqlRequestHelper {
     }
 
     private def lookupTableInfosFrom(preAnalysis: Any) = {
-      Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+      on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList
     }
 
     private def tableIdentifierFrom(tableInfo: Any) = {

--- a/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -96,11 +96,18 @@ object EsqlRequestHelper {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -270,6 +277,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -37,10 +39,11 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -78,22 +81,6 @@ object EsqlRequestHelper {
     on(request).call("params").get[AnyRef]
   }
 
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
-  }
-
   private final class EsqlParser(
       implicit classLoader: ClassLoader
   ) {
@@ -124,19 +111,29 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val tableInfoList = tableInfosFrom(preAnalyze)
-      tableInfoList
-        .map(tableIdentifierFrom)
-        .map(indexStringFrom)
-        .flatMap { tableString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(tableString))
-            .map(IndexTable(tableString, _))
-        }
+      tablesFrom(tableInfosFrom(preAnalyze), fromTableFrom) ++
+        tablesFrom(lookupTableInfosFrom(preAnalyze), lookupJoinTableFrom)
     }
 
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+    private def tablesFrom(tableInfos: List[Any], tableFrom: String => Option[EsqlIndexTable]): List[EsqlIndexTable] = {
+      tableInfos
+        .map(tableIdentifierFrom)
+        .map(indexStringFrom)
+        .flatMap(tableFrom)
+    }
+
+    private def fromTableFrom(tableString: String): Option[EsqlIndexTable] = {
+      NonEmptyList.fromList(splitIntoIndices(tableString)).map(EsqlIndexTable.From(tableString, _))
+    }
+
+    private def lookupJoinTableFrom(tableString: String): Option[EsqlIndexTable] = {
+      NonEmptyList
+        .fromList(splitIntoIndices(tableString))
+        .map(indices => EsqlIndexTable.LookupJoin(tableString, indices.head))
+    }
+
+    private def splitIntoIndices(tableString: String): List[IndexName] = {
+      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -153,6 +150,10 @@ object EsqlRequestHelper {
       on(preAnalysis).get[java.util.List[Any]]("indices").asScala.toList
     }
 
+    private def lookupTableInfosFrom(preAnalysis: Any) = {
+      Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+    }
+
     private def tableIdentifierFrom(tableInfo: Any) = {
       on(tableInfo).call("id").get[Any]()
     }
@@ -164,7 +165,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -261,14 +262,17 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
+        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
+        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
+      }
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification

--- a/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -24,9 +24,9 @@ import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
-import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
@@ -41,10 +41,14 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
-    EsqlIndexTable
-      .newQueryFrom(getQuery(request), requestTables, finalIndices)
-      .map(setQuery(request, _))
+  ): EsqlQueryRewriteResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        rewritten
+      case EsqlQueryRewriteResult.CannotRewriteQuery =>
+        EsqlQueryRewriteResult.CannotRewriteQuery
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(

--- a/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,7 +23,7 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
-import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
@@ -42,8 +42,7 @@ object EsqlRequestHelper {
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -111,8 +110,8 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      tablesFrom(tableInfosFrom(preAnalyze), fromTableFrom) ++
-        tablesFrom(lookupTableInfosFrom(preAnalyze), lookupJoinTableFrom)
+      tablesFrom(tableInfosFrom(preAnalyze), EsqlIndexTable.From.parse) ++
+        tablesFrom(lookupTableInfosFrom(preAnalyze), EsqlIndexTable.LookupJoin.parse)
     }
 
     private def tablesFrom(tableInfos: List[Any], tableFrom: String => Option[EsqlIndexTable]): List[EsqlIndexTable] = {
@@ -120,20 +119,6 @@ object EsqlRequestHelper {
         .map(tableIdentifierFrom)
         .map(indexStringFrom)
         .flatMap(tableFrom)
-    }
-
-    private def fromTableFrom(tableString: String): Option[EsqlIndexTable] = {
-      NonEmptyList.fromList(splitIntoIndices(tableString)).map(EsqlIndexTable.From(tableString, _))
-    }
-
-    private def lookupJoinTableFrom(tableString: String): Option[EsqlIndexTable] = {
-      NonEmptyList
-        .fromList(splitIntoIndices(tableString))
-        .map(indices => EsqlIndexTable.LookupJoin(tableString, indices.head))
-    }
-
-    private def splitIntoIndices(tableString: String): List[IndexName] = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -268,10 +253,7 @@ object EsqlRequestHelper {
 
     final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
 
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
-        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
-        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
-      }
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
 
     }
 

--- a/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -41,13 +41,13 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): EsqlQueryRewriteResult = {
+  ): IndicesModificationResult = {
     EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
-      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
         setQuery(request, newQuery)
-        rewritten
-      case EsqlQueryRewriteResult.CannotRewriteQuery =>
-        EsqlQueryRewriteResult.CannotRewriteQuery
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
     }
   }
 
@@ -278,6 +278,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -79,7 +79,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -98,7 +98,7 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
       tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],

--- a/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,13 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
-import tech.beshu.ror.es.EsqlQueryRewriteResult
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -75,16 +79,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
-          case EsqlQueryRewriteResult.Rewritten(_) =>
-            updatedRequest(request, filter, fieldLevelSecurity)
-          case EsqlQueryRewriteResult.CannotRewriteQuery =>
-            logger.warn(
-              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
-                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
-            )
-            ModificationResult.ShouldBeInterrupted
-        }
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -98,6 +93,25 @@ class EsqlIndicesEsRequestContext private (
           s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
             "unknown. The request will be rejected. Cause:",
           ex
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[EsqlIndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
         )
         ModificationResult.ShouldBeInterrupted
     }

--- a/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,6 +29,7 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlQueryRewriteResult
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
@@ -71,37 +72,34 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices) match {
-      case Some(_) =>
-        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-        applyFilterTo(request, filter)
-        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-      case None =>
-        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
-        ModificationResult.ShouldBeInterrupted
-    }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        Some(request)
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
-        } else {
-          Some(request)
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+          case EsqlQueryRewriteResult.Rewritten(_) =>
+            updatedRequest(request, filter, fieldLevelSecurity)
+          case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            ModificationResult.ShouldBeInterrupted
         }
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        Some(request)
+        updatedRequest(request, filter, fieldLevelSecurity)
     }
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -59,7 +59,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -85,8 +85,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
         request
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
+        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request

--- a/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -61,7 +61,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.requestedIndices
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -79,6 +79,10 @@ class EsqlIndicesEsRequestContext private (
           case EsqlQueryRewriteResult.Rewritten(_) =>
             updatedRequest(request, filter, fieldLevelSecurity)
           case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            logger.warn(
+              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
+                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
+            )
             ModificationResult.ShouldBeInterrupted
         }
       case Right(_) =>
@@ -89,6 +93,13 @@ class EsqlIndicesEsRequestContext private (
           ex
         )
         updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
   }
 

--- a/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -71,31 +71,36 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+    modifyRequestIndices(request, filteredRequestedIndices) match {
+      case Some(_) =>
+        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+        applyFilterTo(request, filter)
+        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+      case None =>
+        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def modifyRequestIndices(
       request: ActionRequest with CompositeIndicesRequest,
       filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
+  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
+        Some(request)
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
-          request
+          Some(request)
         }
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        Some(request)
     }
   }
 

--- a/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -87,7 +87,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
         if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
+          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request
         }

--- a/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.time.ZoneOffset
-import java.util.regex.Pattern
 import java.util.{List as JList, Locale}
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
@@ -38,10 +40,11 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -99,22 +102,6 @@ object EsqlRequestHelper {
       .get[AnyRef]()
   }
 
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
-  }
-
   private final class EsqlParser(
       implicit classLoader: ClassLoader
   ) {
@@ -146,18 +133,31 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      val indexPatterns = indexPatternsFrom(preAnalyze)
-      indexPatterns
-        .map(indexPatternStringFrom)
-        .flatMap { indexPatternString =>
-          NonEmptyList
-            .fromList(splitIntoIndices(indexPatternString))
-            .map(IndexTable(indexPatternString, _))
-        }
+      tablesFrom(indexPatternsFrom(preAnalyze), fromTableFrom) ++
+        tablesFrom(lookupIndexPatternsFrom(preAnalyze), lookupJoinTableFrom)
     }
 
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+    private def tablesFrom(
+        indexPatterns: List[Any],
+        tableFrom: String => Option[EsqlIndexTable]
+    ): List[EsqlIndexTable] = {
+      indexPatterns
+        .map(indexPatternStringFrom)
+        .flatMap(tableFrom)
+    }
+
+    private def fromTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
+      NonEmptyList.fromList(splitIntoIndices(indexPatternString)).map(EsqlIndexTable.From(indexPatternString, _))
+    }
+
+    private def lookupJoinTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
+      NonEmptyList
+        .fromList(splitIntoIndices(indexPatternString))
+        .map(indices => EsqlIndexTable.LookupJoin(indexPatternString, indices.head))
+    }
+
+    private def splitIntoIndices(tableString: String): List[IndexName] = {
+      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -174,6 +174,10 @@ object EsqlRequestHelper {
       on(preAnalysis).get[java.util.List[Any]]("indices").asScala.toList
     }
 
+    private def lookupIndexPatternsFrom(preAnalysis: Any) = {
+      Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+    }
+
     private def indexPatternStringFrom(indexPattern: Any) = {
       on(indexPattern).call("indexPattern").get[String]()
     }
@@ -181,7 +185,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -278,14 +282,17 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
+        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
+        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
+      }
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification

--- a/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -24,9 +24,9 @@ import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
-import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
@@ -42,10 +42,14 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
-    EsqlIndexTable
-      .newQueryFrom(getQuery(request), requestTables, finalIndices)
-      .map(setQuery(request, _))
+  ): EsqlQueryRewriteResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        rewritten
+      case EsqlQueryRewriteResult.CannotRewriteQuery =>
+        EsqlQueryRewriteResult.CannotRewriteQuery
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(

--- a/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -117,11 +117,18 @@ object EsqlRequestHelper {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -290,6 +297,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -42,8 +42,10 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
+  ): Option[CompositeIndicesRequest] = {
+    EsqlIndexTable
+      .newQueryFrom(getQuery(request), requestTables, finalIndices)
+      .map(setQuery(request, _))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -160,7 +162,7 @@ object EsqlRequestHelper {
     }
 
     private def lookupIndexPatternsFrom(preAnalysis: Any) = {
-      Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+      on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList
     }
 
     private def indexPatternStringFrom(indexPattern: Any) = {

--- a/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,7 +23,7 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
-import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
@@ -43,8 +43,7 @@ object EsqlRequestHelper {
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -133,8 +132,8 @@ object EsqlRequestHelper {
 
     private def indicesFrom(statement: Any) = {
       val preAnalyze = doPreAnalyze(newPreAnalyzer, statement)
-      tablesFrom(indexPatternsFrom(preAnalyze), fromTableFrom) ++
-        tablesFrom(lookupIndexPatternsFrom(preAnalyze), lookupJoinTableFrom)
+      tablesFrom(indexPatternsFrom(preAnalyze), EsqlIndexTable.From.parse) ++
+        tablesFrom(lookupIndexPatternsFrom(preAnalyze), EsqlIndexTable.LookupJoin.parse)
     }
 
     private def tablesFrom(
@@ -144,20 +143,6 @@ object EsqlRequestHelper {
       indexPatterns
         .map(indexPatternStringFrom)
         .flatMap(tableFrom)
-    }
-
-    private def fromTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
-      NonEmptyList.fromList(splitIntoIndices(indexPatternString)).map(EsqlIndexTable.From(indexPatternString, _))
-    }
-
-    private def lookupJoinTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
-      NonEmptyList
-        .fromList(splitIntoIndices(indexPatternString))
-        .map(indices => EsqlIndexTable.LookupJoin(indexPatternString, indices.head))
-    }
-
-    private def splitIntoIndices(tableString: String): List[IndexName] = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -288,10 +273,7 @@ object EsqlRequestHelper {
 
     final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
 
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
-        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
-        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
-      }
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
 
     }
 

--- a/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es91x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -42,13 +42,13 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): EsqlQueryRewriteResult = {
+  ): IndicesModificationResult = {
     EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
-      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
         setQuery(request, newQuery)
-        rewritten
-      case EsqlQueryRewriteResult.CannotRewriteQuery =>
-        EsqlQueryRewriteResult.CannotRewriteQuery
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
     }
   }
 
@@ -298,6 +298,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,6 +29,7 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlQueryRewriteResult
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
@@ -72,37 +73,34 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices) match {
-      case Some(_) =>
-        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-        applyFilterTo(request, filter)
-        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-      case None =>
-        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
-        ModificationResult.ShouldBeInterrupted
-    }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        Some(request)
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
-          esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
-        } else {
-          Some(request)
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        esqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+          case EsqlQueryRewriteResult.Rewritten(_) =>
+            updatedRequest(request, filter, fieldLevelSecurity)
+          case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            ModificationResult.ShouldBeInterrupted
         }
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        Some(request)
+        updatedRequest(request, filter, fieldLevelSecurity)
     }
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -72,31 +72,36 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+    modifyRequestIndices(request, filteredRequestedIndices) match {
+      case Some(_) =>
+        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+        applyFilterTo(request, filter)
+        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+      case None =>
+        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def modifyRequestIndices(
       request: ActionRequest with CompositeIndicesRequest,
       filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
+  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
+        Some(request)
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
-          request
+          Some(request)
         }
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        Some(request)
     }
   }
 

--- a/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -88,7 +88,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
         if (filteredIndicesStrings != r.indices) {
-          esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
+          esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request
         }

--- a/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -62,7 +62,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.requestedIndices
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -80,6 +80,10 @@ class EsqlIndicesEsRequestContext private (
           case EsqlQueryRewriteResult.Rewritten(_) =>
             updatedRequest(request, filter, fieldLevelSecurity)
           case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            logger.warn(
+              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
+                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
+            )
             ModificationResult.ShouldBeInterrupted
         }
       case Right(_) =>
@@ -90,6 +94,13 @@ class EsqlIndicesEsRequestContext private (
           ex
         )
         updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
   }
 

--- a/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -60,7 +60,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -86,8 +86,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
         request
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
+        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           esqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request

--- a/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,13 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
-import tech.beshu.ror.es.EsqlQueryRewriteResult
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -76,16 +80,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        esqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
-          case EsqlQueryRewriteResult.Rewritten(_) =>
-            updatedRequest(request, filter, fieldLevelSecurity)
-          case EsqlQueryRewriteResult.CannotRewriteQuery =>
-            logger.warn(
-              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
-                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
-            )
-            ModificationResult.ShouldBeInterrupted
-        }
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -99,6 +94,25 @@ class EsqlIndicesEsRequestContext private (
           s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
             "unknown. The request will be rejected. Cause:",
           ex
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[EsqlIndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    esqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
         )
         ModificationResult.ShouldBeInterrupted
     }

--- a/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -80,7 +80,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -99,7 +99,7 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
       tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],

--- a/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,15 +23,17 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
 import tech.beshu.ror.es.EsVersion
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification, IndexTable}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -39,10 +41,11 @@ class EsqlRequestHelper(esVersion: EsVersion) {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -78,22 +81,6 @@ class EsqlRequestHelper(esVersion: EsVersion) {
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
     on(request).call("params").get[AnyRef]
-  }
-
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
   }
 
   private final class EsqlParser(
@@ -139,24 +126,40 @@ class EsqlRequestHelper(esVersion: EsVersion) {
     private def indicesFromPreAnalysisForEsBelow930(preAnalysis: Any) = {
       val indexPattern = indexPatternFrom(preAnalysis)
       val indexPatternString = indexPatternStringFrom(indexPattern)
-      NonEmptyList
-        .fromList(splitIntoIndices(indexPatternString))
-        .map(IndexTable(indexPatternString, _))
-        .toList
+      val fromTables = fromTableFrom(indexPatternString).toList
+      fromTables ++ lookupTablesFrom(preAnalysis)
     }
 
     private def indicesFromPreAnalysisForEsEqualOrAbove930(preAnalysis: Any) = {
       val indexesMap = on(preAnalysis).get[java.util.Map[Any, Any]]("indexes")
-      indexesMap.keySet().asScala.toList.flatMap { indexPattern =>
+      val fromTables = indexesMap.keySet().asScala.toList.flatMap { indexPattern =>
         val indexPatternString = on(indexPattern).call("indexPattern").get[String]()
-        NonEmptyList
-          .fromList(splitIntoIndices(indexPatternString))
-          .map(IndexTable(indexPatternString, _))
+        fromTableFrom(indexPatternString)
+      }
+      fromTables ++ lookupTablesFrom(preAnalysis)
+    }
+
+    private def lookupTablesFrom(preAnalysis: Any): List[EsqlIndexTable] = {
+      val lookupIndexPatterns =
+        Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+      lookupIndexPatterns.flatMap { indexPattern =>
+        val indexPatternString = on(indexPattern).call("indexPattern").get[String]()
+        lookupJoinTableFrom(indexPatternString)
       }
     }
 
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+    private def fromTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
+      NonEmptyList.fromList(splitIntoIndices(indexPatternString)).map(EsqlIndexTable.From(indexPatternString, _))
+    }
+
+    private def lookupJoinTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
+      NonEmptyList
+        .fromList(splitIntoIndices(indexPatternString))
+        .map(indices => EsqlIndexTable.LookupJoin(indexPatternString, indices.head))
+    }
+
+    private def splitIntoIndices(tableString: String): List[IndexName] = {
+      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -180,7 +183,7 @@ class EsqlRequestHelper(esVersion: EsVersion) {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -281,14 +284,17 @@ class EsqlRequestHelper(esVersion: EsVersion) {
 
 object EsqlRequestHelper {
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
+        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
+        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
+      }
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification

--- a/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -27,7 +27,11 @@ import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsVersion
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
@@ -43,13 +47,13 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): EsqlQueryRewriteResult = {
+  ): IndicesModificationResult = {
     EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
-      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
         setQuery(request, newQuery)
-        rewritten
-      case EsqlQueryRewriteResult.CannotRewriteQuery =>
-        EsqlQueryRewriteResult.CannotRewriteQuery
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
     }
   }
 
@@ -300,6 +304,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -98,11 +98,18 @@ class EsqlRequestHelper(esVersion: EsVersion) {
         .get[Any]()
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -292,6 +299,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -43,8 +43,10 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
+  ): Option[CompositeIndicesRequest] = {
+    EsqlIndexTable
+      .newQueryFrom(getQuery(request), requestTables, finalIndices)
+      .map(setQuery(request, _))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -140,7 +142,7 @@ class EsqlRequestHelper(esVersion: EsVersion) {
 
     private def lookupTablesFrom(preAnalysis: Any): List[EsqlIndexTable] = {
       val lookupIndexPatterns =
-        Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+        on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList
       lookupIndexPatterns.flatMap { indexPattern =>
         val indexPatternString = on(indexPattern).call("indexPattern").get[String]()
         EsqlIndexTable.LookupJoin.parse(indexPatternString)

--- a/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,7 +23,7 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
-import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsVersion
 import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
@@ -44,8 +44,7 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -126,7 +125,7 @@ class EsqlRequestHelper(esVersion: EsVersion) {
     private def indicesFromPreAnalysisForEsBelow930(preAnalysis: Any) = {
       val indexPattern = indexPatternFrom(preAnalysis)
       val indexPatternString = indexPatternStringFrom(indexPattern)
-      val fromTables = fromTableFrom(indexPatternString).toList
+      val fromTables = EsqlIndexTable.From.parse(indexPatternString).toList
       fromTables ++ lookupTablesFrom(preAnalysis)
     }
 
@@ -134,7 +133,7 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       val indexesMap = on(preAnalysis).get[java.util.Map[Any, Any]]("indexes")
       val fromTables = indexesMap.keySet().asScala.toList.flatMap { indexPattern =>
         val indexPatternString = on(indexPattern).call("indexPattern").get[String]()
-        fromTableFrom(indexPatternString)
+        EsqlIndexTable.From.parse(indexPatternString)
       }
       fromTables ++ lookupTablesFrom(preAnalysis)
     }
@@ -144,22 +143,8 @@ class EsqlRequestHelper(esVersion: EsVersion) {
         Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
       lookupIndexPatterns.flatMap { indexPattern =>
         val indexPatternString = on(indexPattern).call("indexPattern").get[String]()
-        lookupJoinTableFrom(indexPatternString)
+        EsqlIndexTable.LookupJoin.parse(indexPatternString)
       }
-    }
-
-    private def fromTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
-      NonEmptyList.fromList(splitIntoIndices(indexPatternString)).map(EsqlIndexTable.From(indexPatternString, _))
-    }
-
-    private def lookupJoinTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
-      NonEmptyList
-        .fromList(splitIntoIndices(indexPatternString))
-        .map(indices => EsqlIndexTable.LookupJoin(indexPatternString, indices.head))
-    }
-
-    private def splitIntoIndices(tableString: String): List[IndexName] = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -290,10 +275,7 @@ object EsqlRequestHelper {
 
     final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
 
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
-        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
-        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
-      }
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
 
     }
 

--- a/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es92x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -25,10 +25,10 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsVersion
-import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
 import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
@@ -43,10 +43,14 @@ class EsqlRequestHelper(esVersion: EsVersion) {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
-    EsqlIndexTable
-      .newQueryFrom(getQuery(request), requestTables, finalIndices)
-      .map(setQuery(request, _))
+  ): EsqlQueryRewriteResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        rewritten
+      case EsqlQueryRewriteResult.CannotRewriteQuery =>
+        EsqlQueryRewriteResult.CannotRewriteQuery
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(

--- a/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -79,7 +79,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
+        updatedRequestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -98,7 +98,7 @@ class EsqlIndicesEsRequestContext private (
     }
   }
 
-  private def requestWithIndicesNarrowedTo(
+  private def updatedRequestWithIndicesNarrowedTo(
       request: ActionRequest with CompositeIndicesRequest,
       tables: NonEmptyList[EsqlIndexTable],
       filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],

--- a/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,13 +29,17 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
-import tech.beshu.ror.es.EsqlQueryRewriteResult
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
 import tech.beshu.ror.es.handler.response.FLSContextHeaderHandler
 import tech.beshu.ror.es.utils.EsqlRequestHelper
-import tech.beshu.ror.es.utils.EsqlRequestHelper.{ClassificationError, EsqlRequestClassification}
+import tech.beshu.ror.es.utils.EsqlRequestHelper.{
+  ClassificationError,
+  EsqlRequestClassification,
+  IndicesModificationResult
+}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 
@@ -75,16 +79,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
           if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
-        EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
-          case EsqlQueryRewriteResult.Rewritten(_) =>
-            updatedRequest(request, filter, fieldLevelSecurity)
-          case EsqlQueryRewriteResult.CannotRewriteQuery =>
-            logger.warn(
-              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
-                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
-            )
-            ModificationResult.ShouldBeInterrupted
-        }
+        requestWithIndicesNarrowedTo(request, tables, filteredRequestedIndices, filter, fieldLevelSecurity)
       case Right(_) =>
         updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
@@ -98,6 +93,25 @@ class EsqlIndicesEsRequestContext private (
           s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
             "unknown. The request will be rejected. Cause:",
           ex
+        )
+        ModificationResult.ShouldBeInterrupted
+    }
+  }
+
+  private def requestWithIndicesNarrowedTo(
+      request: ActionRequest with CompositeIndicesRequest,
+      tables: NonEmptyList[EsqlIndexTable],
+      filteredRequestedIndices: NonEmptyList[RequestedIndex[ClusterIndexName]],
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+      case IndicesModificationResult.IndicesModified =>
+        updatedRequest(request, filter, fieldLevelSecurity)
+      case IndicesModificationResult.CannotModifyIndices(reason) =>
+        logger.warn(
+          s"[${id.show}] The ESQL query cannot be narrowed down to [${filteredRequestedIndices.show}], because " +
+            s"$reason. The request will be rejected."
         )
         ModificationResult.ShouldBeInterrupted
     }

--- a/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -29,6 +29,7 @@ import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.Strategy.{
   FlsAtLuceneLevelApproach
 }
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, FieldLevelSecurity, Filter, RequestedIndex}
+import tech.beshu.ror.es.EsqlQueryRewriteResult
 import tech.beshu.ror.es.handler.AclAwareRequestFilter.EsContext
 import tech.beshu.ror.es.handler.request.context.ModificationResult
 import tech.beshu.ror.es.handler.request.context.ModificationResult.UpdateResponse
@@ -71,37 +72,34 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices) match {
-      case Some(_) =>
-        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-        applyFilterTo(request, filter)
-        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
-      case None =>
-        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
-        ModificationResult.ShouldBeInterrupted
-    }
-  }
-
-  private def modifyRequestIndices(
-      request: ActionRequest with CompositeIndicesRequest,
-      filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
-      case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        Some(request)
-      case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
-        } else {
-          Some(request)
+      case Right(r @ EsqlRequestClassification.IndicesRelated(tables))
+          if filteredRequestedIndices.toList.toCovariantSet != r.requestedIndices =>
+        EsqlRequestHelper.modifyIndicesOf(request, tables, filteredRequestedIndices) match {
+          case EsqlQueryRewriteResult.Rewritten(_) =>
+            updatedRequest(request, filter, fieldLevelSecurity)
+          case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            ModificationResult.ShouldBeInterrupted
         }
+      case Right(_) =>
+        updatedRequest(request, filter, fieldLevelSecurity)
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        Some(request)
+        updatedRequest(request, filter, fieldLevelSecurity)
     }
+  }
+
+  private def updatedRequest(
+      request: ActionRequest with CompositeIndicesRequest,
+      filter: Option[Filter],
+      fieldLevelSecurity: Option[FieldLevelSecurity]
+  ): ModificationResult = {
+    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+    applyFilterTo(request, filter)
+    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
   }
 
   private def applyFieldLevelSecurityTo(

--- a/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -59,7 +59,7 @@ class EsqlIndicesEsRequestContext private (
   ): Set[RequestedIndex[ClusterIndexName]] = {
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
-        r.indices.flatMap(RequestedIndex.fromString)
+        r.requestedIndices
       case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
@@ -85,8 +85,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
         request
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
-        val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
-        if (filteredIndicesStrings != r.indices) {
+        if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request

--- a/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -61,7 +61,7 @@ class EsqlIndicesEsRequestContext private (
     requestClassification match {
       case Right(r @ EsqlRequestClassification.IndicesRelated(_)) =>
         r.requestedIndices
-      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(ClassificationError.ParsingException(_)) =>
+      case Right(EsqlRequestClassification.NonIndicesRelated) | Left(_) =>
         Set(RequestedIndex(ClusterIndexName.Local.wildcard, excluded = false))
     }
   }
@@ -79,6 +79,10 @@ class EsqlIndicesEsRequestContext private (
           case EsqlQueryRewriteResult.Rewritten(_) =>
             updatedRequest(request, filter, fieldLevelSecurity)
           case EsqlQueryRewriteResult.CannotRewriteQuery =>
+            logger.warn(
+              s"[${id.show}] Cannot unambiguously locate tables [${tables.show}] in the ESQL query text, so the " +
+                s"query cannot be narrowed down to [${filteredRequestedIndices.show}]. The request will be rejected."
+            )
             ModificationResult.ShouldBeInterrupted
         }
       case Right(_) =>
@@ -89,6 +93,13 @@ class EsqlIndicesEsRequestContext private (
           ex
         )
         updatedRequest(request, filter, fieldLevelSecurity)
+      case Left(ClassificationError.IndicesExtractionException(ex)) =>
+        logger.warn(
+          s"[${id.show}] Cannot read the tables of the parsed ESQL statement - the indices it touches are " +
+            "unknown. The request will be rejected. Cause:",
+          ex
+        )
+        ModificationResult.ShouldBeInterrupted
     }
   }
 

--- a/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -71,31 +71,36 @@ class EsqlIndicesEsRequestContext private (
       filter: Option[Filter],
       fieldLevelSecurity: Option[FieldLevelSecurity]
   ): ModificationResult = {
-    modifyRequestIndices(request, filteredRequestedIndices)
-    applyFieldLevelSecurityTo(request, fieldLevelSecurity)
-    applyFilterTo(request, filter)
-    UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+    modifyRequestIndices(request, filteredRequestedIndices) match {
+      case Some(_) =>
+        applyFieldLevelSecurityTo(request, fieldLevelSecurity)
+        applyFilterTo(request, filter)
+        UpdateResponse.sync { response => applyFieldLevelSecurityTo(response, fieldLevelSecurity) }
+      case None =>
+        logger.debug("Cannot narrow the indices of the ESQL query - the request is going to be rejected")
+        ModificationResult.ShouldBeInterrupted
+    }
   }
 
   private def modifyRequestIndices(
       request: ActionRequest with CompositeIndicesRequest,
       filteredIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
+  ): Option[CompositeIndicesRequest] = {
     requestClassification match {
       case Right(EsqlRequestClassification.NonIndicesRelated) =>
-        request
+        Some(request)
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         if (filteredIndices.toList.toCovariantSet != r.requestedIndices) {
           EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
-          request
+          Some(request)
         }
       case Left(ClassificationError.ParsingException(ex)) =>
         logger.debug(
           s"Cannot parse ESQL statement - we can pass it though, because ES is going to reject it. Cause:",
           ex
         )
-        request
+        Some(request)
     }
   }
 

--- a/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/EsqlIndicesEsRequestContext.scala
@@ -87,7 +87,7 @@ class EsqlIndicesEsRequestContext private (
       case Right(r @ EsqlRequestClassification.IndicesRelated(tables)) =>
         val filteredIndicesStrings = filteredIndices.stringify.toCovariantSet
         if (filteredIndicesStrings != r.indices) {
-          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndicesStrings)
+          EsqlRequestHelper.modifyIndicesOf(request, tables, filteredIndices)
         } else {
           request
         }

--- a/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,13 +23,15 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
 
 import java.util.List as JList
-import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
@@ -37,10 +39,11 @@ object EsqlRequestHelper {
 
   def modifyIndicesOf(
       request: CompositeIndicesRequest,
-      requestTables: NonEmptyList[IndexTable],
-      finalIndices: Set[String]
+      requestTables: NonEmptyList[EsqlIndexTable],
+      finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    setQuery(request, newQueryFrom(getQuery(request), requestTables, finalIndices))
+    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -76,22 +79,6 @@ object EsqlRequestHelper {
 
   private def getParams(request: CompositeIndicesRequest): AnyRef = {
     on(request).call("params").get[AnyRef]
-  }
-
-  private def newQueryFrom(oldQuery: String, requestTables: NonEmptyList[IndexTable], finalIndices: Set[String]) = {
-    requestTables.toList.foldLeft(oldQuery) { case (currentQuery, table) =>
-      val (beforeFrom, afterFrom) = currentQuery.splitBy("FROM")
-      afterFrom match {
-        case None =>
-          replaceTableNameInQueryPart(currentQuery, table.tableStringInQuery, finalIndices)
-        case Some(tablesPart) =>
-          s"${beforeFrom}FROM ${replaceTableNameInQueryPart(tablesPart, table.tableStringInQuery, finalIndices)}"
-      }
-    }
-  }
-
-  private def replaceTableNameInQueryPart(currentQuery: String, originTable: String, finalIndices: Set[String]) = {
-    currentQuery.replaceAll(Pattern.quote(originTable), finalIndices.mkString(","))
   }
 
   private final class EsqlParser(
@@ -135,17 +122,35 @@ object EsqlRequestHelper {
     }
 
     private def indicesFromPreAnalysis(preAnalysis: Any) = {
-      val indexesMap = on(preAnalysis).get[java.util.Map[Any, Any]]("indexes")
-      indexesMap.keySet().asScala.toList.flatMap { indexPattern =>
+      val fromIndexPatterns = on(preAnalysis).get[java.util.Map[Any, Any]]("indexes").keySet().asScala.toList
+      val lookupIndexPatterns =
+        Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+      tablesFrom(fromIndexPatterns, fromTableFrom) ++
+        tablesFrom(lookupIndexPatterns, lookupJoinTableFrom)
+    }
+
+    private def tablesFrom(
+        indexPatterns: List[Any],
+        tableFrom: String => Option[EsqlIndexTable]
+    ): List[EsqlIndexTable] = {
+      indexPatterns.flatMap { indexPattern =>
         val indexPatternString = on(indexPattern).call("indexPattern").get[String]()
-        NonEmptyList
-          .fromList(splitIntoIndices(indexPatternString))
-          .map(IndexTable(indexPatternString, _))
+        tableFrom(indexPatternString)
       }
     }
 
-    private def splitIntoIndices(tableString: String) = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty)
+    private def fromTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
+      NonEmptyList.fromList(splitIntoIndices(indexPatternString)).map(EsqlIndexTable.From(indexPatternString, _))
+    }
+
+    private def lookupJoinTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
+      NonEmptyList
+        .fromList(splitIntoIndices(indexPatternString))
+        .map(indices => EsqlIndexTable.LookupJoin(indexPatternString, indices.head))
+    }
+
+    private def splitIntoIndices(tableString: String): List[IndexName] = {
+      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -161,7 +166,7 @@ object EsqlRequestHelper {
   }
 
   private sealed trait Statement
-  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[IndexTable])
+  private final class IndicesRelatedStatement(val underlyingObject: Any, val indices: NonEmptyList[EsqlIndexTable])
       extends Statement
 
   private final class OtherCommand(val underlyingObject: Any) extends Statement
@@ -258,14 +263,17 @@ object EsqlRequestHelper {
 
   }
 
-  final case class IndexTable(tableStringInQuery: String, indices: NonEmptyList[String])
-
   sealed trait EsqlRequestClassification
 
   object EsqlRequestClassification {
 
-    final case class IndicesRelated(tables: NonEmptyList[IndexTable]) extends EsqlRequestClassification {
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap(_.indices.toIterable)
+    final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
+
+      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
+        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
+        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
+      }
+
     }
 
     case object NonIndicesRelated extends EsqlRequestClassification

--- a/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -41,13 +41,13 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): EsqlQueryRewriteResult = {
+  ): IndicesModificationResult = {
     EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
-      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+      case EsqlQueryRewriteResult.Rewritten(newQuery) =>
         setQuery(request, newQuery)
-        rewritten
-      case EsqlQueryRewriteResult.CannotRewriteQuery =>
-        EsqlQueryRewriteResult.CannotRewriteQuery
+        IndicesModificationResult.IndicesModified
+      case EsqlQueryRewriteResult.CannotRewriteQuery(reason) =>
+        IndicesModificationResult.CannotModifyIndices(reason)
     }
   }
 
@@ -279,6 +279,13 @@ object EsqlRequestHelper {
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
     final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
+  }
+
+  sealed trait IndicesModificationResult
+
+  object IndicesModificationResult {
+    case object IndicesModified extends IndicesModificationResult
+    final case class CannotModifyIndices(reason: String) extends IndicesModificationResult
   }
 
 }

--- a/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -41,8 +41,10 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): CompositeIndicesRequest = {
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
+  ): Option[CompositeIndicesRequest] = {
+    EsqlIndexTable
+      .newQueryFrom(getQuery(request), requestTables, finalIndices)
+      .map(setQuery(request, _))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -123,7 +125,7 @@ object EsqlRequestHelper {
     private def indicesFromPreAnalysis(preAnalysis: Any) = {
       val fromIndexPatterns = on(preAnalysis).get[java.util.Map[Any, Any]]("indexes").keySet().asScala.toList
       val lookupIndexPatterns =
-        Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
+        on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList
       tablesFrom(fromIndexPatterns, EsqlIndexTable.From.parse) ++
         tablesFrom(lookupIndexPatterns, EsqlIndexTable.LookupJoin.parse)
     }

--- a/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -102,11 +102,18 @@ object EsqlRequestHelper {
     }
 
     def createStatementBasedOn(request: CompositeIndicesRequest): Either[ClassificationError, Statement] = {
-      createStatement(request).map { statement =>
-        NonEmptyList.fromList(indicesFrom(statement)) match {
-          case Some(indices) => new IndicesRelatedStatement(statement, indices)
-          case None          => OtherCommand(statement)
-        }
+      createStatement(request).flatMap(statementWithIndices)
+    }
+
+    private def statementWithIndices(statement: Any): Either[ClassificationError, Statement] = {
+      Try(indicesFrom(statement)) match {
+        case Success(tables) =>
+          Right(NonEmptyList.fromList(tables) match {
+            case Some(indices) => new IndicesRelatedStatement(statement, indices)
+            case None          => OtherCommand(statement)
+          })
+        case Failure(ex) =>
+          Left(ClassificationError.IndicesExtractionException(ex))
       }
     }
 
@@ -271,6 +278,7 @@ object EsqlRequestHelper {
 
   object ClassificationError {
     final case class ParsingException(cause: Throwable) extends ClassificationError
+    final case class IndicesExtractionException(cause: Throwable) extends ClassificationError
   }
 
 }

--- a/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -24,9 +24,9 @@ import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
 import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
-import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
+import tech.beshu.ror.es.{EsqlIndexTable, EsqlQueryRewriteResult}
 import tech.beshu.ror.implicits.*
 import tech.beshu.ror.syntax.*
 import tech.beshu.ror.utils.ScalaOps.*
@@ -41,10 +41,14 @@ object EsqlRequestHelper {
       request: CompositeIndicesRequest,
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
-  ): Option[CompositeIndicesRequest] = {
-    EsqlIndexTable
-      .newQueryFrom(getQuery(request), requestTables, finalIndices)
-      .map(setQuery(request, _))
+  ): EsqlQueryRewriteResult = {
+    EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices) match {
+      case rewritten @ EsqlQueryRewriteResult.Rewritten(newQuery) =>
+        setQuery(request, newQuery)
+        rewritten
+      case EsqlQueryRewriteResult.CannotRewriteQuery =>
+        EsqlQueryRewriteResult.CannotRewriteQuery
+    }
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(

--- a/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
+++ b/es94x/src/main/scala/tech/beshu/ror/es/utils/EsqlRequestHelper.scala
@@ -23,7 +23,7 @@ import org.joor.Reflect.*
 import org.joor.ReflectException
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity
 import tech.beshu.ror.accesscontrol.domain.FieldLevelSecurity.FieldsRestrictions
-import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, IndexName, RequestedIndex}
+import tech.beshu.ror.accesscontrol.domain.{ClusterIndexName, RequestedIndex}
 import tech.beshu.ror.es.EsqlIndexTable
 import tech.beshu.ror.es.handler.response.FieldsFiltering
 import tech.beshu.ror.es.handler.response.FieldsFiltering.NonMetadataDocumentFields
@@ -42,8 +42,7 @@ object EsqlRequestHelper {
       requestTables: NonEmptyList[EsqlIndexTable],
       finalIndices: NonEmptyList[RequestedIndex[ClusterIndexName]]
   ): CompositeIndicesRequest = {
-    val replacements = EsqlIndexTable.buildReplacements(requestTables, finalIndices)
-    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), replacements))
+    setQuery(request, EsqlIndexTable.newQueryFrom(getQuery(request), requestTables, finalIndices))
   }
 
   def modifyResponseAccordingToFieldLevelSecurity(
@@ -125,8 +124,8 @@ object EsqlRequestHelper {
       val fromIndexPatterns = on(preAnalysis).get[java.util.Map[Any, Any]]("indexes").keySet().asScala.toList
       val lookupIndexPatterns =
         Try(on(preAnalysis).get[java.util.List[Any]]("lookupIndices").asScala.toList).getOrElse(List.empty)
-      tablesFrom(fromIndexPatterns, fromTableFrom) ++
-        tablesFrom(lookupIndexPatterns, lookupJoinTableFrom)
+      tablesFrom(fromIndexPatterns, EsqlIndexTable.From.parse) ++
+        tablesFrom(lookupIndexPatterns, EsqlIndexTable.LookupJoin.parse)
     }
 
     private def tablesFrom(
@@ -137,20 +136,6 @@ object EsqlRequestHelper {
         val indexPatternString = on(indexPattern).call("indexPattern").get[String]()
         tableFrom(indexPatternString)
       }
-    }
-
-    private def fromTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
-      NonEmptyList.fromList(splitIntoIndices(indexPatternString)).map(EsqlIndexTable.From(indexPatternString, _))
-    }
-
-    private def lookupJoinTableFrom(indexPatternString: String): Option[EsqlIndexTable] = {
-      NonEmptyList
-        .fromList(splitIntoIndices(indexPatternString))
-        .map(indices => EsqlIndexTable.LookupJoin(indexPatternString, indices.head))
-    }
-
-    private def splitIntoIndices(tableString: String): List[IndexName] = {
-      tableString.split(',').asSafeList.filter(_.nonEmpty).flatMap(IndexName.fromString)
     }
 
     private def newPreAnalyzer(
@@ -269,10 +254,7 @@ object EsqlRequestHelper {
 
     final case class IndicesRelated(tables: NonEmptyList[EsqlIndexTable]) extends EsqlRequestClassification {
 
-      lazy val indices: Set[String] = tables.toCovariantSet.flatMap {
-        case t: EsqlIndexTable.From       => t.indices.toIterable.map(_.show)
-        case t: EsqlIndexTable.LookupJoin => List(t.index.show)
-      }
+      lazy val requestedIndices: Set[RequestedIndex[ClusterIndexName]] = EsqlIndexTable.requestedIndicesOf(tables)
 
     }
 

--- a/integration-tests/src/test/resources/xpack_api/readonlyrest_with_ror_ssl.yml
+++ b/integration-tests/src/test/resources/xpack_api/readonlyrest_with_ror_ssl.yml
@@ -77,6 +77,22 @@ readonlyrest:
       indices: ["bookstore"]
       filter: '{"query_string":{"query":"name:(Dune)"}}'
 
+    - name: "dev4 sql"
+      auth_key: dev4sql:test
+      indices: ["book_catalog"]
+
+    - name: "dev5 sql"
+      auth_key: dev5sql:test
+      indices: ["book_*"]
+
+    - name: "dev6 sql"
+      auth_key: dev6sql:test
+      indices: ["book_prices"]
+
+    - name: "dev7 sql"
+      auth_key: dev7sql:test
+      indices: ["book_catalog", "book_prices"]
+
     - name: "dev7"
       auth_key: dev7:test
       indices: ["test7_*"]

--- a/integration-tests/src/test/resources/xpack_api/readonlyrest_without_ror_ssl.yml
+++ b/integration-tests/src/test/resources/xpack_api/readonlyrest_without_ror_ssl.yml
@@ -64,6 +64,22 @@ readonlyrest:
       indices: ["bookstore"]
       filter: '{"query_string":{"query":"name:(Dune)"}}'
 
+    - name: "dev4 sql"
+      auth_key: dev4sql:test
+      indices: ["book_catalog"]
+
+    - name: "dev5 sql"
+      auth_key: dev5sql:test
+      indices: ["book_*"]
+
+    - name: "dev6 sql"
+      auth_key: dev6sql:test
+      indices: ["book_prices"]
+
+    - name: "dev7 sql"
+      auth_key: dev7sql:test
+      indices: ["book_catalog", "book_prices"]
+
     - name: "dev7"
       auth_key: dev7:test
       indices: ["test7_*"]

--- a/integration-tests/src/test/resources/xpack_api/readonlyrest_without_ror_ssl_es714+.yml
+++ b/integration-tests/src/test/resources/xpack_api/readonlyrest_without_ror_ssl_es714+.yml
@@ -78,6 +78,22 @@ readonlyrest:
       indices: ["bookstore"]
       filter: '{"query_string":{"query":"name:(Dune)"}}'
 
+    - name: "dev4 sql"
+      auth_key: dev4sql:test
+      indices: ["book_catalog"]
+
+    - name: "dev5 sql"
+      auth_key: dev5sql:test
+      indices: ["book_*"]
+
+    - name: "dev6 sql"
+      auth_key: dev6sql:test
+      indices: ["book_prices"]
+
+    - name: "dev7 sql"
+      auth_key: dev7sql:test
+      indices: ["book_catalog", "book_prices"]
+
     - name: "dev7"
       auth_key: dev7:test
       indices: ["test7_*"]

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
@@ -1310,9 +1310,7 @@ trait BaseXpackApiSuite
             result.rows.size should be(4)
           }
       }
-      // ES reports the index list normalized ("book_catalog,book_prices"), so neither spelling below
-      // contains it verbatim. The rewrite used to find nothing and forward the query untouched, handing
-      // book_prices' rows to a user with no grant on it.
+      // ES reports this list as `book_catalog,book_prices`, which neither spelling below contains verbatim.
       "narrow a comma-separated FROM list to what the user is granted" when {
         "the entries are separated by a space" excludeES (allEs6x, allEs7x, allEs8xBelowEs818x) in {
           val result = dev4EsqlManager.execute("""FROM book_catalog, book_prices | SORT book_id | LIMIT 100""")

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
@@ -1294,23 +1294,20 @@ trait BaseXpackApiSuite
           result.columnNames should contain only ("book_id", "title", "title.keyword", "discount_price")
           result.column("discount_price").toList should contain only (Num(90), Num(180))
         }
-        "FROM is wildcard-narrowed and the LOOKUP JOIN target shares its name prefix with the FROM " +
-          "pattern (the wildcard genuinely matches the LOOKUP JOIN target too, so FROM legitimately " +
-          "includes its rows, same as an equivalent-permission admin running the same query would see)" excludeES (
-            allEs6x,
-            allEs7x,
-            allEs8xBelowEs818x
-          ) in {
-            val result = dev5EsqlManager.execute(
-              """FROM book_* | LOOKUP JOIN book_prices ON book_id | SORT book_id | LIMIT 100"""
-            )
-            result should have statusCode 200
-            result.columnNames should contain only ("book_id", "title", "title.keyword", "discount_price")
-            result.column("title").toList should contain only (Str("Leviathan Wakes"), Str("Hyperion"), Null)
-            result.rows.size should be(4)
-          }
+        "the narrowed FROM wildcard also matches the LOOKUP JOIN target" excludeES (
+          allEs6x,
+          allEs7x,
+          allEs8xBelowEs818x
+        ) in {
+          val result = dev5EsqlManager.execute(
+            """FROM book_* | LOOKUP JOIN book_prices ON book_id | SORT book_id | LIMIT 100"""
+          )
+          result should have statusCode 200
+          result.columnNames should contain only ("book_id", "title", "title.keyword", "discount_price")
+          result.column("title").toList should contain only (Str("Leviathan Wakes"), Str("Hyperion"), Null)
+          result.rows.size should be(4)
+        }
       }
-      // ES reports this list as `book_catalog,book_prices`, which neither spelling below contains verbatim.
       "narrow a comma-separated FROM list to what the user is granted" when {
         "the entries are separated by a space" excludeES (allEs6x, allEs7x, allEs8xBelowEs818x) in {
           val result = dev4EsqlManager.execute("""FROM book_catalog, book_prices | SORT book_id | LIMIT 100""")
@@ -1325,7 +1322,7 @@ trait BaseXpackApiSuite
           result.rows.size should be(2)
         }
       }
-      "deny the whole request with a generic 'Unknown index' error (masking, not a data/existence leak)" when {
+      "deny the whole request with a generic 'Unknown index' error" when {
         "the LOOKUP JOIN target is not authorized, even though FROM's own target is fine on its own" excludeES (
           allEs6x,
           allEs7x,
@@ -1339,17 +1336,19 @@ trait BaseXpackApiSuite
           reason should include("Unknown index")
           reason should not include "book_prices"
         }
-        "FROM's own target is not authorized, even though the LOOKUP JOIN target is fine on its own " +
-          "(masking FROM to a concrete nonexistent name 400s independently of the join - no behavior " +
-          "change from today, see spec section 4)" excludeES (allEs6x, allEs7x, allEs8xBelowEs818x) in {
-            val result = dev6EsqlManager.execute(
-              """FROM book_catalog | LOOKUP JOIN book_prices ON book_id | LIMIT 100"""
-            )
-            result should have statusCode 400
-            val reason = result.responseJson("error").obj("reason").str
-            reason should include("Unknown index")
-            reason should not include "book_catalog"
-          }
+        "FROM's own target is not authorized, even though the LOOKUP JOIN target is fine on its own" excludeES (
+          allEs6x,
+          allEs7x,
+          allEs8xBelowEs818x
+        ) in {
+          val result = dev6EsqlManager.execute(
+            """FROM book_catalog | LOOKUP JOIN book_prices ON book_id | LIMIT 100"""
+          )
+          result should have statusCode 400
+          val reason = result.responseJson("error").obj("reason").str
+          reason should include("Unknown index")
+          reason should not include "book_catalog"
+        }
       }
     }
   }

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
@@ -1291,7 +1291,7 @@ trait BaseXpackApiSuite
             """FROM book_catalog | LOOKUP JOIN book_prices ON book_id | SORT book_id | LIMIT 100"""
           )
           result should have statusCode 200
-          result.columnNames should contain only ("book_id", "title", "discount_price")
+          result.columnNames should contain only ("book_id", "title", "title.keyword", "discount_price")
           result.column("discount_price").toList should contain only (Num(90), Num(180))
         }
         "FROM is wildcard-narrowed and the LOOKUP JOIN target shares its name prefix with the FROM " +
@@ -1305,10 +1305,27 @@ trait BaseXpackApiSuite
               """FROM book_* | LOOKUP JOIN book_prices ON book_id | SORT book_id | LIMIT 100"""
             )
             result should have statusCode 200
-            result.columnNames should contain only ("book_id", "title", "discount_price")
+            result.columnNames should contain only ("book_id", "title", "title.keyword", "discount_price")
             result.column("title").toList should contain only (Str("Leviathan Wakes"), Str("Hyperion"), Null)
             result.rows.size should be(4)
           }
+      }
+      // ES reports the index list normalized ("book_catalog,book_prices"), so neither spelling below
+      // contains it verbatim. The rewrite used to find nothing and forward the query untouched, handing
+      // book_prices' rows to a user with no grant on it.
+      "narrow a comma-separated FROM list to what the user is granted" when {
+        "the entries are separated by a space" excludeES (allEs6x, allEs7x, allEs8xBelowEs818x) in {
+          val result = dev4EsqlManager.execute("""FROM book_catalog, book_prices | SORT book_id | LIMIT 100""")
+          result should have statusCode 200
+          result.columnNames should contain only ("book_id", "title", "title.keyword")
+          result.rows.size should be(2)
+        }
+        "the entries are quoted" excludeES (allEs6x, allEs7x, allEs8xBelowEs818x) in {
+          val result = dev4EsqlManager.execute("""FROM \"book_catalog\",\"book_prices\" | SORT book_id | LIMIT 100""")
+          result should have statusCode 200
+          result.columnNames should contain only ("book_id", "title", "title.keyword")
+          result.rows.size should be(2)
+        }
       }
       "deny the whole request with a generic 'Unknown index' error (masking, not a data/existence leak)" when {
         "the LOOKUP JOIN target is not authorized, even though FROM's own target is fine on its own" excludeES (

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
@@ -27,6 +27,7 @@ import tech.beshu.ror.utils.containers.*
 import tech.beshu.ror.utils.elasticsearch.*
 import tech.beshu.ror.utils.httpclient.RestClient
 import tech.beshu.ror.utils.misc.CustomScalaTestMatchers
+import tech.beshu.ror.utils.misc.Version
 
 trait BaseXpackApiSuite
     extends AnyWordSpecLike
@@ -76,6 +77,10 @@ trait BaseXpackApiSuite
   private lazy val dev1EsqlManager = new EsqlApiManager(basicAuthClient("dev1sql", "test"), esVersionUsed)
   private lazy val dev2EsqlManager = new EsqlApiManager(basicAuthClient("dev2sql", "test"), esVersionUsed)
   private lazy val dev3EsqlManager = new EsqlApiManager(basicAuthClient("dev3sql", "test"), esVersionUsed)
+  private lazy val dev4EsqlManager = new EsqlApiManager(basicAuthClient("dev4sql", "test"), esVersionUsed)
+  private lazy val dev5EsqlManager = new EsqlApiManager(basicAuthClient("dev5sql", "test"), esVersionUsed)
+  private lazy val dev6EsqlManager = new EsqlApiManager(basicAuthClient("dev6sql", "test"), esVersionUsed)
+  private lazy val dev7EsqlManager = new EsqlApiManager(basicAuthClient("dev7sql", "test"), esVersionUsed)
 
   "Async search" should {
     "be allowed for dev1 and test1_index_a" excludeES (allEs6x, allEs7xBelowEs77x) in {
@@ -1279,6 +1284,59 @@ trait BaseXpackApiSuite
         }
       }
     }
+    "LOOKUP JOIN is used" should {
+      "be allowed" when {
+        "the LOOKUP JOIN target is authorized" excludeES (allEs6x, allEs7x, allEs8xBelowEs818x) in {
+          val result = dev7EsqlManager.execute(
+            """FROM book_catalog | LOOKUP JOIN book_prices ON book_id | SORT book_id | LIMIT 100"""
+          )
+          result should have statusCode 200
+          result.columnNames should contain only ("book_id", "title", "discount_price")
+          result.column("discount_price").toList should contain only (Num(90), Num(180))
+        }
+        "FROM is wildcard-narrowed and the LOOKUP JOIN target shares its name prefix with the FROM " +
+          "pattern (the wildcard genuinely matches the LOOKUP JOIN target too, so FROM legitimately " +
+          "includes its rows, same as an equivalent-permission admin running the same query would see)" excludeES (
+            allEs6x,
+            allEs7x,
+            allEs8xBelowEs818x
+          ) in {
+            val result = dev5EsqlManager.execute(
+              """FROM book_* | LOOKUP JOIN book_prices ON book_id | SORT book_id | LIMIT 100"""
+            )
+            result should have statusCode 200
+            result.columnNames should contain only ("book_id", "title", "discount_price")
+            result.column("title").toList should contain only (Str("Leviathan Wakes"), Str("Hyperion"), Null)
+            result.rows.size should be(4)
+          }
+      }
+      "deny the whole request with a generic 'Unknown index' error (masking, not a data/existence leak)" when {
+        "the LOOKUP JOIN target is not authorized, even though FROM's own target is fine on its own" excludeES (
+          allEs6x,
+          allEs7x,
+          allEs8xBelowEs818x
+        ) in {
+          val result = dev4EsqlManager.execute(
+            """FROM book_catalog | LOOKUP JOIN book_prices ON book_id | LIMIT 100"""
+          )
+          result should have statusCode 400
+          val reason = result.responseJson("error").obj("reason").str
+          reason should include("Unknown index")
+          reason should not include "book_prices"
+        }
+        "FROM's own target is not authorized, even though the LOOKUP JOIN target is fine on its own " +
+          "(masking FROM to a concrete nonexistent name 400s independently of the join - no behavior " +
+          "change from today, see spec section 4)" excludeES (allEs6x, allEs7x, allEs8xBelowEs818x) in {
+            val result = dev6EsqlManager.execute(
+              """FROM book_catalog | LOOKUP JOIN book_prices ON book_id | LIMIT 100"""
+            )
+            result should have statusCode 400
+            val reason = result.responseJson("error").obj("reason").str
+            reason should include("Unknown index")
+            reason should not include "book_catalog"
+          }
+      }
+    }
   }
 
   "Get terms request" should {
@@ -1336,6 +1394,9 @@ object BaseXpackApiSuite {
     storeScriptTemplate(adminRestClient, esVersion)
     configureBookstore(documentManager, indexManager)
     configureLibrary(documentManager)
+    if (Version.greaterOrEqualThan(esVersion, 8, 18, 0)) {
+      configureBookPrices(documentManager, indexManager)
+    }
 
     indexManager.closeIndex("test3_index_c").force()
   }
@@ -1448,6 +1509,40 @@ object BaseXpackApiSuite {
       )
     )
     indexManager.createAliasOf("bookstore", "bookshop").force()
+  }
+
+  private def configureBookPrices(documentManager: DocumentManager, indexManager: IndexManager): Unit = {
+    documentManager.createDocAndAssert(
+      index = "book_catalog",
+      `type` = "_doc",
+      id = 1,
+      content = ujson.read("""{"book_id": 1, "title": "Leviathan Wakes"}""")
+    )
+    documentManager.createDocAndAssert(
+      index = "book_catalog",
+      `type` = "_doc",
+      id = 2,
+      content = ujson.read("""{"book_id": 2, "title": "Hyperion"}""")
+    )
+
+    indexManager
+      .createIndex(
+        "book_prices",
+        settings = Some(ujson.read("""{"settings": {"index": {"mode": "lookup"}}}"""))
+      )
+      .force()
+    documentManager.createDocAndAssert(
+      index = "book_prices",
+      `type` = "_doc",
+      id = 1,
+      content = ujson.read("""{"book_id": 1, "discount_price": 90}""")
+    )
+    documentManager.createDocAndAssert(
+      index = "book_prices",
+      `type` = "_doc",
+      id = 2,
+      content = ujson.read("""{"book_id": 2, "discount_price": 180}""")
+    )
   }
 
   private def configureLibrary(documentManager: DocumentManager): Unit = {

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/base/BaseXpackApiSuite.scala
@@ -1191,6 +1191,21 @@ trait BaseXpackApiSuite
             )
             result.rows.size should be(3)
           }
+          "full indices names are used, one of them is not allowed and they are separated by a space" excludeES (
+            allEs6x,
+            allEs7x,
+            allEs8xBelowEs811x
+          ) in {
+            val result = dev1EsqlManager.execute("""FROM bookstore, library | LIMIT 100""")
+            result should have statusCode 200
+            result.columnNames should contain only ("author", "author.keyword", "name", "name.keyword", "release_date")
+            result.column("author").toList should contain only (
+              Str("James S.A. Corey"),
+              Str("Dan Simmons"),
+              Str("Frank Herbert")
+            )
+            result.rows.size should be(3)
+          }
           "wildcard is used" excludeES (allEs6x, allEs7x, allEs8xBelowEs811x) in {
             val result = dev1EsqlManager.execute("""FROM book* | LIMIT 100""")
             result should have statusCode 200


### PR DESCRIPTION
- type: security                                                                                                                                                                                                            
    components: [es]                                                                                                                                                                                                          
    text: "Fix authorization bypass allowing ESQL LOOKUP JOIN to read indices the user isn't granted"                                                                                                                         
                                                                                                                                                                                                                              
  ## What changed                                                                                                                                                                                                             
                                                                                                                                                                                                                              
  Added `EsqlIndexTable` (with a `From`/`LookupJoin` origin) so both `FROM` and `LOOKUP JOIN` tables are                                                                                                                      
  extracted, authorized, and narrowed/masked the same way — previously only `FROM` was.                                                                                                                                       
                                                                                                                                                                                                                              
  ## Why                                                                                                                                                                                                                      
                                                                                                                                                                                                                              
  Before this PR, `LOOKUP JOIN` targets were invisible to ROR's ACL: a user authorized for one index could                                                                                                                    
  join in data from any other index on the cluster, unmasked. This closes that bypass, with the same                                                                                                                          
  wildcard/alias narrowing `FROM` already had. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added ESQL `LOOKUP JOIN` access control alongside standard `FROM` queries.
- Improved handling of authorized, narrowed, wildcard, aliased, and unauthorized index patterns.
- Added generic nonexistent-index masking for unauthorized or unavailable targets.
- Improved query rewriting while preserving table boundaries and independent source resolution.

## Bug Fixes
- Ensured lookup tables are analyzed and handled independently from regular query sources.

## Tests
- Added coverage for joins, wildcard narrowing, aliases, unauthorized targets, and index masking across supported Elasticsearch versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->