### PR TITLE
[RORDEV-2171] Never let the telemetry report fail a leg whose tests passed

### DIFF
--- a/ci/mem-telemetry.sh
+++ b/ci/mem-telemetry.sh
@@ -83,11 +83,15 @@ case "${1:-}" in
     if [ -n "${ROR_CI_JOB_ID:-}" ]; then
       docker ps -a --filter "label=ror.ci-job=$ROR_CI_JOB_ID" --format '{{.ID}} {{.Names}}' 2>/dev/null \
         | while read -r id name; do
-            docker inspect -f "{{.Name}} oomkilled={{.State.OOMKilled}} exit={{.State.ExitCode}} status={{.State.Status}}" "$id" 2>/dev/null
+            docker inspect -f "{{.Name}} oomkilled={{.State.OOMKilled}} exit={{.State.ExitCode}} status={{.State.Status}}" "$id" 2>/dev/null \
+              || echo "$name ($id) is gone - reaped before it could be inspected"
           done
     else
       echo "ROR_CI_JOB_ID not set - skipping container inspection"
     fi
+    # This report is diagnostics. The workflow step runs it under `bash -e`, so any non-zero exit
+    # here fails a leg whose tests all passed.
+    exit 0
     ;;
 
   *)

--- a/ci/mem-telemetry.sh
+++ b/ci/mem-telemetry.sh
@@ -83,8 +83,13 @@ case "${1:-}" in
     if [ -n "${ROR_CI_JOB_ID:-}" ]; then
       docker ps -a --filter "label=ror.ci-job=$ROR_CI_JOB_ID" --format '{{.ID}} {{.Names}}' 2>/dev/null \
         | while read -r id name; do
-            docker inspect -f "{{.Name}} oomkilled={{.State.OOMKilled}} exit={{.State.ExitCode}} status={{.State.Status}}" "$id" 2>/dev/null \
-              || echo "$name ($id) is gone - reaped before it could be inspected"
+            if out=$(docker inspect -f "{{.Name}} oomkilled={{.State.OOMKilled}} exit={{.State.ExitCode}} status={{.State.Status}}" "$id" 2>&1); then
+              echo "$out"
+            elif printf '%s' "$out" | grep -qiE "no such (object|container)"; then
+              echo "$name ($id) is gone - reaped before it could be inspected"
+            else
+              echo "$name ($id) could not be inspected: $out"
+            fi
           done
     else
       echo "ROR_CI_JOB_ID not set - skipping container inspection"


### PR DESCRIPTION
## Why

`integration_es94x` on #1333 failed with every test green. The failing step was not the tests — it was the diagnostics I added in #1331:

| step | result |
|---|---|
| 7 — `integration_es94x` | **success** |
| 10 — `Memory telemetry report` | **failure** |

The report ends by inspecting this job's containers. Between `docker ps` and `docker inspect`, Ryuk can reap a container; `docker inspect` then returns 1, the `while` loop propagates that as the script's exit status, and the workflow step runs under `bash -e` — so the leg goes red. The log shows it stopping exactly there: the `##### Containers of this CI job #####` header prints, and the step's own `::endgroup::` never does.

This is on `develop`, so it can redden any integration leg, on anyone's PR, at random.

## What

- A container that vanished before inspection is now reported as such instead of failing the run.
- The `report` branch ends with an explicit `exit 0`. Diagnostics must never decide whether a build passes.

The sampler and everything it records are untouched.

## Verification

Reproduced the failure and then proved the fix, with `docker` stubbed so the reaped-container race is deterministic:

| script | conditions | exit |
|---|---|---|
| `develop` | `ps` lists a container, `inspect` fails | **1** — reproduces the CI failure |
| this branch | identical | **0** |

The report still says what happened: `gone_container (deadbeef1234) is gone - reaped before it could be inspected`.

Healthy path re-checked too: with `inspect` succeeding, the container line prints as before and the exit is 0.

JIRA: [RORDEV-2171](https://readonlyrest.atlassian.net/browse/RORDEV-2171)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container diagnostics now clearly report successful inspections, already-reaped containers, and inspection failures.
  * Diagnostic reporting exits successfully after completing, even if an inspection command encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->