### PR TITLE
[RORDEV-2158] Drop the bootstrap fallback from the conventions check

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -31,23 +31,8 @@ jobs:
           persist-credentials: false
           path: base
 
-      # Fallback source, used only while the base branch does not have the checks yet (the pull request
-      # that introduces them). The check then runs from the pull request instead of being skipped.
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: ci/pr-conventions
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
-          path: pr
-
       - name: Check PR conventions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: |
-          runner=base/ci/pr-conventions/run.sh
-          if [ ! -x "$runner" ]; then
-            echo "::warning::the checks are not on the base branch yet, so this run uses the pull request's own copy"
-            runner=pr/ci/pr-conventions/run.sh
-          fi
-          "$runner" "${{ github.event.pull_request.number }}"
+        run: base/ci/pr-conventions/run.sh "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Jira: [RORDEV-2158](https://readonlyrest.atlassian.net/browse/RORDEV-2158)

_No changelog entry: CI-only change._

Follow-up to #1318, filed at the time so the temporary scaffolding would not quietly become permanent.

That workflow checked out `ci/pr-conventions` **twice**: from the base branch (the trusted copy) and from the pull request (a fallback). The fallback existed solely for the PR that *introduced* the checks — at that moment the base branch did not have them yet, and removing it there would have stopped that PR's own check from running.

#1318 is merged, so the base copy always exists. The second checkout now runs on every pull request and is never used, and the `not on the base branch yet` branch is unreachable.

Result: one checkout, one command. The check still runs the **base branch's** copy, so a pull request cannot edit the rule it is judged by.

This PR is its own proof — the `conventions` check on it runs through the simplified path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request convention checks to run consistently from the base branch.
  * Simplified the validation workflow by removing fallback checkout and conditional runner behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->