### PR TITLE
[RORDEV-2154] Accept several Jira keys in the PR title check

### DIFF
--- a/ci/pr-conventions/checks/10-title-jira-key.sh
+++ b/ci/pr-conventions/checks/10-title-jira-key.sh
@@ -1,4 +1,6 @@
 # The title must carry the Jira key: "[RORDEV-1234] Short summary".
+# A change can close several tickets, so a run of keys is fine too, with or without spaces between
+# them: "[RORDEV-1234][RORDEV-5678] Short summary".
 # Escape hatch: the `no-jira` label, for a change that does not need a ticket.
 
 : "${PR_JSON_FILE:?this check is sourced by ci/pr-conventions/run.sh}"
@@ -8,7 +10,7 @@ labels=$(jq -r '.labels[].name' "$PR_JSON_FILE")
 
 if grep -qx 'no-jira' <<<"$labels"; then
   pass "title: skipped ('no-jira' label)"
-elif [[ $title =~ ^\[RORDEV-[0-9]+\][[:space:]]+.+ ]]; then
+elif [[ $title =~ ^(\[RORDEV-[0-9]+\][[:space:]]*)*\[RORDEV-[0-9]+\][[:space:]]+.+ ]]; then
   pass "title: carries the Jira key"
 else
   fail "the title must start with the Jira key, e.g. '[RORDEV-1234] $title'

--- a/ci/pr-conventions/checks/10-title-jira-key.sh
+++ b/ci/pr-conventions/checks/10-title-jira-key.sh
@@ -8,9 +8,14 @@
 title=$(jq -r '.title' "$PR_JSON_FILE")
 labels=$(jq -r '.labels[].name' "$PR_JSON_FILE")
 
+# Keys, then a summary that starts with a visible character. Only plain spaces separate them: a tab
+# or a newline in a title is a mistake, not a separator. The pattern lives in a variable because an
+# unquoted space would end the pattern inside `[[ =~ ]]`.
+jira_key_title='^(\[RORDEV-[0-9]+\] *)*\[RORDEV-[0-9]+\] +[^[:space:]]'
+
 if grep -qx 'no-jira' <<<"$labels"; then
   pass "title: skipped ('no-jira' label)"
-elif [[ $title =~ ^(\[RORDEV-[0-9]+\][[:space:]]*)*\[RORDEV-[0-9]+\][[:space:]]+.+ ]]; then
+elif [[ $title =~ $jira_key_title ]]; then
   pass "title: carries the Jira key"
 else
   fail "the title must start with the Jira key, e.g. '[RORDEV-1234] $title'


### PR DESCRIPTION
The PR title check only accepted one Jira key, because the pattern required whitespace right after the first `]`. A title like `[RORDEV-2165][RORDEV-2163][RORDEV-2161] ES 9.5.1, 9.4.5, 8.19.20 support` (PR #1326) failed, even though a PR can close more than one ticket.

Now the check accepts a run of keys, with or without spaces between them. Everything else stays the same: the keys must be at the start, and a non-empty summary must follow.

Checked against:

| Title | Result |
| --- | --- |
| `[RORDEV-2165][RORDEV-2163][RORDEV-2161] ES 9.5.1, ... support` | pass |
| `[RORDEV-1234] Short summary` | pass |
| `[RORDEV-1] [RORDEV-2] Two tickets, spaced` | pass |
| `[RORDEV-1234]No space` | fail |
| `[RORDEV-1234][RORDEV-5678]` (no summary) | fail |
| `prefix [RORDEV-1234] summary` | fail |
| `Fix a thing` | fail |

Ref: https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/pull/1318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request title conventions to support multiple Jira keys separated by spaces before a nonempty summary.
  * Titles with a single Jira key remain valid.
  * Tabs and newlines are not accepted as separators between Jira keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->