### PR TITLE
[RORDEV-1229] Add jq and GitHub CLI to the CI toolchains image

### DIFF
--- a/ci/toolchains/JdkToolchains.Dockerfile
+++ b/ci/toolchains/JdkToolchains.Dockerfile
@@ -42,8 +42,22 @@ FROM eclipse-temurin:17-jdk AS base
 
 # apt tools the pipeline needs (was: `apt-get install -y git curl` on every run).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git curl ca-certificates unzip file \
+ && apt-get install -y --no-install-recommends git curl ca-certificates unzip file jq \
  && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI: pipeline steps that dispatch workflows in other ROR repos and poll their runs.
+# Installed from the pinned release tarball rather than GitHub's apt repo — same reason as the
+# docker CLI above: no extra apt repo/keyring, and the version is fixed here.
+ARG GH_CLI_VERSION=2.97.0
+# TARGETARCH (amd64 on CI) is set by BuildKit and matches gh's release naming, so the image also
+# builds natively on an arm64 laptop.
+ARG TARGETARCH
+RUN GH_DIR="gh_${GH_CLI_VERSION}_linux_${TARGETARCH}" \
+ && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/${GH_DIR}.tar.gz" -o /tmp/gh.tar.gz \
+ && tar -xzf /tmp/gh.tar.gz -C /tmp "${GH_DIR}/bin/gh" \
+ && mv "/tmp/${GH_DIR}/bin/gh" /usr/local/bin/gh \
+ && rm -rf /tmp/gh.tar.gz "/tmp/${GH_DIR}" \
+ && gh --version
 
 # Docker CLIENT only: UPLOAD_PRE_ROR/RELEASE_ROR run `docker login` / `publishEsRorDockerImage`
 # from inside this container and talk to the agent host's Docker daemon over the bind-mounted


### PR DESCRIPTION
Adds jq and the GitHub CLI to the CI toolchains image.                                                                                                                       

Some pipeline steps need these two tools (building JSON, dispatching and polling workflows in other ROR repos), and today that forces those steps to run outside the container — which means no baked Gradle home and no baked JDKs, so they pay a cold Gradle setup on every run.                                                                
                                                                                                            
- jq comes from apt, alongside the other tools already installed there.                                                                                                      
- gh comes from its pinned release tarball, like the docker CLI, so no apt repo or keyring is added. The URL uses BuildKit's TARGETARCH, so the image still builds natively on an arm64 laptop.                                                                                                                                                          
                                                                                                   
The image tag is unchanged: it encodes the JDK set and the Gradle version, neither of which changed here. The next image rebuild picks the tools up.                         
                                                                                                                                                                              
Verified by building the base stage locally: gh version 2.97.0, jq-1.8.1. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI environment with additional command-line tooling.
  * Added GitHub CLI support and verified its installed version.
  * Added JSON processing utilities for CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->