### PR TITLE
[RORDEV-2155] Revert "Drop the Scala 2.11 and 2.12 builds of the audit module" (#1320)

### DIFF
--- a/audit/build.gradle
+++ b/audit/build.gradle
@@ -36,14 +36,15 @@ java {
 
 crossBuild {
     scalaVersionsCatalog = [
+            '2.11': '2.11.12',
+            '2.12': '2.12.21',
             '2.13': '2.13.18',
             '3.3.0': '3.3.7'
     ]
 
-    // Scala 2.11 and 2.12 are gone: every shipped plugin loads the Scala 3 core, so a serializer built
-    // against audit_2.11/audit_2.12 cannot link in the plugin class loader. 2.13 stays because the
-    // plugin class path carries scala-library 2.13 and both shipped examples target it.
     builds {
+        v211
+        v212
         v213
         v3
     }
@@ -51,6 +52,8 @@ crossBuild {
 
 dependencies {
     implementation                 group: 'org.json',           name: 'json',                version: '20251224'
+    crossBuildV211Implementation   group: 'org.scala-lang',     name: 'scala-library',       version: '2.11.12'
+    crossBuildV212Implementation   group: 'org.scala-lang',     name: 'scala-library',       version: '2.12.21'
     crossBuildV213Implementation   group: 'org.scala-lang',     name: 'scala-library',       version: '2.13.17'
     crossBuildV3Implementation     group: 'org.scala-lang',     name: 'scala3-library_3',    version: '3.3.7'
     compileOnly                    group: 'org.scala-lang',     name: 'scala3-library_3',    version: '3.3.7'
@@ -111,6 +114,18 @@ version = pluginVersion
 
 publishing {
     publications {
+        crossBuildV211(MavenPublication) {
+            artifact crossBuildV211Jar
+            artifact sourcesJar
+            artifact javadocJar
+            pom ror_pom
+        }
+        crossBuildV212(MavenPublication) {
+            artifact crossBuildV212Jar
+            artifact sourcesJar
+            artifact javadocJar
+            pom ror_pom
+        }
         crossBuildV213(MavenPublication) {
             artifact crossBuildV213Jar
             artifact sourcesJar

--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/logging/DeprecatedAuditLoggingDecorator.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/logging/DeprecatedAuditLoggingDecorator.scala
@@ -1,0 +1,43 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+package tech.beshu.ror.accesscontrol.logging
+
+import tech.beshu.ror.audit.instances.{DefaultAuditLogSerializer, QueryAuditLogSerializer}
+import tech.beshu.ror.commons
+import tech.beshu.ror.implicits.*
+import tech.beshu.ror.requestcontext.AuditLogSerializer
+import tech.beshu.ror.utils.RequestIdAwareLogging
+
+import scala.annotation.nowarn
+
+@nowarn("cat=deprecation")
+final class DeprecatedAuditLoggingDecorator[T](underlying: AuditLogSerializer[T])
+    extends AuditLogSerializer[T]
+    with RequestIdAwareLogging {
+
+  private val deprecatedSerializerCanonicalName = underlying.getClass.getCanonicalName
+  private val defaultSerializerCanonicalName = classOf[DefaultAuditLogSerializer].getCanonicalName
+  private val querySerializerCanonicalName = classOf[QueryAuditLogSerializer].getCanonicalName
+
+  override def createLoggableEntry(context: commons.ResponseContext): T = {
+    noRequestIdLogger.warn(
+      s"you're using deprecated serializer ${deprecatedSerializerCanonicalName.show}, please use ${defaultSerializerCanonicalName.show}, or ${querySerializerCanonicalName.show} instead"
+    )
+    underlying.createLoggableEntry(context)
+  }
+
+}


### PR DESCRIPTION
Reverts #1320 (squash commit `83e768c`).

## Why

#1320 was merged before the review had finished. @coutoPL had a comment in progress and asked for the revert. This puts `develop` back to the state before that merge, so the removal can be discussed on its own merits.

## What

A plain `git revert` of the squash commit. No manual edits:

- `audit/build.gradle` — the `v211` / `v212` builds, their `scala-library` dependencies and their publications are back.
- `core/src/main/scala/tech/beshu/ror/accesscontrol/logging/DeprecatedAuditLoggingDecorator.scala` — restored.

Both files are byte-identical to `94d6158`, the parent of the reverted merge. No commit between that merge and `develop` HEAD touched either file, so the revert applied clean and the branch fast-forwards from `develop`.

@coutoPL — sorry for the premature merge. The original argument is untouched; it can go back up as a fresh PR once you have had the chance to comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and publishing compatible artifacts for Scala 2.11 and 2.12, including source and API documentation packages.
  * Added deprecation warnings for legacy audit-log serializers, including recommended alternatives.
* **Bug Fixes**
  * Restored previously unavailable Scala cross-builds and their associated library support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->