### PR TITLE
[RORDEV-2168] Add CI memory telemetry and cut container RSS to stop host-OOM kills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,8 @@ jobs:
         with: { fetch-depth: 1, persist-credentials: false }
       - name: Free host disk (no-op on self-hosted)
         run: ci/free-host-disk.sh
+      - name: Start memory telemetry
+        run: ci/mem-telemetry.sh start integration-tests/build/mem-telemetry-${{ matrix.ROR_TASK }}.log > "$RUNNER_TEMP/mem-telemetry.pid"
       - name: ${{ matrix.ROR_TASK }}
         env:
           ROR_TASK: ${{ matrix.ROR_TASK }}
@@ -361,8 +363,7 @@ jobs:
           # es94x tolerated 3 only because it excludes some of the heavy suites other modules run.
           ROR_BALANCED_SHARDS: 'true'
           ROR_HEAVY_SUITE_PERMITS: '2'
-          # No debugger ever attaches to a CI ES container; the JDWP agent costs ~90MB RSS per
-          # container (~1GB at the ~11-container worst case). Local runs keep it on. (RORDEV-2168)
+          # the JDWP agent costs ~90MB RSS per ES container and nothing attaches to it in CI
           ROR_ES_JDWP: 'false'
           ROR_LIBS_STORE_ENDPOINT_URL: ${{ vars.ROR_LIBS_STORE_ENDPOINT_URL }}
           ROR_LIBS_STORE_REGION: ${{ vars.ROR_LIBS_STORE_REGION }}
@@ -394,13 +395,12 @@ jobs:
             cat "$f"
             echo "::endgroup::"
           done
-      # Memory-pressure evidence (RORDEV-2168): worst sample + OOM forensics, so an exit-137 leg
-      # shows WHAT was resident when the host ran dry instead of a bare SIGKILL.
       - name: Memory telemetry report
         if: always()
         env:
           ROR_CI_JOB_ID: ${{ github.run_id }}-${{ strategy.job-index }}
         run: |
+          [ -f "$RUNNER_TEMP/mem-telemetry.pid" ] && ci/mem-telemetry.sh stop "$(cat "$RUNNER_TEMP/mem-telemetry.pid")" || true
           for f in integration-tests/build/mem-telemetry-*.log; do
             [ -f "$f" ] || continue
             echo "::group::$(basename "$f") report"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,9 @@ jobs:
           # es94x tolerated 3 only because it excludes some of the heavy suites other modules run.
           ROR_BALANCED_SHARDS: 'true'
           ROR_HEAVY_SUITE_PERMITS: '2'
+          # No debugger ever attaches to a CI ES container; the JDWP agent costs ~90MB RSS per
+          # container (~1GB at the ~11-container worst case). Local runs keep it on. (RORDEV-2168)
+          ROR_ES_JDWP: 'false'
           ROR_LIBS_STORE_ENDPOINT_URL: ${{ vars.ROR_LIBS_STORE_ENDPOINT_URL }}
           ROR_LIBS_STORE_REGION: ${{ vars.ROR_LIBS_STORE_REGION }}
           ROR_LIBS_STORE_ACCESS_KEY_ID: ${{ secrets.ROR_LIBS_STORE_ACCESS_KEY_ID }}
@@ -391,6 +394,26 @@ jobs:
             cat "$f"
             echo "::endgroup::"
           done
+      # Memory-pressure evidence (RORDEV-2168): worst sample + OOM forensics, so an exit-137 leg
+      # shows WHAT was resident when the host ran dry instead of a bare SIGKILL.
+      - name: Memory telemetry report
+        if: always()
+        env:
+          ROR_CI_JOB_ID: ${{ github.run_id }}-${{ strategy.job-index }}
+        run: |
+          for f in integration-tests/build/mem-telemetry-*.log; do
+            [ -f "$f" ] || continue
+            echo "::group::$(basename "$f") report"
+            ci/mem-telemetry.sh report "$f"
+            echo "::endgroup::"
+          done
+      - name: Publish memory telemetry
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mem-telemetry-${{ matrix.ROR_TASK }}
+          path: integration-tests/build/mem-telemetry-*.log
+          if-no-files-found: ignore
       # Drift guard for duration-balanced sharding: warns when measured suite times diverge from
       # the committed suite-timings.json and uploads a regenerated file (regeneration = download
       # the artifact, commit it). One leg only — es90x (the first ES 9 module: a stable reference

--- a/ci/mem-telemetry.sh
+++ b/ci/mem-telemetry.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Memory telemetry for the integration CI legs (RORDEV-2168).
+# Memory telemetry for the integration CI legs.
 #
 # A leg runs ~9 JVMs plus up to 8 ES containers on a 16GB runner. When the tail of that sum
 # crosses physical RAM, the kernel OOM killer SIGKILLs the fattest process and the job dies

--- a/ci/mem-telemetry.sh
+++ b/ci/mem-telemetry.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Memory telemetry for the integration CI legs (RORDEV-2168).
+#
+# A leg runs ~9 JVMs plus up to 8 ES containers on a 16GB runner. When the tail of that sum
+# crosses physical RAM, the kernel OOM killer SIGKILLs the fattest process and the job dies
+# with a bare "exit code 137" and no evidence. This sampler records, every 10 seconds:
+#   * host MemAvailable/SwapFree (/proc/meminfo is not namespaced, so the values are host-wide
+#     even though the job runs inside the toolchains container)
+#   * memory PSI (pressure-stall, /proc/pressure/memory) where the kernel exposes it
+#   * the top processes by RSS in the job container's PID namespace (the gradle/JVM stack)
+#   * docker stats for all containers (the ES/deps containers are siblings on the host daemon)
+#
+# Usage:
+#   ci/mem-telemetry.sh start <logfile>    prints the sampler PID; runs until stopped or 3h
+#   ci/mem-telemetry.sh stop <pid>
+#   ci/mem-telemetry.sh report <logfile>   worst-pressure sample + end-of-run OOM forensics
+set -u
+
+INTERVAL_S=10
+MAX_LIFETIME_S=10800   # self-terminate after 3h: never outlive a hung/cancelled job
+
+sample_once() {
+  local ts avail swapfree psi
+  ts=$(date -u +%FT%TZ)
+  # MemAvailable, not MemFree: it includes reclaimable page cache, which is what the OOM killer
+  # effectively has to work with.
+  read -r avail swapfree < <(awk '/^MemAvailable:/{a=int($2/1024)} /^SwapFree:/{s=int($2/1024)} END{print a, s}' /proc/meminfo)
+  psi=$(awk '/^some/{for(i=1;i<=NF;i++) if($i ~ /^avg10=/){sub("avg10=","",$i); print $i}}' /proc/pressure/memory 2>/dev/null || echo "n/a")
+  echo "=== $ts avail_mb=$avail swapfree_mb=$swapfree psi_some_avg10=$psi"
+  # Top of THIS PID namespace = the gradle stack (orchestrator, shard JVMs, test workers).
+  ps -eo rss=,pid=,args= --sort=-rss | head -12 | awk '{rss=int($1/1024); pid=$2; $1=""; $2=""; cmd=substr($0,3,90); printf "P rss_mb=%s pid=%s %s\n", rss, pid, cmd}'
+  # Sibling containers (ES nodes, LDAP, wiremock, ...). --no-stream: one shot, ~1s.
+  docker stats --no-stream --format 'D {{.Name}} {{.MemUsage}}' 2>/dev/null || echo "D docker-stats-unavailable"
+}
+
+case "${1:-}" in
+  start)
+    LOG=${2:?usage: mem-telemetry.sh start <logfile>}
+    mkdir -p "$(dirname "$LOG")"
+    (
+      # Sub-shell sampler, disowned: survives the caller, never survives MAX_LIFETIME_S.
+      end=$((SECONDS + MAX_LIFETIME_S))
+      while [ "$SECONDS" -lt "$end" ]; do
+        sample_once
+        sleep "$INTERVAL_S"
+      done
+    ) >>"$LOG" 2>&1 &
+    disown
+    echo $!
+    ;;
+
+  stop)
+    kill "${2:?usage: mem-telemetry.sh stop <pid>}" 2>/dev/null || true
+    ;;
+
+  report)
+    LOG=${2:?usage: mem-telemetry.sh report <logfile>}
+    if [ ! -s "$LOG" ]; then echo "no telemetry recorded at $LOG"; exit 0; fi
+    echo "##### Worst memory-pressure sample (lowest host MemAvailable) #####"
+    # Block = one sample (=== header + P/D lines). Print the block with the lowest avail_mb.
+    # BEGIN{n=0} is load-bearing: an uninitialized n is "" as an array SUBSCRIPT (not 0), so the
+    # first saved block would land under key "" and index 0 would read back empty.
+    awk '
+      BEGIN { n=0 }
+      /^=== / { if (block != "" ) { blocks[n]=block; avails[n]=avail; n++ }
+                block=$0 ORS; avail=$0; sub(/.*avail_mb=/,"",avail); sub(/ .*/,"",avail); next }
+      { block=block $0 ORS }
+      END { if (block != "") { blocks[n]=block; avails[n]=avail; n++ }
+            min=-1
+            for (i=0;i<n;i++) if (min<0 || avails[i]+0 < avails[min]+0) min=i
+            if (min>=0) print blocks[min]
+            print "samples=" n
+            low=0; for (i=0;i<n;i++) if (avails[i]+0 < 1024) low++
+            print "samples_below_1gb_available=" low }
+    ' "$LOG"
+    echo "##### Last sample before shutdown #####"
+    awk '/^=== /{block=$0 ORS; next} {block=block $0 ORS} END{printf "%s", block}' "$LOG"
+    echo "##### Kernel OOM-killer evidence (host ring buffer; may be restricted in-container) #####"
+    # Capture first: `| tail` exits 0 even on empty input, so `|| echo` alone can never fire.
+    OOM_LINES=$(dmesg 2>/dev/null | grep -iE "out of memory|oom[-_]kill|killed process" | tail -20)
+    if [ -n "$OOM_LINES" ]; then echo "$OOM_LINES"; else echo "no OOM events visible (or dmesg restricted)"; fi
+    echo "##### Containers of this CI job: OOMKilled / exit codes #####"
+    if [ -n "${ROR_CI_JOB_ID:-}" ]; then
+      docker ps -a --filter "label=ror.ci-job=$ROR_CI_JOB_ID" --format '{{.ID}} {{.Names}}' 2>/dev/null \
+        | while read -r id name; do
+            docker inspect -f "{{.Name}} oomkilled={{.State.OOMKilled}} exit={{.State.ExitCode}} status={{.State.Status}}" "$id" 2>/dev/null
+          done
+    else
+      echo "ROR_CI_JOB_ID not set - skipping container inspection"
+    fi
+    ;;
+
+  *)
+    echo "usage: $0 start <logfile> | stop <pid> | report <logfile>"; exit 2
+    ;;
+esac

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -11,7 +11,6 @@ source "$(dirname "$0")/publish-ror-plugins.sh"
 GRADLE_PIDS=()
 terminate() {
   echo ">>> Termination signal received — killing gradle tree(s) + reaping this CI job's containers..."
-  [ -n "${TELEMETRY_PID:-}" ] && kill "$TELEMETRY_PID" 2>/dev/null
   # Negative PID = signal the whole process group (gradle + its worker JVMs).
   for pid in "${GRADLE_PIDS[@]}"; do kill -TERM -- "-$pid" 2>/dev/null || true; done
   sleep 5
@@ -80,11 +79,6 @@ run_integration_tests() {
 
   echo ">>> $ES_MODULE => ror-tools:test (serial gate) + integration-tests:shardedTest (${parallelism} shard(s)).."
 
-  # Background memory sampler (RORDEV-2168): records host MemAvailable + per-process/container RSS
-  # so an exit-137 (host OOM SIGKILL) leaves evidence. Reported/uploaded by ci.yml `if: always()`.
-  # Global, not local: terminate() must reach it. Self-terminates after 3h even if never stopped.
-  TELEMETRY_PID=$(ci/mem-telemetry.sh start "integration-tests/build/mem-telemetry-${ES_MODULE}.log") || TELEMETRY_PID=""
-
   # Each gradle invocation runs in its OWN process group (setsid) so the trap can reap the whole tree;
   # appends the leader PID to GRADLE_PIDS (never pruned) and sets LAST_PID for the caller.
   LAST_PID=""
@@ -104,17 +98,12 @@ run_integration_tests() {
   # 1) ror-tools:test ONCE, serially (cheap, no ES; gates the CI job). Also warms :build-base/:buildSrc.
   run_one ror-tools:test
   wait "$LAST_PID"; local rc=$?
-  if [ "$rc" -ne 0 ]; then
-    # Stop the sampler on this early exit too, so it cannot keep writing while ci.yml reads the log.
-    [ -n "${TELEMETRY_PID:-}" ] && ci/mem-telemetry.sh stop "$TELEMETRY_PID"
-    find . | grep hs_err | xargs cat 2>/dev/null || true; return "$rc"
-  fi
+  if [ "$rc" -ne 0 ]; then find . | grep hs_err | xargs cat 2>/dev/null || true; return "$rc"; fi
 
   # 2) All sharding orchestration lives in integration-tests:shardedTest (see its build.gradle):
   #    prebuild barrier via task deps, K child ./gradlew spawn/wait, ProcessHandle kill on cancel.
   run_one integration-tests:shardedTest "${esArgs[@]}" -PshardCount="$parallelism"
   wait "$LAST_PID"; rc=$?
-  [ -n "${TELEMETRY_PID:-}" ] && ci/mem-telemetry.sh stop "$TELEMETRY_PID"
   if [ "$rc" -ne 0 ]; then find . | grep hs_err | xargs cat 2>/dev/null || true; return "$rc"; fi
 }
 

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -11,6 +11,7 @@ source "$(dirname "$0")/publish-ror-plugins.sh"
 GRADLE_PIDS=()
 terminate() {
   echo ">>> Termination signal received — killing gradle tree(s) + reaping this CI job's containers..."
+  [ -n "${TELEMETRY_PID:-}" ] && kill "$TELEMETRY_PID" 2>/dev/null
   # Negative PID = signal the whole process group (gradle + its worker JVMs).
   for pid in "${GRADLE_PIDS[@]}"; do kill -TERM -- "-$pid" 2>/dev/null || true; done
   sleep 5
@@ -79,6 +80,11 @@ run_integration_tests() {
 
   echo ">>> $ES_MODULE => ror-tools:test (serial gate) + integration-tests:shardedTest (${parallelism} shard(s)).."
 
+  # Background memory sampler (RORDEV-2168): records host MemAvailable + per-process/container RSS
+  # so an exit-137 (host OOM SIGKILL) leaves evidence. Reported/uploaded by ci.yml `if: always()`.
+  # Global, not local: terminate() must reach it. Self-terminates after 3h even if never stopped.
+  TELEMETRY_PID=$(ci/mem-telemetry.sh start "integration-tests/build/mem-telemetry-${ES_MODULE}.log") || TELEMETRY_PID=""
+
   # Each gradle invocation runs in its OWN process group (setsid) so the trap can reap the whole tree;
   # appends the leader PID to GRADLE_PIDS (never pruned) and sets LAST_PID for the caller.
   LAST_PID=""
@@ -104,6 +110,7 @@ run_integration_tests() {
   #    prebuild barrier via task deps, K child ./gradlew spawn/wait, ProcessHandle kill on cancel.
   run_one integration-tests:shardedTest "${esArgs[@]}" -PshardCount="$parallelism"
   wait "$LAST_PID"; rc=$?
+  [ -n "${TELEMETRY_PID:-}" ] && ci/mem-telemetry.sh stop "$TELEMETRY_PID"
   if [ "$rc" -ne 0 ]; then find . | grep hs_err | xargs cat 2>/dev/null || true; return "$rc"; fi
 }
 

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -104,7 +104,11 @@ run_integration_tests() {
   # 1) ror-tools:test ONCE, serially (cheap, no ES; gates the CI job). Also warms :build-base/:buildSrc.
   run_one ror-tools:test
   wait "$LAST_PID"; local rc=$?
-  if [ "$rc" -ne 0 ]; then find . | grep hs_err | xargs cat 2>/dev/null || true; return "$rc"; fi
+  if [ "$rc" -ne 0 ]; then
+    # Stop the sampler on this early exit too, so it cannot keep writing while ci.yml reads the log.
+    [ -n "${TELEMETRY_PID:-}" ] && ci/mem-telemetry.sh stop "$TELEMETRY_PID"
+    find . | grep hs_err | xargs cat 2>/dev/null || true; return "$rc"
+  fi
 
   # 2) All sharding orchestration lives in integration-tests:shardedTest (see its build.gradle):
   #    prebuild barrier via task deps, K child ./gradlew spawn/wait, ProcessHandle kill on cancel.

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -145,10 +145,7 @@ test {
     // Per worker JVM. The JVM only orchestrates (streams small HTTP to ES, no bulk data); measured peak
     // live heap is ~50MB, so 512m is ~10x headroom. Overridable via -PitTestHeap for outlier suites.
     maxHeapSize = project.findProperty('itTestHeap') ?: '512m'
-    // The worker was the ONLY uncapped-metaspace JVM in a CI leg (orchestrator, shard gradles and ES
-    // containers are all capped). Same 512m every other JVM gets; a runaway now dies as an
-    // attributable OutOfMemoryError in THIS process instead of feeding a host-level OOM SIGKILL
-    // that takes down the whole leg with a bare exit 137. (RORDEV-2168)
+    // bounded like every other JVM in the CI leg, so a runaway fails in-process, not via the host OOM killer
     jvmArgs '-XX:MaxMetaspaceSize=512m'
 }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -145,6 +145,11 @@ test {
     // Per worker JVM. The JVM only orchestrates (streams small HTTP to ES, no bulk data); measured peak
     // live heap is ~50MB, so 512m is ~10x headroom. Overridable via -PitTestHeap for outlier suites.
     maxHeapSize = project.findProperty('itTestHeap') ?: '512m'
+    // The worker was the ONLY uncapped-metaspace JVM in a CI leg (orchestrator, shard gradles and ES
+    // containers are all capped). Same 512m every other JVM gets; a runaway now dies as an
+    // attributable OutOfMemoryError in THIS process instead of feeding a host-level OOM SIGKILL
+    // that takes down the whole leg with a bare exit 137. (RORDEV-2168)
+    jvmArgs '-XX:MaxMetaspaceSize=512m'
 }
 
 dependencies {

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/audit/RemoteClusterAuditingToolsSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/audit/RemoteClusterAuditingToolsSuite.scala
@@ -32,10 +32,6 @@ import tech.beshu.ror.utils.misc.{OsUtils, Version}
 
 import java.util.UUID
 
-// HeavySuiteGated mixed in LAST so its run() is the outermost layer: this suite boots 2 extra ES
-// nodes + 2 toxiproxy containers ON TOP of the shared singleton ES, which is exactly the load the
-// machine-wide heavy-suite permit exists to bound — but BaseSingleNodeEsClusterTest (unlike the
-// Base*IntegrationTest cluster traits) does not carry the gate. (RORDEV-2168)
 class RemoteClusterAuditingToolsSuite
     extends BaseAuditingToolsSuite
     with BaseSingleNodeEsClusterTest

--- a/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/audit/RemoteClusterAuditingToolsSuite.scala
+++ b/integration-tests/src/test/scala/tech/beshu/ror/integration/suites/audit/RemoteClusterAuditingToolsSuite.scala
@@ -18,7 +18,7 @@ package tech.beshu.ror.integration.suites.audit
 
 import cats.data.NonEmptyList
 import tech.beshu.ror.integration.suites.base.BaseAuditingToolsSuite
-import tech.beshu.ror.integration.suites.base.support.BaseSingleNodeEsClusterTest
+import tech.beshu.ror.integration.suites.base.support.{BaseSingleNodeEsClusterTest, HeavySuiteGated}
 import tech.beshu.ror.integration.utils.SingletonPluginTestSupport
 import tech.beshu.ror.utils.containers.*
 import tech.beshu.ror.utils.containers.EsClusterSettings.positiveInt
@@ -32,10 +32,15 @@ import tech.beshu.ror.utils.misc.{OsUtils, Version}
 
 import java.util.UUID
 
+// HeavySuiteGated mixed in LAST so its run() is the outermost layer: this suite boots 2 extra ES
+// nodes + 2 toxiproxy containers ON TOP of the shared singleton ES, which is exactly the load the
+// machine-wide heavy-suite permit exists to bound — but BaseSingleNodeEsClusterTest (unlike the
+// Base*IntegrationTest cluster traits) does not carry the gate. (RORDEV-2168)
 class RemoteClusterAuditingToolsSuite
     extends BaseAuditingToolsSuite
     with BaseSingleNodeEsClusterTest
-    with SingletonPluginTestSupport {
+    with SingletonPluginTestSupport
+    with HeavySuiteGated {
 
   private val isDataStreamSupported = Version.greaterOrEqualThan(esVersionUsed, 7, 9, 0)
 

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/WireMockContainer.java
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/WireMockContainer.java
@@ -59,12 +59,8 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
                   DockerfileBuilder b = builder.from("rodolpheche/wiremock:2.5.1");
                   mappingFiles.forEach(
                       mappingFile -> b.copy(mappingFile.getName(), "/home/wiremock/mappings/"));
-                  // Same command the image ships, plus -Xmx. The 2016 image's JDK 8 is not
-                  // cgroup-aware: without -Xmx its max heap defaults to 1/4 of the HOST's RAM
-                  // (4GB on a 16GB CI runner) and the container carries no memory limit. The mock
-                  // serves a handful of small auth-service responses per suite; 256m is plenty.
-                  // (The base image's entrypoint `exec`s this CMD; the -cp wildcard is expanded
-                  // by the JVM, so exec form without a shell is fine.) (RORDEV-2168)
+                  // the image's own CMD plus -Xmx: its JDK 8 is not cgroup-aware and defaults to
+                  // 1/4 of host RAM
                   b.cmd(
                       "java",
                       "-Xmx256m",

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/WireMockContainer.java
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/WireMockContainer.java
@@ -59,6 +59,18 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
                   DockerfileBuilder b = builder.from("rodolpheche/wiremock:2.5.1");
                   mappingFiles.forEach(
                       mappingFile -> b.copy(mappingFile.getName(), "/home/wiremock/mappings/"));
+                  // Same command the image ships, plus -Xmx. The 2016 image's JDK 8 is not
+                  // cgroup-aware: without -Xmx its max heap defaults to 1/4 of the HOST's RAM
+                  // (4GB on a 16GB CI runner) and the container carries no memory limit. The mock
+                  // serves a handful of small auth-service responses per suite; 256m is plenty.
+                  // (The base image's entrypoint `exec`s this CMD; the -cp wildcard is expanded
+                  // by the JVM, so exec form without a shell is fine.) (RORDEV-2168)
+                  b.cmd(
+                      "java",
+                      "-Xmx256m",
+                      "-cp",
+                      "/var/wiremock/lib/*:/var/wiremock/extensions/*",
+                      "com.github.tomakehurst.wiremock.standalone.WireMockServerRunner");
                   b.build();
                 }));
     WireMockContainer cont =

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/Elasticsearch.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/Elasticsearch.scala
@@ -372,11 +372,6 @@ class Elasticsearch(val esVersion: String, val config: Config, val plugins: Seq[
       .add("-Xms512m")
       .add("-Xmx512m")
       .add("-Djava.security.egd=file:/dev/./urandoms")
-      // The JDWP agent exists so a developer can attach a debugger to the containerized ES. It is
-      // not free: measured ~90MB extra RSS per container (docker stats, ES 8.18, idle), which at
-      // the CI worst case of ~11 concurrent ES containers on a 16GB runner is ~1GB — so CI turns
-      // it off via ROR_ES_JDWP=false. Default stays ON to keep local debugging zero-setup.
-      // (RORDEV-2168)
       .addWhen(
         jdwpEnabled,
         "-Xdebug",

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/Elasticsearch.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/Elasticsearch.scala
@@ -372,12 +372,21 @@ class Elasticsearch(val esVersion: String, val config: Config, val plugins: Seq[
       .add("-Xms512m")
       .add("-Xmx512m")
       .add("-Djava.security.egd=file:/dev/./urandoms")
-      .add(
+      // The JDWP agent exists so a developer can attach a debugger to the containerized ES. It is
+      // not free: measured ~90MB extra RSS per container (docker stats, ES 8.18, idle), which at
+      // the CI worst case of ~11 concurrent ES containers on a 16GB runner is ~1GB — so CI turns
+      // it off via ROR_ES_JDWP=false. Default stays ON to keep local debugging zero-setup.
+      // (RORDEV-2168)
+      .addWhen(
+        jdwpEnabled,
         "-Xdebug",
         s"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${xDebugAddressBasedOn(esVersion)}"
       )
       .addWhen(needsCorretto19, "--add-modules=jdk.net")
   }
+
+  private def jdwpEnabled: Boolean =
+    Option(System.getenv("ROR_ES_JDWP")).forall(_.equalsIgnoreCase("true"))
 
   private def xDebugAddressBasedOn(esVersion: String) = {
     if (Version.greaterOrEqualThan(esVersion, 6, 3, 0)) "*:8000" else "8000"
@@ -419,8 +428,8 @@ final case class EsJavaOptsBuilder(options: Seq[String]) {
     this.copy(options = this.options ++ option.toSeq)
   }
 
-  def addWhen(condition: Boolean, option: => String): EsJavaOptsBuilder = {
-    if (condition) add(option) else this
+  def addWhen(condition: Boolean, option: => String, more: String*): EsJavaOptsBuilder = {
+    if (condition) add(option +: more.toSeq *) else this
   }
 
 }

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/Elasticsearch.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/images/Elasticsearch.scala
@@ -429,7 +429,7 @@ final case class EsJavaOptsBuilder(options: Seq[String]) {
   }
 
   def addWhen(condition: Boolean, option: => String, more: String*): EsJavaOptsBuilder = {
-    if (condition) add(option +: more.toSeq *) else this
+    if (condition) add(option +: more.toSeq*) else this
   }
 
 }


### PR DESCRIPTION
## Why

The integration legs sporadically die with `exit code 137`. Deep RCA result:

- The SIGKILL comes from the **kernel OOM killer**, not from a JVM. No leg log contains a `java.lang.OutOfMemoryError`, a heap dump, or an `ExitOnOutOfMemoryError` trigger. The host runs dry; no single process hits its own cap.
- The worst case holds more containers than the memory budget assumed. The per-JVM **singleton ES never stops**, so each of the 4 shard JVMs keeps one ES resident under every later suite. Two gated heavy suites can add 4+3 nodes. Total: **~11 concurrent ES containers** (~12GB at the measured ~1.1GiB each) plus 9 JVMs on a 16GB runner.
- One multi-container suite **bypassed the heavy-suite gate**: `RemoteClusterAuditingToolsSuite` boots 2 extra ES nodes + 2 toxiproxy containers via `BaseSingleNodeEsClusterTest`, which carries no gate.
- All dependency containers run **uncapped**. WireMock's 2016 image runs JDK 8 with no `-Xmx`; that JDK is not cgroup-aware, so its default max heap is 1/4 of the **host** RAM (4GB).
- The test workers were the **only JVMs with unbounded metaspace** in the leg.

## What (all measured, `docker stats`, ES 8.18.0)

| Change | Effect |
|---|---|
| CI sets `ROR_ES_JDWP=false`; the JDWP agent stays out of ES containers | **−94MB per container**, ~−1GB at the 11-container worst case. Local runs keep the debugger (default on). The image tag hashes `ES_JAVA_OPTS`, so no stale-image reuse. |
| WireMock CMD gets `-Xmx256m` | Bounds a 4GB default to 256m. Verified: image boots, `__admin` answers, RSS 87MB. |
| Worker `-XX:MaxMetaspaceSize=512m` | A runaway now dies as an attributable `OutOfMemoryError`, not as a host OOM SIGKILL. Same cap every other JVM has. |
| `RemoteClusterAuditingToolsSuite` mixes in `HeavySuiteGated` | The 2-permit gate now covers all multi-container suites. |
| `ci/mem-telemetry.sh` + workflow report/artifact steps | Every 10s: host MemAvailable, memory PSI, per-process RSS, `docker stats`. On any outcome CI prints the worst sample + OOM forensics (dmesg, per-container `OOMKilled`) and uploads the log. The next 137 shows what was resident. |

## Considered and rejected

- `-XX:MaxDirectMemorySize=128m` and `-XX:ReservedCodeCacheSize=128m` on ES: measured only ~26MB together at idle; a lower direct-memory cap risks flaky suites under load. ES ergonomics already pins direct memory at 256m.
- Gating `RorStartingResponseCodeSuite`: it holds only 1 extra container at a time (singleton-suite weight); a permit would over-serialize it.
- `IT_PARALLELISM` 4→3: not needed if the shaves hold; the telemetry will show.

## Verification

- `tests-utils:compileScala`, `integration-tests:compileTestScala`, `formatCodeCheck`, `license`: green locally.
- Telemetry script: live start/stop/report cycle tested; worst-sample selection covered an mawk subscript trap (`BEGIN{n=0}`).
- WireMock override and ES flag deltas: verified against running containers, not deduced.

JIRA: [RORDEV-2168](https://readonlyrest.atlassian.net/browse/RORDEV-2168)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration-test stability by controlling memory usage and limiting resource-intensive test environments.
  * Enhanced containerized test components with more predictable startup and memory settings.
  * Added configurable debugging support for Elasticsearch-based test runs.

* **Chores**
  * Added automated memory and resource telemetry to Linux CI jobs, including improved diagnostics and archived reports for failed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->