### PR TITLE
Suppress CVE-2026-12185 on bctls-fips (CPE false positive)

### DIFF
--- a/suppressions_cve.xml
+++ b/suppressions_cve.xml
@@ -208,4 +208,21 @@ False positive: CVE-2021-34364 is for "Refined GitHub" (browser extension), not 
         <packageUrl regex="true">^pkg:maven/org\.scala-lang\.modules/scala-parallel-collections_3@1\.2\.0$</packageUrl>
         <cve>CVE-2017-1000034</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: bctls-fips-2.1.24.jar
+   False positive: CVE-2026-12185 is BKS/UBER keystore parsing, and it lists two products --
+   BC-JAVA before 1.85 and BC-LTS-JAVA 2.73.0 to 2.73.12. We ship the FIPS distribution, which is a
+   separate product line with its own versioning (bc-fips 2.1.x), so it is in neither range; the
+   CPE matcher maps the artifact version 2.1.24 onto the generic bouncy_castle_for_java CPE.
+   Two further signs it is a version-number coincidence: the flagged module is the TLS/JSSE
+   provider, while BKS/UBER keystores live in the provider jar, and none of the sibling FIPS
+   artifacts we ship (bc-fips 2.1.3, bcpkix-fips 2.1.12, bcutil-fips 2.1.7) is flagged -- only the
+   one whose version happens to land in the matched range.
+   Scoped to this one CVE and this one artifact so a real future finding is not masked. There is no
+   upgrade to take: all four FIPS pins are already the newest published versions.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bctls-fips@.*$</packageUrl>
+        <cve>CVE-2026-12185</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
`cve_check` started failing on every branch today (first seen on #1335, which is unrelated to BouncyCastle). Same pattern as the netty CVE last week: a newly published advisory reaching the scanner's feed, not a regression in anyone's PR.

## Why this is a false positive

[CVE-2026-12185](https://nvd.nist.gov/vuln/detail/CVE-2026-12185) is BKS/UBER keystore parsing, and its affected list is **BC-JAVA before 1.85** and **BC-LTS-JAVA 2.73.0–2.73.12**. We ship the **FIPS** distribution, a separate product line with its own versioning (`bc-fips` 2.1.x) — neither range covers it. The scanner matched `cpe:2.3:a:bouncycastle:bouncy_castle_for_java:2.1.24`, i.e. it mapped our artifact's version number onto the generic BC CPE.

Two further signs it's a version-number coincidence rather than a real product match:

1. The flagged jar is `bctls-fips` — the **TLS/JSSE provider**. BKS/UBER keystore code lives in the provider jar, not there.
2. **None of the sibling FIPS artifacts we ship is flagged** (`bc-fips` 2.1.3, `bcpkix-fips` 2.1.12, `bcutil-fips` 2.1.7) — only the one whose version number happens to land in the matched range.

## Why suppress rather than upgrade

There is nothing to upgrade to: all four FIPS pins are already the newest versions published on Maven Central (checked today — `bc-fips` 2.1.3, `bcpkix-fips` 2.1.12, `bctls-fips` 2.1.24, `bcutil-fips` 2.1.7).

The suppression is scoped to **this one CVE on this one artifact**, so a genuine future finding in the FIPS line still fails the build.

## Please sanity-check me

This is a security judgement, not a mechanical fix, so it deserves a second pair of eyes rather than a rubber stamp. If you'd rather treat the FIPS line as in-scope for this advisory, the alternative is to raise it with BouncyCastle and hold until they publish a FIPS release that states otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vulnerability scanning to correctly classify a `bctls-fips` finding as a false positive for CVE-2026-12185.
  * Limited the exception to the specific vulnerability and affected artifact pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->