### PR TITLE
[RORDEV-1229] Mirror ES libs in a manual workflow, not in CI

### DIFF
--- a/.claude/skills/ror-release/SKILL.md
+++ b/.claude/skills/ror-release/SKILL.md
@@ -33,7 +33,7 @@ Source: `beshu-tech/readonlyrest-internal` (`versioning.md`, `releasing.md`), re
 Verified against recent PRs (e.g. #1257). Files touched:
 
 1. `es{NN}x/gradle.properties` — add the version to `supportedEsVersions` in the matching module. **This is the single source of truth**: CI build/test, the default ES module, and the docs action-string sync all derive from it (`EsModuleFinder` / `printAllSupportedEsVersions`). There is no separate version list to update.
-2. `ci/upload-es-artifacts.sh` — add a *commented-out* line for the new version (the existing entries are all commented, kept as a historical record). To actually upload raw ES jars to S3: uncomment the line, push to a `newes/*` branch (the `ES_S3_UP` pipeline stage fires on that branch name), then re-comment before merging. This is a separate manual step — it is NOT what gates CI build/test (that's `supportedEsVersions`, step 1).
+2. Mirror the ES jars into the libs store, for versions Maven Central doesn't carry yet: run the **Mirror ES Libs** workflow (`.github/workflows/mirror-es-libs.yml`) with `es_versions` set to the new versions (e.g. `9.5.1 9.4.5`). Manual, once per version, and **before** the branch adding that version goes through CI — the build resolves ES dependencies from the store, so it cannot compile against jars that aren't there yet. Not what gates CI build/test (that's `supportedEsVersions`, step 1). *(Until 2026-08: uncomment a line in `ci/upload-es-artifacts.sh`, push a `newes/*` branch to fire ci.yml's `es_s3_up` job, re-comment before merge. Both that job and the `newes/*` trigger are gone.)*
 3. Sometimes `ror-tools/build.gradle`.
 
 Test locally first: `./gradlew integration-tests:test '-PesModule=es{NN}x'`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
       is_master:  ${{ steps.f.outputs.is_master }}
       is_develop: ${{ steps.f.outputs.is_develop }}
       is_epic:    ${{ steps.f.outputs.is_epic }}
-      is_newes:   ${{ steps.f.outputs.is_newes }}
       action:     ${{ github.event.inputs.actionToPerform || 'run_all_tests_on_linux' }}
       it_linux_matrix:   ${{ steps.m.outputs.linux }}
       it_windows_matrix: ${{ steps.m.outputs.windows }}
@@ -85,9 +84,8 @@ jobs:
         run: |
           echo "is_master=${{ github.ref == 'refs/heads/master' }}"   >> "$GITHUB_OUTPUT"
           echo "is_develop=${{ github.ref == 'refs/heads/develop' }}" >> "$GITHUB_OUTPUT"
-          # contains() semantics, matching Azure's isEpicBranchOrPr / isNewEsBranchOrPr
+          # contains() semantics, matching Azure's isEpicBranchOrPr
           case "$REF" in *epic/*)  echo "is_epic=true"  >> "$GITHUB_OUTPUT";; *) echo "is_epic=false"  >> "$GITHUB_OUTPUT";; esac
-          case "$REF" in *newes/*) echo "is_newes=true" >> "$GITHUB_OUTPUT";; *) echo "is_newes=false" >> "$GITHUB_OUTPUT";; esac
       - id: m
         env:
           # Deliberately also true for epic/** refs — they get the same full matrices as master/develop.
@@ -182,45 +180,15 @@ jobs:
           ls "$GRADLE_USER_HOME/wrapper/dists" || { echo "No baked Gradle dist in image"; exit 1; }
           ./gradlew --no-daemon -q help
 
-  # ── ES_S3_UP (newes/* only) ───────────────────────────────────────────────
-  # Uploads new ES-version artifacts BEFORE any test job runs (they fetch from the libs store).
-  es_s3_up:
-    needs: setup
-    if: >-
-      needs.setup.outputs.is_newes == 'true' &&
-      github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    runs-on: ubicloud-standard-4
-    container: *toolchains
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 1, persist-credentials: false }
-      - name: Upload missing ROR ES dependencies
-        env:
-          ROR_ARTIFACTS_STORE_ENDPOINT_URL: ${{ vars.ROR_ARTIFACTS_STORE_ENDPOINT_URL }}
-          ROR_ARTIFACTS_STORE_REGION: ${{ vars.ROR_ARTIFACTS_STORE_REGION }}
-          ROR_ARTIFACTS_STORE_ACCESS_KEY_ID: ${{ secrets.ROR_ARTIFACTS_STORE_ACCESS_KEY_ID }}
-          ROR_ARTIFACTS_STORE_ACCESS_KEY_SECRET: ${{ secrets.ROR_ARTIFACTS_STORE_ACCESS_KEY_SECRET }}
-          ROR_ARTIFACTS_STORE_BUCKET: ${{ vars.ROR_ARTIFACTS_STORE_BUCKET }}
-          ROR_ARTIFACTS_STORE_PATH_PREFIX: ${{ vars.ROR_ARTIFACTS_STORE_PATH_PREFIX }}
-          ROR_LIBS_STORE_ENDPOINT_URL: ${{ vars.ROR_LIBS_STORE_ENDPOINT_URL }}
-          ROR_LIBS_STORE_REGION: ${{ vars.ROR_LIBS_STORE_REGION }}
-          ROR_LIBS_STORE_ACCESS_KEY_ID: ${{ secrets.ROR_LIBS_STORE_ACCESS_KEY_ID }}
-          ROR_LIBS_STORE_ACCESS_KEY_SECRET: ${{ secrets.ROR_LIBS_STORE_ACCESS_KEY_SECRET }}
-          ROR_LIBS_STORE_BUCKET: ${{ vars.ROR_LIBS_STORE_BUCKET }}
-          ROR_LIBS_STORE_PATH_PREFIX: ${{ vars.ROR_LIBS_STORE_PATH_PREFIX }}
-        run: ci/upload-es-artifacts.sh
-
   # ── OPTIONAL_CHECKS: CVE (non-blocking) ───────────────────────────────────
   # Azure's OPTIONAL_CHECKS stage: failures annotate the run but never block it
   # (continue-on-error = Azure's "warning, stage passes"). Matrix for symmetry with
   # required_checks; cve_check is currently its only member.
   optional_checks:
-    needs: [ setup, toolchains_verify, es_s3_up ]
+    needs: [ setup, toolchains_verify ]
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      needs.es_s3_up.result != 'cancelled' &&
       github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
     container: *toolchains
@@ -264,11 +232,10 @@ jobs:
 
   # ── REQUIRED_CHECKS ───────────────────────────────────────────────────────
   required_checks:
-    needs: [ setup, toolchains_verify, es_s3_up ]
+    needs: [ setup, toolchains_verify ]
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      needs.es_s3_up.result != 'cancelled' &&
       github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
     container: *toolchains
@@ -293,11 +260,10 @@ jobs:
 
   # ── TEST: unit (Linux) ────────────────────────────────────────────────────
   unit_tests_linux:
-    needs: [ setup, toolchains_verify, es_s3_up ]
+    needs: [ setup, toolchains_verify ]
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      needs.es_s3_up.result != 'cancelled' &&
       github.event_name != 'schedule' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_all_tests_on_linux')
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
@@ -326,11 +292,10 @@ jobs:
   # Matrix comes from setup: full 34-version set on develop/master/epic + manual run, the
   # 10-version representative subset on plain PRs (same split Azure encoded as separate jobs).
   it_linux:
-    needs: [ setup, toolchains_verify, es_s3_up ]
+    needs: [ setup, toolchains_verify ]
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      needs.es_s3_up.result != 'cancelled' &&
       github.event_name != 'schedule' &&
       needs.setup.outputs.it_linux_matrix != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_all_tests_on_linux')
@@ -420,11 +385,10 @@ jobs:
   it_windows:
     # toolchains_verify is in needs even though Windows doesn't use the image: Azure's TEST stage
     # depended on TOOLCHAINS_VERIFY, so a broken image fails fast instead of running doomed legs.
-    needs: [ setup, toolchains_verify, es_s3_up ]
+    needs: [ setup, toolchains_verify ]
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      needs.es_s3_up.result != 'cancelled' &&
       github.event_name != 'schedule' &&
       needs.setup.outputs.it_windows_matrix != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_all_tests_on_windows')

--- a/.github/workflows/mirror-es-libs.yml
+++ b/.github/workflows/mirror-es-libs.yml
@@ -1,0 +1,68 @@
+name: Mirror ES Libs
+
+# Mirrors an ES version's jars (and generated POMs) into the ROR libs store, for versions Elastic has
+# released but not yet published to Maven Central. Every plugin build resolves ES dependencies from that
+# store — see the repository declared in readonlyrest.plugin-common-conventions, and LibsStore, which is
+# where this workflow's write side and that read side both take the store's address from.
+#
+# Manual-only, and a one-off per ES version: run it BEFORE the branch adding that version goes through CI,
+# or that branch's build cannot resolve org.elasticsearch:elasticsearch:<version>. Step 2 of "supporting a
+# new ES version" — see the ror-release skill.
+on:
+  workflow_dispatch:
+    inputs:
+      es_versions:
+        description: 'Space or comma-separated ES versions to mirror (e.g. "9.5.1" or "9.5.1 9.4.5")'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  mirror:
+    name: Mirroring
+    runs-on: ubicloud-standard-4
+    timeout-minutes: 120
+    env:
+      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle-home
+      GRADLE_OPTS: '-Dorg.gradle.java.installations.auto-download=true'
+      AGENT_ISSELFHOSTED: '1'
+    steps:
+      - uses: actions/checkout@v4
+        with: { persist-credentials: false }
+
+      - name: Free host disk (no-op on self-hosted)
+        run: ci/free-host-disk.sh
+
+      - uses: actions/setup-java@v4
+        with: { distribution: temurin, java-version: '17' }
+
+      - name: Restore Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.gradle-home
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties', '**/settings.gradle*', '**/build.gradle*', '**/gradle.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: upload_es_artifacts
+        env:
+          ES_VERSIONS_TO_UPLOAD: ${{ inputs.es_versions }}
+          ROR_LIBS_STORE_ENDPOINT_URL: ${{ vars.ROR_LIBS_STORE_ENDPOINT_URL }}
+          ROR_LIBS_STORE_REGION: ${{ vars.ROR_LIBS_STORE_REGION }}
+          ROR_LIBS_STORE_ACCESS_KEY_ID: ${{ secrets.ROR_LIBS_STORE_ACCESS_KEY_ID }}
+          ROR_LIBS_STORE_ACCESS_KEY_SECRET: ${{ secrets.ROR_LIBS_STORE_ACCESS_KEY_SECRET }}
+          ROR_LIBS_STORE_BUCKET: ${{ vars.ROR_LIBS_STORE_BUCKET }}
+          ROR_LIBS_STORE_PATH_PREFIX: ${{ vars.ROR_LIBS_STORE_PATH_PREFIX }}
+        run: |
+          set -e
+          if [ -z "$(echo "$ES_VERSIONS_TO_UPLOAD" | tr -d '[:space:],')" ]; then
+            echo "::error::es_versions is empty — nothing to mirror"
+            exit 1
+          fi
+          ci/upload-es-artifacts.sh

--- a/build-base/src/main/groovy/readonlyrest.plugin-common-conventions.gradle
+++ b/build-base/src/main/groovy/readonlyrest.plugin-common-conventions.gradle
@@ -15,6 +15,7 @@
  *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
  */
 import tech.beshu.ror.gradle.utils.EsVersions
+import tech.beshu.ror.gradle.utils.LibsStore
 import tech.beshu.ror.gradle.utils.PluginArtifact
 
 plugins {
@@ -35,9 +36,6 @@ project.ext {
     // bytecode guard: it forces a recompile at a boundary version to prove that version's bytecode matches
     // the base before trusting the repackage.
     baselineEsVersion = EsVersions.baseline(project)
-    s3BucketName = System.getenv('ROR_LIBS_STORE_BUCKET') ?: 'beshu'
-    s3StoreAddress = System.getenv('ROR_LIBS_STORE_ENDPOINT_URL') ?: 'https://dgp.serve.beshu.tech'
-    s3LibsPathPrefix = (System.getenv('ROR_LIBS_STORE_PATH_PREFIX') ?: 'ror/libs').replaceAll('^/+', '').replaceAll('/+$', '')
 }
 
 group = 'org.elasticsearch.plugin'
@@ -71,9 +69,12 @@ ext.assemblePluginZip = { File contentsDir, esVer, File outputDir = distribution
 // The libs store: ES versions Elastic has released but not yet published to Maven Central resolve from here.
 // It is declared after mavenCentral(), so Central still answers for every version it has. mavenPom() reads
 // the POMs ror-tools publishes next to the jars; artifact() covers the jars stored without one.
+//
+// The address comes from LibsStore, which the WRITE side (ror-tools:uploadArtifactsFromEsBinaries) reads too —
+// the two must name the same location, and did not when each carried its own copy of the defaults.
 repositories {
     maven {
-        url = uri("${project.ext.s3StoreAddress.replaceAll('/+$', '')}/${project.ext.s3BucketName}/${project.ext.s3LibsPathPrefix}")
+        url = uri(LibsStore.fromEnv().repositoryUrl())
         metadataSources {
             mavenPom()
             artifact()

--- a/build-base/src/main/java/tech/beshu/ror/gradle/utils/LibsStore.java
+++ b/build-base/src/main/java/tech/beshu/ror/gradle/utils/LibsStore.java
@@ -1,0 +1,106 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.gradle.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Where the ROR libs store lives: the S3-compatible bucket ROR mirrors ES jars into, for versions Elastic has
+ * released but not yet published to Maven Central.
+ *
+ * <p>Two sides of the build address that one location, months apart in wall-clock time. The <b>read</b> side is
+ * every plugin build: {@code readonlyrest.plugin-common-conventions} declares the store as a Maven repository,
+ * so the es*x modules compile against whatever is in it. The <b>write</b> side runs once per new ES release:
+ * {@code ror-tools:uploadArtifactsFromEsBinaries} shells out to {@code ci/upload-files-to-s3.sh} with the store
+ * in the environment.
+ *
+ * <p>They must agree, and nothing checks that they do. When they disagreed the symptom appeared far from the
+ * cause: jars land in a path the repository does not serve, and the next plugin build fails to resolve
+ * {@code org.elasticsearch:elasticsearch:X.Y.Z} — which reads like a broken build, not like a mismatched bucket.
+ * So both sides read the coordinates from here, and the defaults exist once.
+ *
+ * <p>The credentials are deliberately part of this record but never defaulted: an absent key must reach the
+ * uploader as empty (it then attempts an anonymous upload and fails loudly) rather than as something guessed.
+ */
+public record LibsStore(
+    String endpointUrl,
+    String bucket,
+    String region,
+    String pathPrefix,
+    String accessKeyId,
+    String accessKeySecret) {
+
+  private static final String DEFAULT_ENDPOINT_URL = "https://dgp.serve.beshu.tech";
+  private static final String DEFAULT_BUCKET = "beshu";
+  private static final String DEFAULT_REGION = "us-east-1";
+  private static final String DEFAULT_PATH_PREFIX = "ror/libs";
+
+  /** The store as the environment describes it, falling back to the defaults above. */
+  public static LibsStore fromEnv() {
+    return from(System::getenv);
+  }
+
+  /** {@link #fromEnv()} over an arbitrary environment, so the resolution is testable. */
+  public static LibsStore from(Function<String, String> env) {
+    return new LibsStore(
+        valueOrDefault(env, "ROR_LIBS_STORE_ENDPOINT_URL", DEFAULT_ENDPOINT_URL),
+        valueOrDefault(env, "ROR_LIBS_STORE_BUCKET", DEFAULT_BUCKET),
+        valueOrDefault(env, "ROR_LIBS_STORE_REGION", DEFAULT_REGION),
+        trimSlashes(valueOrDefault(env, "ROR_LIBS_STORE_PATH_PREFIX", DEFAULT_PATH_PREFIX)),
+        valueOrDefault(env, "ROR_LIBS_STORE_ACCESS_KEY_ID", ""),
+        valueOrDefault(env, "ROR_LIBS_STORE_ACCESS_KEY_SECRET", ""));
+  }
+
+  /** The URL a Gradle {@code maven {}} repository resolves the mirrored jars and POMs from. */
+  public String repositoryUrl() {
+    return trimTrailingSlashes(endpointUrl) + "/" + bucket + "/" + pathPrefix;
+  }
+
+  /**
+   * The store as {@code ci/upload-files-to-s3.sh} expects to find it in the environment. {@code
+   * ROR_S3_TARGET_STORE} is what makes that script resolve the {@code ROR_LIBS_STORE_*} family rather than the
+   * artifacts one.
+   */
+  public Map<String, String> uploadEnvironment() {
+    var environment = new LinkedHashMap<String, String>();
+    environment.put("ROR_S3_TARGET_STORE", "LIBS");
+    environment.put("ROR_LIBS_STORE_ENDPOINT_URL", endpointUrl);
+    environment.put("ROR_LIBS_STORE_ACCESS_KEY_ID", accessKeyId);
+    environment.put("ROR_LIBS_STORE_ACCESS_KEY_SECRET", accessKeySecret);
+    environment.put("ROR_LIBS_STORE_BUCKET", bucket);
+    environment.put("ROR_LIBS_STORE_REGION", region);
+    environment.put("ROR_LIBS_STORE_PATH_PREFIX", pathPrefix);
+    return environment;
+  }
+
+  private static String valueOrDefault(
+      Function<String, String> env, String name, String defaultValue) {
+    var value = env.apply(name);
+    return value == null || value.isBlank() ? defaultValue : value;
+  }
+
+  private static String trimSlashes(String value) {
+    return trimTrailingSlashes(value).replaceAll("^/+", "");
+  }
+
+  private static String trimTrailingSlashes(String value) {
+    return value.replaceAll("/+$", "");
+  }
+}

--- a/build-base/src/test/java/tech/beshu/ror/gradle/utils/LibsStoreTest.java
+++ b/build-base/src/test/java/tech/beshu/ror/gradle/utils/LibsStoreTest.java
@@ -1,0 +1,122 @@
+/*
+ *    This file is part of ReadonlyREST.
+ *
+ *    ReadonlyREST is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    ReadonlyREST is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
+ */
+
+package tech.beshu.ror.gradle.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class LibsStoreTest {
+
+  @Test
+  void readsTheStoreFromTheEnvironment() {
+    var store =
+        LibsStore.from(
+            Map.of(
+                    "ROR_LIBS_STORE_ENDPOINT_URL", "https://store.example.com",
+                    "ROR_LIBS_STORE_BUCKET", "a-bucket",
+                    "ROR_LIBS_STORE_REGION", "eu-central-1",
+                    "ROR_LIBS_STORE_PATH_PREFIX", "a/prefix",
+                    "ROR_LIBS_STORE_ACCESS_KEY_ID", "an-id",
+                    "ROR_LIBS_STORE_ACCESS_KEY_SECRET", "a-secret")
+                ::get);
+
+    assertEquals("https://store.example.com", store.endpointUrl());
+    assertEquals("a-bucket", store.bucket());
+    assertEquals("eu-central-1", store.region());
+    assertEquals("a/prefix", store.pathPrefix());
+    assertEquals("an-id", store.accessKeyId());
+    assertEquals("a-secret", store.accessKeySecret());
+  }
+
+  @Test
+  void fallsBackToTheDefaultsWhenTheEnvironmentSaysNothing() {
+    var store = LibsStore.from(name -> null);
+
+    assertEquals("https://dgp.serve.beshu.tech", store.endpointUrl());
+    assertEquals("beshu", store.bucket());
+    assertEquals("us-east-1", store.region());
+    assertEquals("ror/libs", store.pathPrefix());
+  }
+
+  // A run gives a job "" for a `vars.X` that was never defined, and that must mean the same as
+  // unset — otherwise the store address silently loses its bucket or its prefix.
+  @Test
+  void treatsABlankValueAsUnset() {
+    var store =
+        LibsStore.from(
+            Map.of(
+                    "ROR_LIBS_STORE_ENDPOINT_URL", "",
+                    "ROR_LIBS_STORE_BUCKET", "  ",
+                    "ROR_LIBS_STORE_PATH_PREFIX", "")
+                ::get);
+
+    assertEquals("https://dgp.serve.beshu.tech", store.endpointUrl());
+    assertEquals("beshu", store.bucket());
+    assertEquals("ror/libs", store.pathPrefix());
+  }
+
+  // Credentials are the one thing never defaulted: a guessed key fails as an unattributable 403.
+  @Test
+  void leavesAbsentCredentialsEmpty() {
+    var store = LibsStore.from(name -> null);
+
+    assertEquals("", store.accessKeyId());
+    assertEquals("", store.accessKeySecret());
+  }
+
+  @Test
+  void buildsTheRepositoryUrlTheReadSideResolvesFrom() {
+    var store = LibsStore.from(name -> null);
+
+    assertEquals("https://dgp.serve.beshu.tech/beshu/ror/libs", store.repositoryUrl());
+  }
+
+  // The endpoint may or may not carry a trailing slash, and the prefix may be given with either;
+  // neither must reach the URL as a doubled or a missing separator.
+  @Test
+  void normalisesTheSlashesAroundTheStoreAddress() {
+    var store =
+        LibsStore.from(
+            Map.of(
+                    "ROR_LIBS_STORE_ENDPOINT_URL", "https://store.example.com//",
+                    "ROR_LIBS_STORE_PATH_PREFIX", "/a/prefix/")
+                ::get);
+
+    assertEquals("a/prefix", store.pathPrefix());
+    assertEquals("https://store.example.com/beshu/a/prefix", store.repositoryUrl());
+  }
+
+  @Test
+  void handsTheWriteSideTheSameStoreTheReadSideResolves() {
+    var store = LibsStore.from(Map.of("ROR_LIBS_STORE_BUCKET", "a-bucket")::get);
+
+    assertEquals(
+        Map.of(
+            "ROR_S3_TARGET_STORE", "LIBS",
+            "ROR_LIBS_STORE_ENDPOINT_URL", "https://dgp.serve.beshu.tech",
+            "ROR_LIBS_STORE_ACCESS_KEY_ID", "",
+            "ROR_LIBS_STORE_ACCESS_KEY_SECRET", "",
+            "ROR_LIBS_STORE_BUCKET", "a-bucket",
+            "ROR_LIBS_STORE_REGION", "us-east-1",
+            "ROR_LIBS_STORE_PATH_PREFIX", "ror/libs"),
+        store.uploadEnvironment());
+  }
+}

--- a/ci/README.md
+++ b/ci/README.md
@@ -20,7 +20,6 @@ directory contain the build logic; the workflow only orchestrates.
 | `it_windows` | integration tests on native-Windows ES | 3 on PRs, 7 on branches, full 33 on manual |
 | `unit_tests_windows` | `core:test` on Windows | manual `run_all_tests_on_windows` |
 | `build_ror` | builds all plugin zips + bytecode-reuse guard | PRs |
-| `es_s3_up` | uploads new ES dependency jars | `newes/*` branches |
 | `build_toolchains_image` | rebuilds the toolchains image | weekly cron + manual |
 | `determine_ci_type` → `upload_pre_ror` / `release_ror` / `publish_mvn` | release pipeline | develop/master pushes + manual `release_without_testing` |
 | `disk_probe` | host-disk recon | manual `run_disk_probe` |
@@ -28,6 +27,11 @@ directory contain the build logic; the workflow only orchestrates.
 Manual actions (`workflow_dispatch` → `actionToPerform`): `run_all_tests_on_linux`,
 `run_all_tests_on_windows`, `build_toolchains_image`, `release_without_testing`,
 `run_disk_probe`.
+
+Other workflows in `.github/workflows/`, all manual or event-driven and independent of the
+above: `mirror-es-libs.yml` (mirrors ES jars into the libs store — see [S3 stores](#s3-stores)),
+`pr-conventions.yml` (PR title/changelog checks), `actionstrings_gen.yml` (regenerates the ES
+action-string lists in the docs repo), `publish-pre-builds.yml` (on-demand ROR+ES dev images).
 
 Two orchestration rules worth knowing before editing conditions:
 
@@ -62,13 +66,38 @@ Shard stdout is written to `shard-<i>.log` files (live interleaving would be unr
 printed to the job console afterwards as collapsible groups, and uploaded as the
 `sharded-logs-*` artifact. Per-shard JUnit XML uploads as `*-results`.
 
+## S3 stores
+
+ROR uploads to S3-compatible stores through one path: `ci/s3-uploader.sh` (curl + SigV4) under
+`ci-lib.sh`'s `upload_using_aws_s3_uploader` / `..._to_key`, driven by `ci/upload-files-to-s3.sh`.
+A store is named, and its name selects a family of env vars — `ROR_<STORE>_STORE_{ENDPOINT_URL,
+ACCESS_KEY_ID,ACCESS_KEY_SECRET,BUCKET,REGION,PATH_PREFIX}`. Resolve that family in one place
+(`ci-lib.sh`) and nowhere else; each store has its own credentials, because the gateway authorizes
+each prefix separately.
+
+| Store | Holds | Written by |
+|---|---|---|
+| `ARTIFACTS` | the plugin zips customers download (`builds/`) | `upload_pre_ror` / `release_ror` |
+| `LIBS` | ES jars + POMs mirrored for versions not yet on Maven Central (`libs/`) | the `mirror-es-libs.yml` workflow |
+
+The LIBS store is the one with two sides: every plugin build **reads** it as a Maven repository,
+and `mirror-es-libs.yml` **writes** it. Both take its address from `LibsStore` (build-base) so
+they cannot name different locations — when they did, the symptom was an unresolvable
+`org.elasticsearch:elasticsearch:X.Y.Z` at compile time, nowhere near the cause.
+
+Mirroring is manual and one-off per ES version: run **Mirror ES Libs** with `es_versions` set
+(e.g. `9.5.1 9.4.5`), and run it **before** the branch adding that version goes through CI — the
+build cannot compile against jars that are not in the store yet. It used to be a CI job
+(`es_s3_up`) fired by pushing a `newes/*` branch; that coupled a few-times-a-year manual act to
+every push on such a branch, and made five CI jobs depend on a job that almost always did nothing.
+
 ## Secrets & variables
 
 **17 repository secrets + 8 variables**:
 
 | Secret | Purpose |
 |---|---|
-| `ROR_LIBS_STORE_ACCESS_KEY_ID` / `..._SECRET` | libs S3 bucket (shared ES jars; read in tests, written by `newes/*`) |
+| `ROR_LIBS_STORE_ACCESS_KEY_ID` / `..._SECRET` | libs S3 bucket (shared ES jars; read by every build, written by `mirror-es-libs.yml`) |
 | `ROR_ARTIFACTS_STORE_ACCESS_KEY_ID` / `..._SECRET` | artifacts S3 bucket (built plugin binaries) |
 | `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD` | pushing ROR + toolchains images |
 | `DOCKER_HUB_USER` / `DOCKER_HUB_RO_TOKEN` | authenticated docker pulls (testcontainers rate limit); `ci/docker-hub-auth.sh` is a no-op when unset |
@@ -77,7 +106,9 @@ printed to the job console afterwards as collapsible groups, and uploaded as the
 | `PGP_SECRET_KEY_B64` | base64 of `secret.pgp`; the publish step decodes it to `.travis/secret.pgp`. Create with `base64 -w0 secret.pgp \| gh secret set PGP_SECRET_KEY_B64` |
 
 Variables (`vars.NAME`, non-sensitive): `ROR_LIBS_STORE_{ENDPOINT_URL,REGION,BUCKET,PATH_PREFIX}`
-and `ROR_ARTIFACTS_STORE_{...}`.
+and `ROR_ARTIFACTS_STORE_{...}`. Only the key pairs are secrets. The LIBS values are optional —
+unset (or empty, which is what an undefined `vars.X` expands to) falls back to the defaults in
+`LibsStore`, which is also what a local build resolves against.
 
 Release tags push via the checkout token (`release_ror` has `permissions: contents: write`)
 — no SSH deploy key. Fork PRs get no secrets (GitHub default); `cve_check` and docker auth
@@ -94,7 +125,7 @@ Everything the Azure pipeline did is ported — nothing was dropped. The mapping
 | `DISK_PROBE` | `disk_probe` (manual `run_disk_probe`) |
 | `BUILD_TOOLCHAINS_IMAGE` | `build_toolchains_image` (weekly cron + manual) |
 | `TOOLCHAINS_VERIFY` | `toolchains_verify` |
-| `ES_S3_UP` | `es_s3_up` |
+| `ES_S3_UP` | the standalone `mirror-es-libs.yml` workflow (manual; was a `newes/*` push trigger) |
 | `REQUIRED_CHECKS` | `required_checks` (same 4-task matrix) |
 | `OPTIONAL_CHECKS` | `optional_checks` (matrix; `continue-on-error` = "warn but pass") |
 | `TEST` (unit + IT + WIN legs) | `unit_tests_linux`, `it_linux`, `it_windows`, `unit_tests_windows` |

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -193,7 +193,9 @@ function upload_using_aws_s3_uploader {
 }
 
 # Upload to an exact key. For callers that mirror a directory tree, where the key is the file's
-# path within that tree and not its basename.
+# path within that tree and not its basename. Its caller is the e2e Cypress report uploader
+# (RORDEV-1229, change/RORDEV-1229_run_e2e_tests), which today resolves ROR_<STORE>_STORE_* with its
+# own inline copy — the duplication this file exists to remove. Unused until that branch lands.
 function upload_using_aws_s3_uploader_to_key {
   _upload_to_s3_target "$1" "$2" "${3:-ARTIFACTS}" "${4:-}"
 }

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 
-CI_DIR=$(dirname "$0")
+# This file's OWN directory — used to locate the sibling scripts it shells out to (s3-uploader.sh).
+# BASH_SOURCE, not $0: $0 is the script that INVOKED us, which is a different directory whenever this
+# lib is sourced rather than run (`source ci/ci-lib.sh && reap_ci_job_containers` resolved it to ".").
+CI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 function docker_image_exists {
   docker manifest inspect "$1" >/dev/null 2>&1
@@ -134,18 +137,30 @@ function tag {
 # Upload a file to an S3-compatible store using the SigV4 curl uploader.
 #
 # The store is selected by the 3rd arg (default ARTIFACTS) and resolves the matching
-# ROR_<STORE>_STORE_* env vars, so the same logic serves both the artifacts store
-# (ROR_ARTIFACTS_STORE_*) and the libs store (ROR_LIBS_STORE_*). Each store keeps its
-# own endpoint, credentials, bucket, region and path-prefix.
-function upload_using_aws_s3_uploader {
+# ROR_<STORE>_STORE_* env vars, so the same logic serves any store: each one keeps its own
+# endpoint, credentials, bucket, region and path-prefix under its own name.
+#
+# This is the ONE place that turns a store name into a set of values. Anything uploading to a
+# ROR store goes through it rather than resolving ROR_<STORE>_STORE_* itself — a second copy of
+# this resolution is how the two sides of the libs store drifted apart before (see LibsStore).
+#
+# For the libs store the caller (ror-tools, via LibsStore) always passes explicit values, so the
+# fallbacks below never apply to it; they only cover a store whose vars are partly unset.
+#
+# Two entry points, differing only in what the destination MEANS:
+#   upload_using_aws_s3_uploader        <file> <dir>  [store] [mime]  — key is <dir>/<basename>
+#   upload_using_aws_s3_uploader_to_key <file> <key>  [store] [mime]  — key is exactly <key>
+# The mime type is optional; without it the uploader guesses (which needs `file` on the runner).
+function _upload_to_s3_target {
   local LOCAL_FILE="$1"
-  local S3_PATH STORE BUCKET PATH_PREFIX
-  S3_PATH=$(echo "$2" | sed 's:/*$::')
-  STORE="${3:-ARTIFACTS}"
+  local S3_TARGET="$2"
+  local STORE="${3:-ARTIFACTS}"
+  local MIME="${4:-}"
+  local BUCKET PATH_PREFIX
 
   if [[ ! -f "$LOCAL_FILE" ]]; then
     echo "ERROR: artifact to upload not found (or not a regular file): $LOCAL_FILE"
-    exit 1
+    return 1
   fi
 
   # Indirectly resolve the store-specific env vars (e.g. ROR_LIBS_STORE_BUCKET).
@@ -167,7 +182,20 @@ function upload_using_aws_s3_uploader {
   S3_ENDPOINT_URL="$ENDPOINT" \
     "$CI_DIR"/s3-uploader.sh \
       "$AK" "$SK" \
-      "$BUCKET@${REGION:-us-east-1}" "$LOCAL_FILE" "${PATH_PREFIX}${S3_PATH}/"
+      "$BUCKET@${REGION:-us-east-1}" "$LOCAL_FILE" "${PATH_PREFIX}${S3_TARGET}" ${MIME:+"$MIME"}
+}
+
+# Upload into a directory: the uploader appends the file's basename to it.
+function upload_using_aws_s3_uploader {
+  local S3_DIR
+  S3_DIR=$(echo "$2" | sed 's:/*$::')
+  _upload_to_s3_target "$1" "${S3_DIR}/" "${3:-ARTIFACTS}" "${4:-}"
+}
+
+# Upload to an exact key. For callers that mirror a directory tree, where the key is the file's
+# path within that tree and not its basename.
+function upload_using_aws_s3_uploader_to_key {
+  _upload_to_s3_target "$1" "$2" "${3:-ARTIFACTS}" "${4:-}"
 }
 
 function log_disk_usage {

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -107,140 +107,11 @@ run_integration_tests() {
   if [ "$rc" -ne 0 ]; then find . | grep hs_err | xargs cat 2>/dev/null || true; return "$rc"; fi
 }
 
-if [[ $ROR_TASK == "integration_es94x" ]]; then
-  run_integration_tests "es94x"
-fi
-
-if [[ $ROR_TASK == "integration_es92x" ]]; then
-  run_integration_tests "es92x"
-fi
-
-if [[ $ROR_TASK == "integration_es91x" ]]; then
-  run_integration_tests "es91x"
-fi
-
-if [[ $ROR_TASK == "integration_es90x" ]]; then
-  run_integration_tests "es90x"
-fi
-
-if [[ $ROR_TASK == "integration_es818x" ]]; then
-  run_integration_tests "es818x"
-fi
-
-if [[ $ROR_TASK == "integration_es816x" ]]; then
-  run_integration_tests "es816x"
-fi
-
-if [[ $ROR_TASK == "integration_es815x" ]]; then
-  run_integration_tests "es815x"
-fi
-
-if [[ $ROR_TASK == "integration_es814x" ]]; then
-  run_integration_tests "es814x"
-fi
-
-if [[ $ROR_TASK == "integration_es813x" ]]; then
-  run_integration_tests "es813x"
-fi
-
-if [[ $ROR_TASK == "integration_es812x" ]]; then
-  run_integration_tests "es812x"
-fi
-
-if [[ $ROR_TASK == "integration_es811x" ]]; then
-  run_integration_tests "es811x"
-fi
-
-if [[ $ROR_TASK == "integration_es810x" ]]; then
-  run_integration_tests "es810x"
-fi
-
-if [[ $ROR_TASK == "integration_es89x" ]]; then
-  run_integration_tests "es89x"
-fi
-
-if [[ $ROR_TASK == "integration_es88x" ]]; then
-  run_integration_tests "es88x"
-fi
-
-if [[ $ROR_TASK == "integration_es87x" ]]; then
-  run_integration_tests "es87x"
-fi
-
-if [[ $ROR_TASK == "integration_es85x" ]]; then
-  run_integration_tests "es85x"
-fi
-
-if [[ $ROR_TASK == "integration_es84x" ]]; then
-  run_integration_tests "es84x"
-fi
-
-if [[ $ROR_TASK == "integration_es83x" ]]; then
-  run_integration_tests "es83x"
-fi
-
-if [[ $ROR_TASK == "integration_es82x" ]]; then
-  run_integration_tests "es82x"
-fi
-
-if [[ $ROR_TASK == "integration_es81x" ]]; then
-  run_integration_tests "es81x"
-fi
-
-if [[ $ROR_TASK == "integration_es80x" ]]; then
-  run_integration_tests "es80x"
-fi
-
-if [[ $ROR_TASK == "integration_es717x" ]]; then
-  run_integration_tests "es717x"
-fi
-
-if [[ $ROR_TASK == "integration_es716x" ]]; then
-  run_integration_tests "es716x"
-fi
-
-if [[ $ROR_TASK == "integration_es714x" ]]; then
-  run_integration_tests "es714x"
-fi
-
-if [[ $ROR_TASK == "integration_es711x" ]]; then
-  run_integration_tests "es711x"
-fi
-
-if [[ $ROR_TASK == "integration_es710x" ]]; then
-  run_integration_tests "es710x"
-fi
-
-if [[ $ROR_TASK == "integration_es79x" ]]; then
-  run_integration_tests "es79x"
-fi
-
-if [[ $ROR_TASK == "integration_es78x" ]]; then
-  run_integration_tests "es78x"
-fi
-
-if [[ $ROR_TASK == "integration_es77x" ]]; then
-  run_integration_tests "es77x"
-fi
-
-if [[ $ROR_TASK == "integration_es74x" ]]; then
-  run_integration_tests "es74x"
-fi
-
-if [[ $ROR_TASK == "integration_es73x" ]]; then
-  run_integration_tests "es73x"
-fi
-
-if [[ $ROR_TASK == "integration_es72x" ]]; then
-  run_integration_tests "es72x"
-fi
-
-if [[ $ROR_TASK == "integration_es70x" ]]; then
-  run_integration_tests "es70x"
-fi
-
-if [[ $ROR_TASK == "integration_es67x" ]]; then
-  run_integration_tests "es67x"
+# One dispatch for every es*x module: the task name is integration_<module>, and the module is the
+# only thing that varies. Adding an ES module therefore needs no edit here — only in the workflow
+# matrix, which is where the list of modules to run actually lives.
+if [[ $ROR_TASK =~ ^integration_(es[0-9]+x)$ ]]; then
+  run_integration_tests "${BASH_REMATCH[1]}"
 fi
 
 build_ror_plugins() {
@@ -264,52 +135,16 @@ build_ror_plugins() {
   done <<< "$modules"
 }
 
-if [[ $ROR_TASK == "build_es9xx" ]]; then
-  build_ror_plugins "9"
-fi
-
-if [[ $ROR_TASK == "build_es8xx" ]]; then
-  build_ror_plugins "8"
-fi
-
-if [[ $ROR_TASK == "build_es7xx" ]]; then
-  build_ror_plugins "7"
-fi
-
-if [[ $ROR_TASK == "build_es6xx" ]]; then
-  build_ror_plugins "6"
-fi
-
-if [[ $ROR_TASK == "upload_pre_es9xx" ]]; then
-  publish_ror_plugins "9" "upload_pre"
-fi
-
-if [[ $ROR_TASK == "upload_pre_es8xx" ]]; then
-  publish_ror_plugins "8" "upload_pre"
-fi
-
-if [[ $ROR_TASK == "upload_pre_es7xx" ]]; then
-  publish_ror_plugins "7" "upload_pre"
-fi
-
-if [[ $ROR_TASK == "upload_pre_es6xx" ]]; then
-  publish_ror_plugins "6" "upload_pre"
-fi
-
-if [[ $ROR_TASK == "release_es9xx" ]]; then
-  publish_ror_plugins "9" "release"
-fi
-
-if [[ $ROR_TASK == "release_es8xx" ]]; then
-  publish_ror_plugins "8" "release"
-fi
-
-if [[ $ROR_TASK == "release_es7xx" ]]; then
-  publish_ror_plugins "7" "release"
-fi
-
-if [[ $ROR_TASK == "release_es6xx" ]]; then
-  publish_ror_plugins "6" "release"
+# build_es<major>xx / upload_pre_es<major>xx / release_es<major>xx: three families over the same four
+# ES generations, differing only in which function the generation is handed to.
+if [[ $ROR_TASK =~ ^(build|upload_pre|release)_es([6-9])xx$ ]]; then
+  ROR_TASK_FAMILY="${BASH_REMATCH[1]}"
+  ES_MAJOR="${BASH_REMATCH[2]}"
+  case "$ROR_TASK_FAMILY" in
+    build)      build_ror_plugins "$ES_MAJOR" ;;
+    upload_pre) publish_ror_plugins "$ES_MAJOR" "upload_pre" ;;
+    release)    publish_ror_plugins "$ES_MAJOR" "release" ;;
+  esac
 fi
 
 check_maven_artifacts_exist() {

--- a/ci/s3-uploader.sh
+++ b/ci/s3-uploader.sh
@@ -142,7 +142,7 @@ else
     CURL_FLAGS="-f"
 fi
 curl                            \
-    -# -k $CURL_FLAGS           \
+    -# $CURL_FLAGS              \
     -F "key=$targfile"          \
     $key_and_sig_args           \
     -F "Content-Type=$mime"     \

--- a/ci/upload-es-artifacts.sh
+++ b/ci/upload-es-artifacts.sh
@@ -1,9 +1,63 @@
 #!/bin/bash
+#
+# Mirrors the ES jars (and their generated POMs) of one or more ES versions into the ROR libs store, for
+# versions Elastic has released but not yet published to Maven Central. The es*x modules resolve those
+# versions from the store until Central catches up — see the repository declared in
+# readonlyrest.plugin-common-conventions, and LibsStore for where both sides get the address.
+#
+# This is a MANUAL step of supporting a new ES version, not something CI decides on its own: run it once
+# per new ES release, then never again for that version.
+#
+#   Which versions:  ES_VERSIONS_TO_UPLOAD, space- or comma-separated (e.g. "9.5.1 9.4.5 8.19.20").
+#   How to run it:   the "Mirror ES Libs" workflow (.github/workflows/mirror-es-libs.yml) — manual only.
+#   Locally:         ES_VERSIONS_TO_UPLOAD="9.5.1" ci/upload-es-artifacts.sh
+#                    (needs ROR_LIBS_STORE_ACCESS_KEY_ID / _SECRET in the environment)
+#
+# Versions used to be selected by uncommenting a line here, pushing a `newes/*` branch to fire ci.yml's
+# es_s3_up job, and re-commenting before merge. That made "nothing was uploaded" and "the upload was not
+# asked for" indistinguishable: a push that forgot the uncomment produced a GREEN job that transferred
+# nothing, and the mistake only surfaced later, and in disguise, as an es*x module failing to resolve
+# org.elasticsearch:elasticsearch:X.Y.Z. Uploaded versions are now recorded in git history (the workflow
+# run) rather than in commented-out code.
+#
+# An empty list is not an error HERE — see the warning below — because this script is also runnable by
+# hand. The workflow, whose whole reason to exist is mirroring something, rejects it before calling us.
 
-set -xe
+set -eo pipefail
 
 echo ">>> ($0) UPLOADING ES ARTIFACTS ..."
 
-#./gradlew --stacktrace --info clean ror-tools:uploadArtifactsFromEsBinaries -PesVersion=9.5.1
-#./gradlew --stacktrace --info clean ror-tools:uploadArtifactsFromEsBinaries -PesVersion=9.4.5
-#./gradlew --stacktrace --info clean ror-tools:uploadArtifactsFromEsBinaries -PesVersion=8.19.20
+VERSIONS_INPUT="${ES_VERSIONS_TO_UPLOAD:-}"
+
+# Not an error here: this script is runnable by hand, and "show me what it would do" should not fail.
+# It is announced loudly all the same — a silent no-op is exactly what used to be mistaken for a
+# successful upload. The workflow turns the same state into an error before it ever gets here.
+if [ -z "$(echo "$VERSIONS_INPUT" | tr -d '[:space:],')" ]; then
+  echo "::warning::ES_VERSIONS_TO_UPLOAD is empty — NO ES artifacts were uploaded to the libs store."
+  echo "    Set it (e.g. ES_VERSIONS_TO_UPLOAD='9.5.1 9.4.5') to mirror an ES version's jars."
+  exit 0
+fi
+
+read -r -a VERSIONS <<< "$(echo "$VERSIONS_INPUT" | tr ',' ' ')"
+
+# Validate the whole list before uploading anything: a typo must not leave the store holding a half-done
+# mirror under a junk version directory that someone later has to find and delete by hand.
+for VERSION in "${VERSIONS[@]}"; do
+  if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+    echo "::error::'$VERSION' is not an ES version (expected X.Y.Z)"
+    exit 1
+  fi
+done
+
+echo ">>> Uploading ES artifacts for: ${VERSIONS[*]}"
+
+for VERSION in "${VERSIONS[@]}"; do
+  echo ""
+  echo ">>> ES $VERSION"
+  # `clean` between versions: the mirror tasks stage the jars they publish in ror-tools/build, and a
+  # previous version's staged jars there would be published again under this version's coordinates.
+  ./gradlew --stacktrace clean ror-tools:uploadArtifactsFromEsBinaries "-PesVersion=$VERSION" </dev/null
+done
+
+echo ""
+echo ">>> DONE — uploaded ES artifacts for: ${VERSIONS[*]}"

--- a/ror-tools/build.gradle
+++ b/ror-tools/build.gradle
@@ -112,6 +112,7 @@ import org.gradle.process.ExecOperations
 import tech.beshu.ror.gradle.utils.EsDistribution
 import tech.beshu.ror.gradle.utils.ArtifactGroups
 import tech.beshu.ror.gradle.utils.EsLibsMirror
+import tech.beshu.ror.gradle.utils.LibsStore
 import tech.beshu.ror.gradle.utils.MavenPoms
 
 // Publishes the ES jars and their POMs to the libs store, for ES versions Elastic has released but not yet
@@ -121,15 +122,9 @@ import tech.beshu.ror.gradle.utils.MavenPoms
 // EsLibsMirror decides what to publish and what the POMs declare; the tasks below do the I/O around it: copying
 // jars out of the unpacked distribution, writing the generated POMs and uploading both.
 
-def libsStoreEnvironment = [
-        'ROR_S3_TARGET_STORE'             : 'LIBS',
-        'ROR_LIBS_STORE_ENDPOINT_URL'     : System.getenv('ROR_LIBS_STORE_ENDPOINT_URL') ?: 'https://dgp.serve.beshu.tech',
-        'ROR_LIBS_STORE_ACCESS_KEY_ID'    : System.getenv('ROR_LIBS_STORE_ACCESS_KEY_ID') ?: '',
-        'ROR_LIBS_STORE_ACCESS_KEY_SECRET': System.getenv('ROR_LIBS_STORE_ACCESS_KEY_SECRET') ?: '',
-        'ROR_LIBS_STORE_BUCKET'           : System.getenv('ROR_LIBS_STORE_BUCKET') ?: 'beshu',
-        'ROR_LIBS_STORE_REGION'           : System.getenv('ROR_LIBS_STORE_REGION') ?: 'us-east-1',
-        'ROR_LIBS_STORE_PATH_PREFIX'      : System.getenv('ROR_LIBS_STORE_PATH_PREFIX') ?: 'ror/libs',
-]
+// Same store the es*x modules RESOLVE from (see the repository in readonlyrest.plugin-common-conventions):
+// LibsStore is where its coordinates and their defaults are defined, once, for both sides.
+def libsStoreEnvironment = LibsStore.fromEnv().uploadEnvironment()
 
 def targetEsVersion = esVersion.toString()
 def buildDirPath = { layout.buildDirectory.get().asFile.toPath() }


### PR DESCRIPTION
## Why

When Elastic releases an ES version, Maven Central does not have its jars yet. We mirror them into
our libs store, and every plugin build resolves ES dependencies from there.

Until now that mirroring worked like this: uncomment a line in `ci/upload-es-artifacts.sh`, push a
`newes/*` branch to fire the `es_s3_up` CI job, then re-comment the line before merging.

Two problems with it:

- If you forgot to uncomment the line, the job was **green and uploaded nothing**. The mistake showed
  up much later as an es*x module failing to resolve `org.elasticsearch:elasticsearch:X.Y.Z`.
- Something we do a few times a year ran on every push to such a branch, and five CI jobs had a
  `needs` on a job that almost always did nothing.

## What changed

**Mirroring is now its own manual workflow.** `.github/workflows/mirror-es-libs.yml` takes the ES
versions as an input (`9.5.1 9.4.5`), so there is nothing to uncomment and nothing to revert. Which
versions were mirrored, and when, is now visible in the workflow run history. `ci/upload-es-artifacts.sh`
reads them from `ES_VERSIONS_TO_UPLOAD`, validates the whole list before uploading anything (a typo
must not leave half a mirror in the store), and can also be run by hand.

**The libs store address lives in one place.** The build that *reads* the store (the Maven repository
in `plugin-common-conventions`) and the task that *writes* it (`ror-tools:uploadArtifactsFromEsBinaries`)
each had their own copy of the endpoint, bucket and prefix defaults. They can drift, and they did. Both
now take the address from the new `LibsStore` class (`build-base`), which has unit tests.

**`es_s3_up` and the `newes/*` trigger are removed** from `ci.yml`, together with the `needs` on it in
the five jobs that waited for it.

## Also in here

- `ci-lib.sh`: `upload_using_aws_s3_uploader` gained a sibling, `..._to_key`, for uploads where the S3
  key is a path in a mirrored tree rather than a file name. Store resolution stays in one function.
- `ci-lib.sh`: `CI_DIR` now uses `BASH_SOURCE` instead of `$0`, which was wrong whenever the lib was
  sourced rather than run.
- `s3-uploader.sh`: dropped `curl -k`, so TLS certificates are verified again.
- `run-pipeline.sh`: ~35 near-identical `if [[ $ROR_TASK == "integration_esNNx" ]]` blocks (and the
  build/upload/release ones) collapsed into two pattern matches. Adding an ES module no longer needs an
  edit here.
- `ci/README.md` and the `ror-release` skill describe the new flow.

## How to use it

Supporting a new ES version, step 2 is now: run **Mirror ES Libs** with `es_versions` set, *before*
the branch adding that version goes through CI.

## Testing

Build-level change only, no product code touched. `LibsStoreTest` covers the store defaults and the
read/write address agreement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for mirroring selected Elasticsearch versions to the libraries store.
  * Version mirroring accepts space- or comma-separated lists, validates all versions, and reports uploaded versions.
  * Added centralized library-store configuration with environment-based defaults and normalized repository paths.
  * Added support for uploading artifacts using exact storage keys.

* **Bug Fixes**
  * TLS certificate verification is now enabled for library uploads.
  * CI task detection now supports Elasticsearch generations 6–9 more consistently.

* **Documentation**
  * Updated CI guidance for library mirroring, storage ownership, credentials, and workflow usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->