### PR TITLE
[RORDEV-2157] Give the ES test containers a memory limit

### DIFF
--- a/tests-utils/build.gradle
+++ b/tests-utils/build.gradle
@@ -54,11 +54,11 @@ dependencies {
     api group: 'io.monix',                       name: 'monix_3',                           version: '3.4.1'
     api group: 'com.lihaoyi',                    name: 'os-lib_3',                          version: '0.11.6'
     api group: 'eu.timepit',                     name: 'refined_3',                         version: '0.11.3'
-    implementation group: 'org.typelevel',        name: 'squants_3',                         version: '1.8.3'
     api group: 'org.scala-lang',                 name: 'scala3-library_3',                  version: '3.3.7'
     api group: 'org.scala-lang.modules'  ,       name: 'scala-parallel-collections_3',      version: '1.2.0'
     api group: 'com.typesafe.scala-logging',     name: 'scala-logging_3',                   version: '3.9.5'
     api group: 'org.scalatest',                  name: 'scalatest_3',                       version: '3.2.19'
+    api group: 'org.typelevel',                  name: 'squants_3',                         version: '1.8.3'
     api group: 'com.dimafeng',                   name: 'testcontainers-scala-scalatest_3',  version: '0.44.0'
     api group: 'org.testcontainers',             name: 'testcontainers',                    version: "2.0.3"
     api group: 'eu.rekawek.toxiproxy',           name: 'toxiproxy-java',                    version: "2.1.11"

--- a/tests-utils/build.gradle
+++ b/tests-utils/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     api group: 'io.monix',                       name: 'monix_3',                           version: '3.4.1'
     api group: 'com.lihaoyi',                    name: 'os-lib_3',                          version: '0.11.6'
     api group: 'eu.timepit',                     name: 'refined_3',                         version: '0.11.3'
+    implementation group: 'org.typelevel',        name: 'squants_3',                         version: '1.8.3'
     api group: 'org.scala-lang',                 name: 'scala3-library_3',                  version: '3.3.7'
     api group: 'org.scala-lang.modules'  ,       name: 'scala-parallel-collections_3',      version: '1.2.0'
     api group: 'com.typesafe.scala-logging',     name: 'scala-logging_3',                   version: '3.9.5'

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/EsContainer.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/EsContainer.scala
@@ -23,6 +23,7 @@ import org.apache.http.message.BasicHeader
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.{OutputFrame, Slf4jLogConsumer}
 import org.testcontainers.images.builder.ImageFromDockerfile
+import squants.information.{Information, Mebibytes}
 import tech.beshu.ror.utils.containers.ElasticsearchNodeWaitingStrategy.AwaitingReadyStrategy
 import tech.beshu.ror.utils.containers.EsContainer.Credentials.{BasicAuth, Header, None, Token}
 import tech.beshu.ror.utils.containers.EsContainer.{Credentials, EsContainerImplementation}
@@ -63,16 +64,12 @@ abstract class EsContainer(
   // under indexing and search load (heap 319/512 MiB, non-heap 197 MiB). 2 GiB leaves room for a full heap
   // plus the ROR plugin -- a node boots and serves at ~54% of it -- while still catching a runaway node.
   // Override with ROR_ES_CONTAINER_MEMORY_MB when a suite genuinely needs more.
-  private val esContainerMemoryLimitBytes: Long = {
-    val defaultMb = 2048L
-    // Upper bound before the multiplication, not after: a value above this overflows Long and would hand
-    // Docker a NEGATIVE byte count, which fails every container in the run instead of raising the limit.
-    val maxMb = Long.MaxValue / (1024L * 1024L)
+  private val esContainerMemoryLimit: Information =
     Option(System.getenv("ROR_ES_CONTAINER_MEMORY_MB"))
       .flatMap(_.toLongOption)
-      .filter(mb => mb > 0 && mb <= maxMb)
-      .getOrElse(defaultMb) * 1024L * 1024L
-  }
+      .filter(_ > 0)
+      .map(Mebibytes(_))
+      .getOrElse(Mebibytes(2048))
 
   private val containerImplementation: EsContainerImplementation = {
     OsUtils.currentOs match {
@@ -115,7 +112,7 @@ abstract class EsContainer(
         container.withCreateContainerCmdModifier { cmd =>
           cmd.getHostConfig
             .withCgroupnsMode("host")
-            .withMemory(esContainerMemoryLimitBytes)
+            .withMemory(esContainerMemoryLimit.toBytes.toLong)
         }
         // Stamp this CI job's id so cleanup reaps ONLY this CI job's containers, never a sibling's on the
         // shared self-hosted Docker daemon. Absent off-CI -> no label, no-op.

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/EsContainer.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/EsContainer.scala
@@ -54,6 +54,21 @@ abstract class EsContainer(
 
   private val esClient = Coeval(adminClient)
 
+  // Each ES container gets a memory budget. Without one the container is unbounded, so when a leg runs
+  // out of memory the HOST OOM killer chooses the victim -- which is why those failures surfaced as an
+  // unrelated Gradle daemon or test worker dying while the container that took the memory kept running.
+  // With a limit, Docker kills the container that went over and the failure names itself.
+  //
+  // Measured on ES 8.18 with the 512m heap these tests pin: ~1.09 GiB resident idle and ~1.10 GiB under
+  // indexing and search load (heap 319/512 MiB, non-heap 197 MiB). 2 GiB leaves room for a full heap plus
+  // the ROR plugin -- a node boots and serves at ~54% of it -- while still catching a runaway node.
+  // Override with ROR_ES_CONTAINER_MEMORY_MB when a suite genuinely needs more.
+  private val esContainerMemoryLimitBytes: Long =
+    Option(System.getenv("ROR_ES_CONTAINER_MEMORY_MB"))
+      .flatMap(_.toLongOption)
+      .filter(_ > 0)
+      .getOrElse(2048L) * 1024L * 1024L
+
   private val containerImplementation: EsContainerImplementation = {
     OsUtils.currentOs match {
       case CurrentOs.Windows =>
@@ -93,7 +108,9 @@ abstract class EsContainer(
         container.setNetworkAliases((esConfig.nodeName :: Nil).asJava)
         // Share host's cgroup namespace to avoid JDK cgroup v2 NPE in nested Docker containers on CI
         container.withCreateContainerCmdModifier { cmd =>
-          cmd.getHostConfig.withCgroupnsMode("host")
+          cmd.getHostConfig
+            .withCgroupnsMode("host")
+            .withMemory(esContainerMemoryLimitBytes)
         }
         // Stamp this CI job's id so cleanup reaps ONLY this CI job's containers, never a sibling's on the
         // shared self-hosted Docker daemon. Absent off-CI -> no label, no-op.

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/EsContainer.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/EsContainer.scala
@@ -59,15 +59,20 @@ abstract class EsContainer(
   // unrelated Gradle daemon or test worker dying while the container that took the memory kept running.
   // With a limit, Docker kills the container that went over and the failure names itself.
   //
-  // Measured on ES 8.18 with the 512m heap these tests pin: ~1.09 GiB resident idle and ~1.10 GiB under
-  // indexing and search load (heap 319/512 MiB, non-heap 197 MiB). 2 GiB leaves room for a full heap plus
-  // the ROR plugin -- a node boots and serves at ~54% of it -- while still catching a runaway node.
+  // Measured on ES 8.18 with the 512m heap every Docker profile pins: ~1.09 GiB resident idle and ~1.10 GiB
+  // under indexing and search load (heap 319/512 MiB, non-heap 197 MiB). 2 GiB leaves room for a full heap
+  // plus the ROR plugin -- a node boots and serves at ~54% of it -- while still catching a runaway node.
   // Override with ROR_ES_CONTAINER_MEMORY_MB when a suite genuinely needs more.
-  private val esContainerMemoryLimitBytes: Long =
+  private val esContainerMemoryLimitBytes: Long = {
+    val defaultMb = 2048L
+    // Upper bound before the multiplication, not after: a value above this overflows Long and would hand
+    // Docker a NEGATIVE byte count, which fails every container in the run instead of raising the limit.
+    val maxMb = Long.MaxValue / (1024L * 1024L)
     Option(System.getenv("ROR_ES_CONTAINER_MEMORY_MB"))
       .flatMap(_.toLongOption)
-      .filter(_ > 0)
-      .getOrElse(2048L) * 1024L * 1024L
+      .filter(mb => mb > 0 && mb <= maxMb)
+      .getOrElse(defaultMb) * 1024L * 1024L
+  }
 
   private val containerImplementation: EsContainerImplementation = {
     OsUtils.currentOs match {


### PR DESCRIPTION
Jira: [RORDEV-2157](https://readonlyrest.atlassian.net/browse/RORDEV-2157)

_No changelog entry: test infrastructure only._

Follow-up to #1321 (RORDEV-2156), which capped the orchestrator JVM. This bounds the other half.

## The problem

The ES test containers pin their heap (`-Xms512m -Xmx512m`) but have **no cgroup memory limit**, so their total footprint is unbounded. When a leg runs out of memory, the **host** OOM killer picks the victim — which is why today's failures surfaced as an unrelated Gradle daemon dying (`hs_err_pid`, "daemon disappeared") or a test worker being cancelled, while the container that actually took the memory kept running.

With a limit, Docker kills the container that went over its budget, and the failure names itself instead of costing someone a log-read to reach "not my code".

## Choosing the number — measured, not guessed

I ran ES 8.18 with the exact heap these tests pin:

| Metric | Value |
|---|---|
| Container RSS, idle | **1.092 GiB** |
| Container RSS, under indexing + search load | **1.105 GiB** |
| JVM heap used / max | 319 / 512 MiB |
| Non-heap | 197 MiB |

A full heap plus the ROR plugin lands around ~1.5 GiB, so **2 GiB** is the limit. Verified by starting a node with `--memory=2g`:

```
ES booted and serving under the 2 GiB cap (after ~90s)
usage under cap: 1.082GiB / 2GiB (54.09%)
cgroup limit applied: 2147483648 bytes
OOMKilled: false  Status: running
```

54% utilisation — comfortable headroom, while still catching a node that balloons to 4–6 GiB.

`ROR_ES_CONTAINER_MEMORY_MB` overrides it without a code change, for a suite that genuinely needs more.

## Scope

Docker path only (`EsContainer.scala`); the Windows legs run ES as native processes and are untouched. `tests-utils:compileScala` is green.

## Honest limitation

This does **not** reduce the memory a leg uses — it bounds each container and makes failures deterministic and attributable. The actual headroom recovery came from #1321 (~4 GB per leg). If a container does start getting OOM-killed at 2 GiB, that is now visible information rather than a mystery crash elsewhere, and the env var is the immediate relief valve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Linux-based Elasticsearch containers by applying a configurable memory limit.
  * Uses a 2048 MB default limit when no valid custom value is provided.
  * Supports customizing the container memory limit through the `ROR_ES_CONTAINER_MEMORY_MB` setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->