### PR TITLE
[RORDEV-2153] Action strings sync: read the ES versions from the build

### DIFF
--- a/.claude/skills/ror-release/SKILL.md
+++ b/.claude/skills/ror-release/SKILL.md
@@ -32,10 +32,9 @@ Source: `beshu-tech/readonlyrest-internal` (`versioning.md`, `releasing.md`), re
 
 Verified against recent PRs (e.g. #1257). Files touched:
 
-1. `es{NN}x/gradle.properties` — bump `esVersion` in the newest matching module.
-2. `ci/supported-es-versions/es{N}x.txt` — prepend the new version (newest first). **This is what CI build/test actually keys off** (read by `ci/run-pipeline.sh`).
-3. `ci/upload-es-artifacts.sh` — add a *commented-out* line for the new version (the existing entries are all commented, kept as a historical record). To actually upload raw ES jars to S3: uncomment the line, push to a `newes/*` branch (the `ES_S3_UP` pipeline stage fires on that branch name), then re-comment before merging. This is a separate manual step — it is NOT what gates CI build/test (that's `ci/supported-es-versions/*.txt`, step 2).
-4. Sometimes `ror-tools/build.gradle`.
+1. `es{NN}x/gradle.properties` — add the version to `supportedEsVersions` in the matching module. **This is the single source of truth**: CI build/test, the default ES module, and the docs action-string sync all derive from it (`EsModuleFinder` / `printAllSupportedEsVersions`). There is no separate version list to update.
+2. `ci/upload-es-artifacts.sh` — add a *commented-out* line for the new version (the existing entries are all commented, kept as a historical record). To actually upload raw ES jars to S3: uncomment the line, push to a `newes/*` branch (the `ES_S3_UP` pipeline stage fires on that branch name), then re-comment before merging. This is a separate manual step — it is NOT what gates CI build/test (that's `supportedEsVersions`, step 1).
+3. Sometimes `ror-tools/build.gradle`.
 
 Test locally first: `./gradlew integration-tests:test '-PesModule=es{NN}x'`.
 

--- a/.github/workflows/actionstrings_gen.yml
+++ b/.github/workflows/actionstrings_gen.yml
@@ -29,6 +29,13 @@ jobs:
           repository: beshu-tech/readonlyrest-docs
           token: ${{ secrets.GH_PAT }}
 
+      # run.sh asks the build for the supported ES versions, so this job needs a JDK.
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
       - run: |
           mv docs main/readonlyrest-docs
           cd main

--- a/.github/workflows/actionstrings_gen.yml
+++ b/.github/workflows/actionstrings_gen.yml
@@ -51,8 +51,12 @@ jobs:
           set -e
           cd readonlyrest-docs
           git add .
-          # `|| true` on the commit only: an empty diff is a normal outcome. The push has no
-          # `|| true`, so a failed push to the docs repo fails this job.
-          git commit -m "commit new action strings" || true
+          # Commit only when there is something staged. `git commit || true` would also swallow a REAL
+          # failure (a hook, an index lock) and report success while publishing nothing.
+          if git diff --cached --quiet; then
+            echo "no new action strings to commit"
+          else
+            git commit -m "commit new action strings"
+          fi
           git push
           exit $generated

--- a/.github/workflows/actionstrings_gen.yml
+++ b/.github/workflows/actionstrings_gen.yml
@@ -40,12 +40,19 @@ jobs:
           mv docs main/readonlyrest-docs
           cd main
           git config --global advice.detachedHead false
+          # Set the commit identity BEFORE generating, and in the docs repo — that is the repo we commit to.
+          git -C readonlyrest-docs config user.name github-actions
+          git -C readonlyrest-docs config user.email github-actions@github.com
+          # Generate first and remember the outcome, then publish whatever was generated: one ES version
+          # that fails must not discard the versions that succeeded. The job still fails afterwards.
+          set +e
           bash -x ci/actionstrings/run.sh
+          generated=$?
+          set -e
           cd readonlyrest-docs
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           git add .
           # `|| true` on the commit only: an empty diff is a normal outcome. The push has no
           # `|| true`, so a failed push to the docs repo fails this job.
           git commit -m "commit new action strings" || true
           git push
+          exit $generated

--- a/build-base/src/main/java/tech/beshu/ror/gradle/utils/EsModuleFinder.java
+++ b/build-base/src/main/java/tech/beshu/ror/gradle/utils/EsModuleFinder.java
@@ -48,6 +48,17 @@ public final class EsModuleFinder {
     return EsVersions.of(esModule).newest;
   }
 
+  /**
+   * Every ES version ROR supports, oldest first, from each module's {@code supportedEsVersions}. The
+   * single source of truth for anything that needs the full list (see {@code printAllSupportedEsVersions}).
+   */
+  public static List<String> allSupportedEsVersions(Project rootProject) {
+    return sortedEsModules(rootProject, newestEsVersionComparator()).stream()
+        .flatMap(module -> EsVersions.of(module).all.stream())
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
   public static List<Project> sortedEsModules(Project rootProject, Comparator<Project> comparator) {
     List<Project> esModules = allEsModules(rootProject);
     esModules.sort(comparator);

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,23 @@ tasks.register("publishEsRorPreBuildDockerImage", RorTaskFinder) {
 // Usage: ./gradlew printEsModules -PesMajor=8 --quiet
 tasks.register("printEsModules", PrintEsModulesTask)
 
+// Prints every ES version ROR supports, one per line, oldest first. The versions come from each es module's
+// `supportedEsVersions` (gradle.properties), so scripts that need the full list cannot drift from what CI
+// actually builds and tests. Invoke with --quiet to suppress Gradle's own output.
+// Usage: ./gradlew printAllSupportedEsVersions --quiet
+tasks.register("printAllSupportedEsVersions") {
+    group = 'help'
+    description = 'Prints every supported ES version (one per line, oldest first)'
+    outputs.upToDateWhen { false }
+    doLast {
+        tech.beshu.ror.gradle.utils.EsModuleFinder
+                .sortedEsModules(rootProject, tech.beshu.ror.gradle.utils.EsModuleFinder.newestEsVersionComparator())
+                .collectMany { tech.beshu.ror.gradle.utils.EsVersions.of(it).all }
+                .unique()
+                .each { println it }
+    }
+}
+
 group = 'tech.beshu.ror'
 version = pluginVersion
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,11 +70,7 @@ tasks.register("printAllSupportedEsVersions") {
     description = 'Prints every supported ES version (one per line, oldest first)'
     outputs.upToDateWhen { false }
     doLast {
-        tech.beshu.ror.gradle.utils.EsModuleFinder
-                .sortedEsModules(rootProject, tech.beshu.ror.gradle.utils.EsModuleFinder.newestEsVersionComparator())
-                .collectMany { tech.beshu.ror.gradle.utils.EsVersions.of(it).all }
-                .unique()
-                .each { println it }
+        tech.beshu.ror.gradle.utils.EsModuleFinder.allSupportedEsVersions(rootProject).each { println it }
     }
 }
 

--- a/ci/actionstrings/fetchIfNecessary.sh
+++ b/ci/actionstrings/fetchIfNecessary.sh
@@ -1,18 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generates the action-string list for ONE ES version and commits it to the readonlyrest-docs checkout,
+# unless that version's file already exists. Called by run.sh.
+
 ES_VERSION=$1
 
 DEST_DIR="readonlyrest-docs/actionstrings"
-mkdir -p $DEST_DIR || echo "$DEST_DIR already present."
+mkdir -p "$DEST_DIR"
 
 FILENAME="$DEST_DIR/action_strings_es$ES_VERSION.txt"
-if test -f $FILENAME; then
+if test -f "$FILENAME"; then
   echo "$FILENAME exists."
-  return 0
+  exit 0
 fi
 
 echo "processing ES action extractions for: $FILENAME"
-ci/actionstrings/fetch.sh "v$ES_VERSION" > $FILENAME
-cat $FILENAME
-git add $FILENAME
-git commit $FILENAME -m "adding actions list for ES $ES_VERSION"
-git push
 
+# Write to a temporary file first and only publish a non-empty result. Writing straight into $FILENAME
+# published whatever the extraction produced, so a failed clone (a tag that does not exist, a network
+# error) committed an EMPTY list, and the missing-file check above then treated that version as done
+# forever.
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+if ! ci/actionstrings/fetch.sh "v$ES_VERSION" > "$TMP_FILE"; then
+  echo "extraction failed for ES $ES_VERSION"
+  exit 1
+fi
+if [ ! -s "$TMP_FILE" ]; then
+  echo "no action strings found for ES $ES_VERSION (is the tag v$ES_VERSION published?)"
+  exit 1
+fi
+
+mv "$TMP_FILE" "$FILENAME"
+trap - EXIT
+cat "$FILENAME"
+
+git add "$FILENAME"
+git commit "$FILENAME" -m "adding actions list for ES $ES_VERSION"
+git push

--- a/ci/actionstrings/fetchIfNecessary.sh
+++ b/ci/actionstrings/fetchIfNecessary.sh
@@ -37,6 +37,8 @@ mv "$TMP_FILE" "$FILENAME"
 trap - EXIT
 cat "$FILENAME"
 
-git add "$FILENAME"
-git commit "$FILENAME" -m "adding actions list for ES $ES_VERSION"
-git push
+# No git commands here on purpose. This script runs with the ROR repo as the working directory, and
+# $FILENAME lives inside the NESTED readonlyrest-docs checkout, so `git add` here stages nothing (git
+# ignores paths inside an embedded repository) and `git commit <that path>` fails with "did not match
+# any file(s) known to git". The workflow publishes everything with a single commit in the docs repo
+# after run.sh finishes.

--- a/ci/actionstrings/run.sh
+++ b/ci/actionstrings/run.sh
@@ -1,7 +1,43 @@
-ESVERSIONS=$(for i in `ls es*x/gradle.properties`;do awk -F= {'print $2'} "$i"; done)
-for VERSION in $ESVERSIONS
-do
+#!/bin/bash
+set -euo pipefail
+
+# Fetches the ES action-string list for every supported ES version and commits the new ones to the
+# readonlyrest-docs checkout (see .github/workflows/actionstrings_gen.yml).
+#
+# The version list comes from the BUILD (each es*x module's `supportedEsVersions`), not from parsing
+# gradle.properties here: a second parser drifts. It did — this script used to read the versions with
+# `awk -F= '{print $2}'` over the whole properties file, which stopped working when the single
+# `esVersion=X.Y.Z` line became a multi-line `supportedEsVersions` list. It then extracted a backslash
+# and committed an empty `action_strings_es\.txt` to the docs repo.
+
+cd "$(dirname "$0")/../.."
+
+ES_VERSIONS=$(./gradlew --quiet printAllSupportedEsVersions)
+
+if [ -z "$ES_VERSIONS" ]; then
+  echo "::error::no supported ES versions returned by printAllSupportedEsVersions"
+  exit 1
+fi
+
+failed=()
+for VERSION in $ES_VERSIONS; do
+  # Guard the invariant the old parser broke silently: anything that is not an ES version must never
+  # reach fetchIfNecessary.sh, or it becomes a junk file in the docs repo.
+  if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+    echo "::error::'$VERSION' is not an ES version"
+    exit 1
+  fi
   echo "check actions for $VERSION if needed"
-  ci/actionstrings/fetchIfNecessary.sh $VERSION
+  if ! ci/actionstrings/fetchIfNecessary.sh "$VERSION"; then
+    # Keep going: one unavailable ES tag must not block the remaining versions. The job still fails.
+    echo "::warning::action strings for ES $VERSION could not be generated"
+    failed+=("$VERSION")
+  fi
 done
+
+if [ ${#failed[@]} -gt 0 ]; then
+  echo "::error::failed for: ${failed[*]}"
+  exit 1
+fi
+
 echo "done checking action strings."


### PR DESCRIPTION
Jira: [RORDEV-2153](https://readonlyrest.atlassian.net/browse/RORDEV-2153)

_No changelog entry: CI-only change, the shipped plugin is unchanged._

> ⚠️ Stacked on #1316 (it also touches `actionstrings_gen.yml`). Review/merge that one first; this diff is the two commits on top.

## The bug

`ci/actionstrings/run.sh` extracted ES versions with `awk -F= '{print $2}'` over the whole of each module's `gradle.properties`. That worked when the file held a single `esVersion=X.Y.Z` line. It now holds a multi-line `supportedEsVersions` list, so the script extracts **a backslash** instead of a version:

```
$ awk -F= '{print $2}' es67x/gradle.properties
\
```

It reached production. `beshu-tech/readonlyrest-docs/actionstrings/` contains a 0-byte file literally named **`action_strings_es\.txt`**. Nobody noticed because the workflow ended in `git push || true`.

## The fix

**The build is the single source of truth.** New `printAllSupportedEsVersions` task prints every supported ES version from each module's `supportedEsVersions`; `run.sh` asks for that instead of parsing properties itself. It returns **256 versions** where the old parser returned `\`.

Three guards so this class of failure cannot be silent again:
1. `run.sh` rejects any token that is not an ES version, and fails if the task returns nothing.
2. `fetchIfNecessary.sh` writes to a temp file and publishes **only a non-empty result**. Previously a failed extraction committed an *empty* list, and the "file exists" check then treated that version as done forever — that is exactly how the junk file became permanent.
3. `fetchIfNecessary.sh` used `return` outside a function (an error in an executed script); now `exit`.

Also: the workflow gets a JDK (run.sh calls Gradle now), and the `ror-release` skill's step 2 — which told the reader to edit `ci/supported-es-versions/es{N}x.txt`, **a directory that no longer exists**, and called it the thing "CI actually keys off" — is corrected to point at `supportedEsVersions`.

## Verification

Sandbox tests with a stubbed `gradlew` (no network, no commits):

| Case | Result |
|---|---|
| Task returns `\` (the exact old output) | rejected, exit 1, **no file created** |
| Task returns nothing | fails loudly, exit 1 |
| ES tag does not exist (`v0.0.0`) | exit 1, **no empty file published** |
| Action-string file already exists | skipped, exit 0 |

Plus `./gradlew printAllSupportedEsVersions` → 256 lines, **0** not matching `^\d+\.\d+\.\d+(-\w+)?$`.

## Cleanup — done

The junk file `actionstrings/action_strings_es\.txt` has been **deleted** from `beshu-tech/readonlyrest-docs` (blob SHA was `e69de29b…`, git's hash for an empty file). 278 valid action-string files remain.

It cannot come back: with the guards in this PR, a non-version token never reaches the fetch step, and an empty extraction is never published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Gradle task to display all supported Elasticsearch versions in order.
  * Supported Elasticsearch versions are now consistently derived across builds, CI, and documentation.

* **Bug Fixes**
  * Improved action-string generation reliability with safer extraction, cleanup, and error reporting.
  * Generation now continues across individual fetch failures and clearly reports unsuccessful versions.

* **Chores**
  * Added manual workflow execution and improved workflow triggering and run management.
  * Updated build automation to use Java 17 and newer checkout tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
