### PR TITLE
[RORDEV-2156] Cap the integration orchestrator JVM (host OOM on the 16 GB runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,11 @@ jobs:
           # Windows (no docker), 3 fit the 16GB box. 4 workers measured no faster (CPU-bound).
           # ror-tools:test is NOT run per-leg: it took ~10 min/leg and every node install already
           # exercises the patcher end-to-end; the suite still runs via unit_tests_windows.
+          # Cap the orchestrator heap for the same reason as the Linux legs (RORDEV-2156): it only
+          # spawns the shard processes, but without this it inherits gradle.properties' -Xmx6144m,
+          # on a 16GB box that already holds 3 shard JVMs, 3 test workers and 3 native ES nodes.
           $gradleArgs = "--no-daemon", "--build-cache", "integration-tests:shardedTest", "-PshardCount=3", "-PesModule=$env:ES_MODULE",
+            "-Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m",
             "-Dorg.gradle.java.installations.paths=", "-Dorg.gradle.java.installations.auto-download=true"
           .\gradlew @gradleArgs
           if ($LASTEXITCODE -ne 0) {

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -72,6 +72,8 @@ run_integration_tests() {
   ES_MODULE=$1
   # IT_PARALLELISM (the user-facing knob) = the gradle -PshardCount it feeds: K parallel shards.
   local parallelism="${IT_PARALLELISM:-1}"
+  # Overridable so a bigger runner can raise it; see run_one for the memory budget.
+  local IT_ORCHESTRATOR_JVMARGS="${IT_ORCHESTRATOR_JVMARGS:--Xmx2048m -XX:MaxMetaspaceSize=512m}"
   local esArgs=("-PesModule=$ES_MODULE")
   [ -n "$ES_VERSION" ] && esArgs+=("-PesVersion=$ES_VERSION")
 
@@ -81,7 +83,15 @@ run_integration_tests() {
   # appends the leader PID to GRADLE_PIDS (never pruned) and sets LAST_PID for the caller.
   LAST_PID=""
   run_one() {  # args: <gradle args...>
-    setsid ./gradlew --no-daemon "$@" &
+    # Cap the ORCHESTRATOR heap. These invocations only spawn the shard processes and build the ES
+    # image; without this they inherit gradle.properties' -Xmx6144m, which the compile jobs need and
+    # this one does not. The leg already holds, on a 16GB runner:
+    #   K shard JVMs        K x (1024m heap + 512m metaspace)   (capped in ShardedGradlewTest)
+    #   K test workers      K x 512m heap                       (itTestHeap)
+    #   >= K ES containers  512m heap each, ~1.1GB RSS each
+    # At K=4 that is already ~15GB, so a 6GB orchestrator ceiling on top is what tips the host into
+    # OOM. A crashed daemon in integration_es80x reported daemonOpts=-Xmx6144m (RORDEV-2156).
+    setsid ./gradlew --no-daemon -Dorg.gradle.jvmargs="$IT_ORCHESTRATOR_JVMARGS" "$@" &
     LAST_PID=$!; GRADLE_PIDS+=("$LAST_PID")
   }
 


### PR DESCRIPTION
Jira: [RORDEV-2156](https://readonlyrest.atlassian.net/browse/RORDEV-2156)

_No changelog entry: CI-only change._

## The crash

`integration_es80x` died today with a JVM crash, not a test failure:

```
JVM crash log found: hs_err_pid346.log
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```

The daemon's own log names the culprit:

```
daemonOpts=-Xmx6144m,-Dfile.encoding=UTF-8,...
```

It died ~2 seconds after the build started — the signature of a host that cannot commit the memory, not of a workload that grew into it.

## Why it happens

`ShardedGradlewTest` already caps the shard **children** at 1024m, and its comment records that uncapped children were *"the real memory ceiling behind the k=5/k=6 host-OOM deaths"*. But the **orchestrators** were never capped — `ci/run-pipeline.sh` (`ror-tools:test`, `integration-tests:shardedTest`) and the Windows leg all inherit `-Xmx6144m` from `gradle.properties`, which the compile jobs genuinely need and these do not. The orchestrator only spawns shards and builds the ES image.

Budget for one leg on `ubicloud-standard-4` (4 vCPU / **16 GB**) at `IT_PARALLELISM=4`:

| Component | Count | Each | Subtotal |
|---|---|---|---|
| shard JVMs | 4 | 1024m heap + 512m metaspace | ~7.1 GB |
| test workers | 4 | 512m heap (`itTestHeap`) | ~3.3 GB |
| ES containers | ≥4 | 512m heap, ~1.1 GB RSS | ~4.4 GB |
| **before the orchestrator** | | | **~15 GB** |

A 6 GB orchestrator ceiling on top of that is what tips the host over. Heavy multi-cluster suites (gated to 2 concurrent) add more.

## The fix

Cap the orchestrator at 2048m on both platforms — it does no compilation of consequence. `gradle.properties` keeps 6144m for the compile jobs, untouched.

Verified locally with the exact invocation the pipeline now uses:

```
uncapped:  ORCHESTRATOR maxHeap = 6144m
capped:    ORCHESTRATOR maxHeap = 2048m
```

The Linux value is overridable via `IT_ORCHESTRATOR_JVMARGS` so a bigger runner can raise it without a code change.

## Follow-ups worth considering (not in this PR)

1. **Give the ES containers a `--memory` limit.** They pin `-Xms512m -Xmx512m` but have no cgroup cap, so off-heap growth is unbounded and the *host* OOM-killer picks the victim — which is why these failures surface as unrelated jobs dying. With a limit, Docker kills the container and the failure names itself.
2. **A flake ledger.** Three infra failures in one day (an `osixia/openldap` container that failed to start, `integration_es90x`, and this one), each costing a human a log-read to reach "not my code". The signatures (`Wait strategy failed`, `daemon disappeared`, `hs_err_pid`) are mechanically detectable and could be auto-labelled or auto-retried once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved integration-test execution by applying dedicated memory limits to the test orchestration process.
  * Added configurable JVM settings for integration-test runs, with sensible defaults for heap and metaspace usage.
  * Updated Windows test execution to use consistent resource settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->