### PR TITLE
[RORDEV-2151] Fix copy-drift between ES modules

### DIFF
--- a/es714x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es714x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es714x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es716x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es716x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es716x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es717x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es717x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es717x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es717x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es80x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es80x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es810x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es810x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es810x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es810x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es811x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es811x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es811x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es812x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es812x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es812x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es813x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteIndexTemplateRequest,
   TransportDeleteComponentTemplateAction
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: TransportDeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es813x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es813x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteIndexTemplateRequest,
   TransportDeleteComposableIndexTemplateAction
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: TransportDeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es814x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteIndexTemplateRequest,
   TransportDeleteComponentTemplateAction
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: TransportDeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es814x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es814x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteIndexTemplateRequest,
   TransportDeleteComposableIndexTemplateAction
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: TransportDeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es815x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteIndexTemplateRequest,
   TransportDeleteComponentTemplateAction
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: TransportDeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es815x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es815x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteIndexTemplateRequest,
   TransportDeleteComposableIndexTemplateAction
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: TransportDeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es81x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es81x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es82x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es82x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es83x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es83x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es84x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es84x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es85x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es85x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es87x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es87x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es87x/src/main/scala/tech/beshu/ror/es/services/EsIndexDocumentManager.scala
+++ b/es87x/src/main/scala/tech/beshu/ror/es/services/EsIndexDocumentManager.scala
@@ -28,10 +28,8 @@ import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.xcontent.XContentType
 import tech.beshu.ror.accesscontrol.domain.{IndexName, RequestId}
 import tech.beshu.ror.boot.RorSchedulers
-import tech.beshu.ror.es.services.IndexDocumentManager
 import tech.beshu.ror.es.services.IndexDocumentManager.*
 import tech.beshu.ror.implicits.*
-import tech.beshu.ror.utils.LoggerOps.*
 import tech.beshu.ror.utils.RequestIdAwareLogging
 
 import scala.annotation.unused

--- a/es88x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es88x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es88x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es89x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComponentTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComponentTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComponentTemplateEsRequestContext(
   extension (request: DeleteComponentTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      Option(on(request).call("name").get[String]).toList
-        .flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es89x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
+++ b/es89x/src/main/scala/tech/beshu/ror/es/handler/request/context/types/templates/DeleteComposableIndexTemplateEsRequestContext.scala
@@ -18,7 +18,6 @@ package tech.beshu.ror.es.handler.request.context.types.templates
 
 import cats.data.NonEmptyList
 import cats.implicits.*
-import org.elasticsearch.Version
 import org.elasticsearch.action.admin.indices.template.delete.{
   DeleteComposableIndexTemplateAction,
   DeleteIndexTemplateRequest
@@ -71,40 +70,11 @@ class DeleteComposableIndexTemplateEsRequestContext(
   extension (request: DeleteComposableIndexTemplateAction.Request)
 
     private def getNames: List[TemplateNamePattern] = {
-      if (isEsNewerThan712) getNamesForEsPost12
-      else getNamesForEsPre13
-    }
-
-    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
-      if (isEsNewerThan712) updateNamesForEsPost12(names)
-      else updateNamesForEsPre13(names)
-    }
-
-    private def isEsNewerThan712 = {
-      Version.CURRENT.after(Version.fromString("7.12.1"))
-    }
-
-    private def getNamesForEsPre13 = {
-      val name: String = on(request).call("name").get[String]
-      Option(name).toList.flatMap(TemplateNamePattern.fromString)
-    }
-
-    private def getNamesForEsPost12 = {
       val names: Array[String] = on(request).call("names").get[Array[String]]
       names.asSafeList.flatMap(TemplateNamePattern.fromString)
     }
 
-    private def updateNamesForEsPre13(names: NonEmptyList[TemplateNamePattern]) = {
-      names.tail match {
-        case Nil =>
-        case _   =>
-          logger.warn(s"""[${id.show}] Filtered result contains more than one template pattern. First was taken.
-               | The whole set of patterns [${names.show}]""".oneLiner)
-      }
-      on(request).call("name", names.head.value.value)
-    }
-
-    private def updateNamesForEsPost12(names: NonEmptyList[TemplateNamePattern]): Unit = {
+    private def updateNames(names: NonEmptyList[TemplateNamePattern]): Unit = {
       on(request).set("names", names.toList.map(_.value.value).toArray)
     }
 

--- a/es90x/src/main/scala/tech/beshu/ror/es/IndexLevelActionFilter.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/IndexLevelActionFilter.scala
@@ -110,7 +110,7 @@ class IndexLevelActionFilter(
     private def createService(cluster: AuditCluster): IndexBasedAuditSinkService & DataStreamBasedAuditSinkService = {
       cluster match {
         case AuditCluster.LocalAuditCluster =>
-          new NodeClientBasedAuditSinkService(client, new XContentJsonParserFactory(xContentRegistry))(
+          new NodeClientBasedAuditSinkService(client, new XContentJsonParserFactory(xContentRegistry), threadPool)(
             using systemContext.clock
           )
         case remote: AuditCluster.RemoteAuditCluster =>
@@ -177,6 +177,7 @@ class IndexLevelActionFilter(
               rorActionListener,
               chain,
               EsServices.withCaching(esServices),
+              esEnv.esVersion
             )
           )
         } recover {

--- a/es90x/src/main/scala/tech/beshu/ror/es/handler/AclAwareRequestFilter.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/handler/AclAwareRequestFilter.scala
@@ -301,7 +301,8 @@ object AclAwareRequestFilter {
       val actionRequest: ActionRequest,
       val listener: RorActionListener[ActionResponse],
       val chain: EsChain,
-      val esServices: EsServices
+      val esServices: EsServices,
+      val esVersion: EsVersion
   ) extends BaseEsContext {
 
     override val esTaskId: Long = task.getId

--- a/es90x/src/main/scala/tech/beshu/ror/es/services/NodeClientBasedAuditSinkService.scala
+++ b/es90x/src/main/scala/tech/beshu/ror/es/services/NodeClientBasedAuditSinkService.scala
@@ -17,13 +17,13 @@
 package tech.beshu.ror.es.services
 
 import cats.data.NonEmptyList
-import org.elasticsearch.action.bulk.{BulkProcessor, BulkRequest, BulkResponse}
+import org.elasticsearch.action.bulk.{BulkProcessor2, BulkRequest, BulkResponse}
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.{ActionListener, DocWriteRequest}
 import org.elasticsearch.client.internal.node.NodeClient
-import org.elasticsearch.common.BackoffPolicy
 import org.elasticsearch.common.unit.{ByteSizeUnit, ByteSizeValue}
 import org.elasticsearch.core.TimeValue
+import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.xcontent.XContentType
 import tech.beshu.ror.accesscontrol.audit.sink.AuditDataStreamCreator
 import tech.beshu.ror.accesscontrol.domain.{DataStreamName, IndexName, RequestId}
@@ -39,20 +39,23 @@ import tech.beshu.ror.utils.RequestIdAwareLogging
 import java.time.Clock
 import java.util.function.BiConsumer
 
-final class NodeClientBasedAuditSinkService(client: NodeClient, jsonParserFactory: XContentJsonParserFactory)(
+final class NodeClientBasedAuditSinkService(
+    client: NodeClient,
+    jsonParserFactory: XContentJsonParserFactory,
+    threadPool: ThreadPool
+)(
     using Clock
 ) extends IndexBasedAuditSinkService
     with DataStreamBasedAuditSinkService
     with RequestIdAwareLogging {
 
   private val bulkProcessor =
-    BulkProcessor
-      .builder(BulkRequestHandler, new AuditSinkBulkProcessorListener, "ror-audit-bulk-processor")
+    BulkProcessor2
+      .builder(BulkRequestHandler, new AuditSinkBulkProcessorListener, threadPool)
       .setBulkActions(AUDIT_SINK_MAX_ITEMS)
       .setBulkSize(ByteSizeValue.of(AUDIT_SINK_MAX_KB, ByteSizeUnit.KB))
       .setFlushInterval(TimeValue.timeValueSeconds(AUDIT_SINK_MAX_SECONDS))
-      .setConcurrentRequests(1)
-      .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(100), AUDIT_SINK_MAX_RETRIES))
+      .setMaxNumberOfRetries(AUDIT_SINK_MAX_RETRIES)
       .build
 
   override def submit(indexName: IndexName.Full, documentId: String, jsonRecord: String)(
@@ -84,7 +87,7 @@ final class NodeClientBasedAuditSinkService(client: NodeClient, jsonParserFactor
     override def accept(t: BulkRequest, u: ActionListener[BulkResponse]): Unit = client.bulk(t, u)
   }
 
-  private class AuditSinkBulkProcessorListener extends BulkProcessor.Listener {
+  private class AuditSinkBulkProcessorListener extends BulkProcessor2.Listener {
 
     override def beforeBulk(executionId: Long, request: BulkRequest): Unit = {
       noRequestIdLogger.debug(s"Flushing ${request.numberOfActions} bulk actions ...")
@@ -104,7 +107,7 @@ final class NodeClientBasedAuditSinkService(client: NodeClient, jsonParserFactor
       }
     }
 
-    override def afterBulk(executionId: Long, request: BulkRequest, failure: Throwable): Unit = {
+    override def afterBulk(executionId: Long, request: BulkRequest, failure: Exception): Unit = {
       noRequestIdLogger.error(s"Failed flushing the BulkProcessor: ${failure.getMessage}", failure)
     }
 


### PR DESCRIPTION
Extracted from #1313 on @coutoPL's request, for separate review. Same commit, cherry-picked onto develop — once this merges, the #1313 diff shrinks to the overlay mechanism and migration only.

Three drift cases, found by hashing every file across all 34 es* modules and flagging paths whose version sequence across modules is non-contiguous:

| Where | Fix |
|---|---|
| `es87x` EsIndexDocumentManager | Remove two redundant imports (the class extends same-package `IndexDocumentManager`; `warnEx` comes from `RequestIdAwareLogging`). File becomes identical to its neighbors. |
| `es87x`/`es88x`/`es89x` DeleteComposableIndexTemplateEsRequestContext | Remove the dead runtime branch for ES ≤ 7.12 carried over from the 7.x lineage. Always false on ES 8.x — behavior unchanged. Files now match es80x..es85x. |
| `es90x` AclAwareRequestFilter, IndexLevelActionFilter, NodeClientBasedAuditSinkService | Align with the es91x..es94x lineage: `EsContext` carries `EsVersion`; audit sink uses `BulkProcessor2` (present in ES 9.0). es90x was forked before these landed in es818x and never caught up. **The `BulkProcessor2` switch is the only behavioral change** — same max retries, ES-managed scheduling instead of the deprecated `BulkProcessor`. |

Deliberately not "fixed": the object-style `EsqlRequestHelper` in single-minor modules is intentional divergence (the class-style `EsVersion`-switch variant exists only where one module spans ESQL-incompatible minors), and the `QueryType` anomaly is a false positive (a `@nowarn` legitimately dropped in 8.x).

Verified: compileScala green for es87x–es90x; all four modules passed their integration legs on #1313's runs (27/27 × 3 CI rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Improved component and composable index template deletion across supported Elasticsearch versions by consistently handling multiple template names.
* **Audit Logging**
  * Updated audit event delivery with improved bulk processing and streamlined retry and scheduling behavior.
* **Bug Fixes**
  * Improved request processing so Elasticsearch version information is handled consistently across operations.
  * Removed outdated compatibility behavior that could affect template deletion requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->