### PR TITLE
[RORDEV-2160] Make the LDAP unavailable-hosts test independent of DNS

### DIFF
--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/LdapServicesSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/decoders/definitions/LdapServicesSettingsTests.scala
@@ -2314,14 +2314,19 @@ class LdapServicesSettingsTests private (ldapConnectionPoolProvider: UnboundidLd
           }
         )
       }
+      // The hosts must RESOLVE and refuse the connection, so that the failure is the connection one and not
+      // the name-resolution one. `localhost` on a closed port is the only choice that behaves the same
+      // everywhere; the earlier name (ssl-ldap2.foo.com) depended on how the machine's resolver treats an
+      // unknown subdomain, so this test failed whenever the resolver answered NXDOMAIN.
+      // Resolution failure has its own test above ("one of LDAP services is unavailable (invalid host)").
       "some of LDAP services are unavailable" in {
         assertDecodingFailure(
           yaml = s"""
                     |  ldaps:
                     |  - name: ldap1
                     |    hosts:
-                    |      - ldaps://ssl-ldap2.foo.com:836
-                    |      - ldaps://ssl-ldap3.foo.com:836
+                    |      - ldaps://localhost:12345
+                    |      - ldaps://localhost:12346
                     |    search_user_base_DN: "ou=People,dc=example,dc=com"
                     |    search_groups_base_DN: "ou=Groups,dc=example,dc=com"
                     |    connection_timeout_in_sec: 2
@@ -2330,7 +2335,7 @@ class LdapServicesSettingsTests private (ldapConnectionPoolProvider: UnboundidLd
             error should be(
               CoreCreationError.DefinitionsLevelCreationError(
                 Message(
-                  "There was a problem with 'ldap1' LDAP connection to: ldaps://ssl-ldap2.foo.com:836, ldaps://ssl-ldap3.foo.com:836"
+                  "There was a problem with 'ldap1' LDAP connection to: ldaps://localhost:12345, ldaps://localhost:12346"
                 )
               )
             )


### PR DESCRIPTION
Jira: [RORDEV-2160](https://readonlyrest.atlassian.net/browse/RORDEV-2160)

_No changelog entry: test-only change._

## The failure

`LdapServicesSettingsTests` — "some of LDAP services are unavailable" — fails on **every branch** since midday today, including PRs that cannot touch `core` (#1322 changes es8x/es9x sources, #1323 changes tests-utils). It passed on #1317 and #1318 this morning.

```
expected: "There was a problem with 'ldap1' LDAP connection to: ldaps://ssl-ldap2.foo.com:836, ..."
actual:   "There was a problem with resolving 'ldap1' LDAP hosts: ldaps://ssl-ldap2.foo.com:836, ..."
```

2553 passed, **1 failed** — the same test on both PRs, and again after a rerun. Deterministic now, not a flake.

## Why

The test points at `ssl-ldap2.foo.com` / `ssl-ldap3.foo.com` and asserts the **connection** failure. That message only appears if the names **resolve** and the connection is then refused. When the resolver answers NXDOMAIN, the code correctly reports a **resolution** failure instead, and the assertion fails.

So the outcome depended on how the machine resolves an unknown subdomain of `foo.com` — and that behaviour changed on the runners today.

## The fix

Use `localhost` on closed ports: it resolves everywhere and refuses immediately, so the failure is deterministically the connection one. This matches the sibling test directly above it, which already uses `localhost:12345` for exactly this reason.

Resolution failure keeps its own dedicated test — "one of LDAP services is unavailable (invalid host)", using `dummy-host` — so no coverage is lost. The two cases are simply no longer entangled.

## Verification

```
LdapServicesSettingsTests:
  - when some of LDAP services are unavailable (16 milliseconds)
Tests: succeeded 51, failed 0, canceled 0, ignored 0, pending 0
```

Bonus: **16 seconds → 16 milliseconds**, since it no longer waits out DNS and connection timeouts.

Unblocks the `unit_tests_linux` leg on #1322, #1323 and anything else opened today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated LDAP service connection tests to use reliably unavailable local ports.
  * Improved validation of connection failure handling and related error messages.
  * Added documentation clarifying the difference between hostname resolution and connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->