### PR TITLE
[RORDEV-2175] Do not deny external auth calls when leasing a connection takes over 1ms

### DIFF
--- a/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/ApacheBasedSimpleHttpClient.scala
+++ b/core/src/main/scala/tech/beshu/ror/accesscontrol/factory/ApacheBasedSimpleHttpClient.scala
@@ -37,6 +37,7 @@ import tech.beshu.ror.accesscontrol.factory.HttpClientsFactory.HttpClient
 import tech.beshu.ror.accesscontrol.factory.HttpClientsFactory.HttpClient.Method
 import tech.beshu.ror.accesscontrol.factory.SimpleHttpClient.Config
 import tech.beshu.ror.accesscontrol.utils.AsyncOps.deferFuture
+import tech.beshu.ror.utils.RefinedUtils.PositiveFiniteDuration
 import tech.beshu.ror.utils.RequestIdAwareLogging
 
 import scala.concurrent.{Future, Promise}
@@ -108,7 +109,7 @@ private class ApacheBasedSimpleHttpClientCreator[F[_]: Async: ContextShift]
       val connectionConfig =
         ConnectionConfig
           .custom()
-          .setConnectTimeout(Timeout.ofMilliseconds(config.connectionTimeout.value.toMillis))
+          .setConnectTimeout(timeoutOf(config.connectionTimeout))
           // Compensates for the TCP keep-alive tuning we can't use below (see ioReactorConfig comment):
           // a pooled connection idle longer than this is checked (cheap liveness probe) before reuse,
           // so a peer that died while idle gets evicted instead of failing the next real request.
@@ -139,10 +140,13 @@ private class ApacheBasedSimpleHttpClientCreator[F[_]: Async: ContextShift]
 
       val requestConfig = RequestConfig
         .custom()
-        .setConnectionRequestTimeout(
-          Timeout.ONE_MILLISECOND
-        ) // fail fast when pool is exhausted (1ms, because 0ms means infinite wait)
-        .setResponseTimeout(Timeout.ofMilliseconds(config.requestTimeout.value.toMillis))
+        // Waiting for a pooled connection is bounded by the configured connection timeout. It used to
+        // be 1ms, to fail fast on an exhausted pool, but 1ms is under the JVM noise floor: a young GC
+        // pause makes even an idle pool answer too late, and the failed lease is reported to the caller
+        // as a failed external auth/authz call — so the user is denied. An exhausted pool now queues
+        // instead, which is what a caller wants, and still cannot wait forever.
+        .setConnectionRequestTimeout(timeoutOf(config.connectionTimeout))
+        .setResponseTimeout(timeoutOf(config.requestTimeout))
         .build()
 
       // httpcore5 only calls the permission-gated jdk.net.ExtendedSocketOptions.TCP_KEEPIDLE/
@@ -178,6 +182,11 @@ private class ApacheBasedSimpleHttpClientCreator[F[_]: Async: ContextShift]
         throw ex
     }
   }
+
+  // Never rounds down to zero: Apache reads a zero timeout as "no timeout at all" (Timeout.isDisabled),
+  // so a sub-millisecond setting would turn a bound into an unbounded wait.
+  private def timeoutOf(duration: PositiveFiniteDuration): Timeout =
+    Timeout.ofMilliseconds(Math.max(1L, duration.value.toMillis))
 
   private def checkJdkNetAvailability(): Unit = {
     catching(classOf[ClassNotFoundException], classOf[NoClassDefFoundError])


### PR DESCRIPTION
### Changelog entry

```yaml
  - type: fix
    components: [es]
    text: "Users are no longer denied access at random when an external authentication or groups-provider service is used on a busy node"
```

## Why

CI found this, but it is not a test problem.

`integration_es78x` on develop failed one test — `ReverseProxyAuthenticationWithGroupsProviderAuthorizationSuite`, expected 200, got **403**. The cause is in the log:

```
org.apache.hc.core5.util.DeadlineTimeoutException: Deadline: 2026-08-13T15:41:56.154+0000, -3 MILLISECONDS overdue
  at org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager.lease(...)
```

We ask the pool for a connection with a **1 millisecond** budget:

```scala
.setConnectionRequestTimeout(Timeout.ONE_MILLISECOND) // fail fast when pool is exhausted
```

The pool was **not** exhausted — it holds 30 connections per route and that suite makes a handful of requests. A GC pause or a busy CPU simply pushed the lease past 1 ms. ROR then treats the external groups-provider call as failed, and the user is **denied**.

The runner was under real memory pressure at that moment (`avail_mb=829`, memory PSI `7.74`, from the telemetry added in #1331), which is why CI hit it first. The same jitter on a loaded ES node produces **intermittent spurious 403s in production**, on `groups_provider` and `external_authentication`. That is the actual defect; the flaky test is the symptom.

## What

The lease wait is now bounded by the already-configured `connectionTimeout` (default 2s) instead of a hardcoded 1 ms.

The fail-fast intent still holds where it matters: a genuinely exhausted pool means 30 in-flight requests to that provider, and queueing briefly is what a caller wants there — better than denying a legitimate user. It still cannot wait forever, and `requestTimeout` (default 5s) is unchanged, so total latency stays bounded.

## Verification

I checked that this setting is really the one that produced that deadline, rather than assuming it from the name. In httpclient5 5.6.4, `PoolingAsyncClientConnectionManager.lease()` passes its `requestTimeout` argument straight to `pool.lease(...)` — that argument is the **connection request timeout**. The connect timeout is used later, in `connect()`, and could not have produced this exception.

`core:compileScala`, `formatCodeCheck` and `license` are green locally.

No unit test: the failure is a timing race inside the pool, so a test asserting it would either be flaky itself or just re-state the constant.
JIRA: [RORDEV-2175](https://readonlyrest.atlassian.net/browse/RORDEV-2175)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request reliability by ensuring connection establishment and connection-pool access consistently respect the configured connection timeout.
  * Prevented extremely short timeout settings from being treated as zero, reducing avoidable connection failures.
  * Response handling continues to use the configured request timeout for consistent request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
