### PR TITLE
[RORDEV-2174] Suppress CVE-2026-12185 for the BouncyCastle FIPS artifacts

### DIFF
--- a/suppressions_cve.xml
+++ b/suppressions_cve.xml
@@ -208,4 +208,18 @@ False positive: CVE-2021-34364 is for "Refined GitHub" (browser extension), not 
         <packageUrl regex="true">^pkg:maven/org\.scala-lang\.modules/scala-parallel-collections_3@1\.2\.0$</packageUrl>
         <cve>CVE-2017-1000034</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: bc-fips / bcpkix-fips / bctls-fips / bcutil-fips
+   False positive: CVE-2026-12185 ("BKS/UBER keystore allocates from untrusted lengths before
+   integrity check") affects the NON-FIPS BouncyCastle distribution only — bcprov before 1.85, and
+   bcprov-lts8on 2.73.0 to 2.73.12. ROR ships neither: the runtime classpath carries the FIPS
+   artifacts alone, which are a separate code line with their own versioning (2.1.x) and do not
+   implement the BKS/UBER keystore types. The CPE matcher maps them to the non-FIPS CPE
+   bouncycastle:bouncy_castle_for_java and reports the CVE against them.
+   Scoped to this one CVE, so any real advisory against the FIPS artifacts still fails the build.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bc(pkix|tls|util)?-fips@.*$</packageUrl>
+        <cve>CVE-2026-12185</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Why

`cve_check` went red on every branch today:

```
bctls-fips-2.1.24.jar (pkg:maven/org.bouncycastle/bctls-fips@2.1.24,
  cpe:2.3:a:bouncycastle:bouncy_castle_for_java:2.1.24) : CVE-2026-12185
```

It is a false positive.

**What the CVE actually says** (NVD): *"In Bouncy Castle for Java before 1.85, BKS/UBER keystore allocates from untrusted lengths before integrity check."* Affected products and ranges:

| product | affected |
|---|---|
| BC-JAVA (`bcprov`) | `< 1.85` |
| BC-LTS-JAVA (`bcprov-lts8on`) | `2.73.0` – `< 2.73.12` |

**What we ship** — the runtime classpath carries the FIPS line only, and no `bcprov` at all:

```
org.bouncycastle:bc-fips:2.1.3
org.bouncycastle:bcpkix-fips:2.1.12
org.bouncycastle:bctls-fips:2.1.24
org.bouncycastle:bcutil-fips:2.1.7
```

The FIPS artifacts are a separate code line with their own versioning, and they do not implement the BKS/UBER keystore types the advisory is about (the FIPS provider uses BCFKS). The CPE matcher maps them onto the non-FIPS `bouncycastle:bouncy_castle_for_java` CPE, which is where the hit comes from — the same class of mismatch already suppressed here for the ES rest client and for `scala-parallel-collections`.

## What

One suppression, scoped to this single CVE, matching only the four `*-fips` artifacts.

## Verification

The scope is the part worth checking, so I tested the regex against both what we ship and what we must not silence:

| purl | matched |
|---|---|
| `bc-fips@2.1.3` | yes |
| `bcpkix-fips@2.1.12` | yes |
| `bctls-fips@2.1.24` | yes |
| `bcutil-fips@2.1.7` | yes |
| `bcprov-jdk18on@1.78` | **no** |
| `bcprov-lts8on@2.73.5` | **no** |

So if we ever pull in the genuinely affected artifact, the build still goes red. XML validated as well-formed.

Since it is scoped to `CVE-2026-12185`, any future advisory against the FIPS artifacts also still fails the build.

JIRA: [RORDEV-2174](https://readonlyrest.atlassian.net/browse/RORDEV-2174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to suppress a confirmed false positive for CVE-2026-12185 affecting specific FIPS BouncyCastle artifacts.
  * The suppression is narrowly scoped to the identified vulnerability and affected components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->