### PR TITLE
[RORDEV-2159] Bump Apache HttpClient to 5.6.4 (CVE-2026-64607)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     api group: 'commons-codec',                     name: 'commons-codec',                       version: '1.15'
     api group: 'com.beachape',                      name: 'enumeratum_3',                        version: '1.9.2'
     api group: 'com.hrakaroo',                      name: 'glob',                                version: '0.9.0'
-    api group: 'org.apache.httpcomponents.client5', name: 'httpclient5',                     version: '5.6.2'
+    api group: 'org.apache.httpcomponents.client5', name: 'httpclient5',                     version: '5.6.4'
     api group: 'com.comcast',                       name: 'ip4s-core_3',                         version: '2.0.4'
     api group: 'org.typelevel',                     name: 'jawn-parser_3',                       version: '1.6.0'
     api group: 'io.jsonwebtoken',                   name: 'jjwt-api',                            version: '0.13.0'


### PR DESCRIPTION
### Changelog entry

```yaml
  - type: security
    components: [es]
    text: "[CVE-2026-64607](https://nvd.nist.gov/vuln/detail/CVE-2026-64607)"
```

Suggested release-note body:

> This release addresses a connection-leak vulnerability in Apache HttpComponents Client, the HTTP client ReadonlyREST uses for its external authentication and authorization connectors. A server responding with an invalid or unsupported `Content-Encoding` header caused the connection not to be returned to the pool, so a misbehaving or hostile external service could exhaust the connection pool. Fixed by updating HttpClient to 5.6.4.

---

Jira: [RORDEV-2159](https://readonlyrest.atlassian.net/browse/RORDEV-2159)

## Why now

`cve_check` is failing on **every branch** — first seen on #1322, which changes nothing related:

```
httpclient5-5.6.2.jar (pkg:maven/org.apache.httpcomponents.client5/httpclient5@5.6.2) : CVE-2026-64607
Execution failed for task ':core:dependencyCheckAnalyze'
```

Per the CVE record, affected range is **5.0-alpha ≤ 5.6.2**; `core/build.gradle` pinned exactly 5.6.2. Unlike this morning's ES-server CVEs, this one is **real for us** — we ship this client and call external services with it, so it is a bump, not a suppression.

## The change

One pin: `5.6.2` → `5.6.4`. 5.6.3 is the first fixed version; 5.6.4 is the newest patch of the same minor.

Verified: `core:compileScala` green, and `dependencyInsight` confirms the compile classpath resolves `httpclient5:5.6.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the HTTP client library to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->