### PR TITLE
[RORDEV-2177] Retry the toxiproxy proxy creation and record container deaths live

### DIFF
--- a/ci/mem-telemetry.sh
+++ b/ci/mem-telemetry.sh
@@ -37,20 +37,36 @@ case "${1:-}" in
   start)
     LOG=${2:?usage: mem-telemetry.sh start <logfile>}
     mkdir -p "$(dirname "$LOG")"
-    (
-      # Sub-shell sampler, disowned: survives the caller, never survives MAX_LIFETIME_S.
-      end=$((SECONDS + MAX_LIFETIME_S))
-      while [ "$SECONDS" -lt "$end" ]; do
-        sample_once
-        sleep "$INTERVAL_S"
-      done
-    ) >>"$LOG" 2>&1 &
+    # setsid: the collector below is a second process, so `stop` signals the whole group.
+    setsid "$0" _collect "$LOG" >>"$LOG" 2>&1 &
     disown
     echo $!
     ;;
 
+  _collect)
+    LOG=${2:?internal}
+    # A container's death has to be recorded WHILE it is visible: by the time the report step runs,
+    # Ryuk has reaped everything, so `docker ps -a` finds nothing and an OOM kill leaves no trace.
+    # `docker events` streams die/oom as they happen, and costs nothing between events.
+    docker events --filter event=die --filter event=oom \
+      --format 'X {{.Action}} name={{index .Actor.Attributes "name"}} exit={{index .Actor.Attributes "exitCode"}}' \
+      >>"$LOG" 2>/dev/null &
+    # The collector must not outlive this loop: `stop` kills the process group, but the lifetime cap
+    # below returns normally, and a background child survives its parent's exit. The PID is captured
+    # in a variable, not read as $! from inside the trap, where it would expand at trap time.
+    events_pid=$!
+    trap 'kill "$events_pid" 2>/dev/null' EXIT
+    end=$((SECONDS + MAX_LIFETIME_S))
+    while [ "$SECONDS" -lt "$end" ]; do
+      sample_once
+      sleep "$INTERVAL_S"
+    done
+    ;;
+
   stop)
-    kill "${2:?usage: mem-telemetry.sh stop <pid>}" 2>/dev/null || true
+    PID=${2:?usage: mem-telemetry.sh stop <pid>}
+    # Negative PID = the whole group, so the docker-events collector dies with the sampler.
+    kill -TERM -- "-$PID" 2>/dev/null || kill "$PID" 2>/dev/null || true
     ;;
 
   report)
@@ -79,7 +95,10 @@ case "${1:-}" in
     # Capture first: `| tail` exits 0 even on empty input, so `|| echo` alone can never fire.
     OOM_LINES=$(dmesg 2>/dev/null | grep -iE "out of memory|oom[-_]kill|killed process" | tail -20)
     if [ -n "$OOM_LINES" ]; then echo "$OOM_LINES"; else echo "no OOM events visible (or dmesg restricted)"; fi
-    echo "##### Containers of this CI job: OOMKilled / exit codes #####"
+    echo "##### Container deaths recorded during the run (docker events) #####"
+    DEATHS=$(grep '^X ' "$LOG" | sort | uniq -c | sort -rn)
+    if [ -n "$DEATHS" ]; then echo "$DEATHS"; else echo "no container died during the run"; fi
+    echo "##### Containers still present at report time: OOMKilled / exit codes #####"
     if [ -n "${ROR_CI_JOB_ID:-}" ]; then
       docker ps -a --filter "label=ror.ci-job=$ROR_CI_JOB_ID" --format '{{.ID}} {{.Names}}' 2>/dev/null \
         | while read -r id name; do

--- a/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/ToxiproxyContainer.scala
+++ b/tests-utils/src/main/scala/tech/beshu/ror/utils/containers/ToxiproxyContainer.scala
@@ -23,12 +23,13 @@ import eu.rekawek.toxiproxy.{Proxy, ToxiproxyClient}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.testcontainers.containers.wait.strategy.{WaitStrategy, WaitStrategyTarget}
-import tech.beshu.ror.utils.containers.ToxiproxyContainer.{httpApiPort, proxiedPort}
+import tech.beshu.ror.utils.containers.ToxiproxyContainer.{httpApiPort, proxiedPort, proxyName}
 import tech.beshu.ror.utils.misc.ScalaUtils.*
 
 import java.time.Duration
 import scala.concurrent.duration.*
 import scala.language.postfixOps
+import scala.util.Try
 
 class ToxiproxyContainer[T <: SingleContainer[_]](val innerContainer: T, innerServicePort: Int)
     extends GenericContainer(
@@ -83,13 +84,31 @@ class ToxiproxyContainer[T <: SingleContainer[_]](val innerContainer: T, innerSe
     innerContainer.start()
     super.start()
 
-    innerContainerProxy = Some(createProxy())
+    // The admin API can drop this call ("Unexpected end of file from server") on a loaded host, and
+    // the container is already up by then, so withStartupAttempts does not cover it. A retry has to
+    // delete the half-created proxy first, else the next attempt fails with "proxy already exists".
+    retry(times = 3, cleanBeforeRetrying = deleteProxyIfExists(), delayBetweenRetries = 2 seconds) {
+      innerContainerProxy = Some(createProxy())
+    }
+  }
+
+  // Best effort: this runs while the admin API is already misbehaving, so letting it throw would
+  // abort the retry it is supposed to enable.
+  private def deleteProxyIfExists(): Unit = {
+    Try {
+      Option(createToxiproxyClient().getProxyOrNull(proxyName)).foreach(_.delete())
+    }.failed.foreach(ex =>
+      logger.warn(s"[TOXIPROXY] Could not delete the leftover proxy before retrying: ${ex.getMessage}")
+    )
   }
 
   override def stop(): Unit = {
     innerContainer.stop()
     super.stop()
   }
+
+  private def createToxiproxyClient() =
+    new ToxiproxyClient(container.getHost, container.getMappedPort(httpApiPort))
 
   private def createProxy() = {
     // Create proxy AFTER both containers are fully started
@@ -106,8 +125,8 @@ class ToxiproxyContainer[T <: SingleContainer[_]](val innerContainer: T, innerSe
     val proxyListen = s"0.0.0.0:$proxiedPort"
 
     logger.debug(s"[TOXIPROXY] Creating proxy: listen=$proxyListen, upstream=$proxyUpstream (container IP)")
-    val toxiproxyClient = new ToxiproxyClient(container.getHost, container.getMappedPort(httpApiPort))
-    val proxy = toxiproxyClient.createProxy("proxy", proxyListen, proxyUpstream)
+    val toxiproxyClient = createToxiproxyClient()
+    val proxy = toxiproxyClient.createProxy(proxyName, proxyListen, proxyUpstream)
     logger.debug(s"[TOXIPROXY] Proxy created successfully")
 
     proxy
@@ -155,5 +174,6 @@ private class ToxiproxyApiWaitStrategy extends WaitStrategy with LazyLogging {
 
 object ToxiproxyContainer {
   private[containers] val httpApiPort = 8474
+  private[containers] val proxyName = "toxiproxy"
   val proxiedPort = 5000
 }


### PR DESCRIPTION
Two CI robustness gaps found while diagnosing the recent integration failures. A third candidate (memory caps on the dependency containers) was measured and **dropped** — see the bottom.

## 1. The toxiproxy proxy creation has no retry

`RemoteClusterAuditingToolsSuite` failed on #1338 with:

```
java.net.SocketException: Unexpected end of file from server
  at eu.rekawek.toxiproxy.ToxiproxyClient.createProxy(ToxiproxyClient.java:49)
  at tech.beshu.ror.utils.containers.ToxiproxyContainer.start(ToxiproxyContainer.scala:86)
```

The container had already started; the **admin API call** dropped. That matters, because `withStartupAttempts` — the retry OpenLdap uses, and our only retry on any dependency container — covers container startup and would not have helped here.

Now retried via the existing `ScalaUtils.retry`, with one detail that is easy to get wrong: the retry **deletes the half-created proxy first**. The connection dropped while reading the response, so the proxy may well exist server-side, and a naive retry would fail with "proxy already exists". That is what `cleanBeforeRetrying` is for.

## 2. Container deaths were never recorded

The `OOMKilled` section of the memory report has been printing **empty**, including on the leg that failed. Two reasons: only ES containers carry the `ror.ci-job` label, and by the time the report step runs Ryuk has reaped everything — so `docker ps -a` finds nothing and an OOM kill leaves no trace at all.

Polling after the fact cannot work. The sampler now streams `docker events` for `die` and `oom` while the run is happening, and the report prints what it caught.

Verified against both failure modes, with containers started `--rm` so they vanish immediately — exactly the case the old approach missed:

```
X die name=ev-fail exit=3
X die name=ev-oom  exit=137
X oom name=ev-oom
```

The OOM-killed container is caught as both an `oom` event and `die exit=137`. The report groups them by count:

```
##### Container deaths recorded during the run (docker events) #####
     11 X oom name=ev-oom exit=
      1 X die name=ev-oom exit=137
      1 X die name=ev-fail exit=3
```

`stop` now signals the process group, so the events collector dies with the sampler — confirmed no `docker events` process survives.

## Dropped: memory caps on the dependency containers

I proposed capping toxiproxy and openldap, estimating ~0.2 GB. Simone pushed back that this seemed far too much for such small services. He was right, and the measurement kills the idea:

| container | idle | after 200 requests | peak |
|---|---|---|---|
| toxiproxy | 2.3 MiB | 7.4 MiB | **7.4 MiB** |
| openldap | 55.3 MiB | 56.8 MiB | **58.0 MiB** |

They do not grow. My figure was the sum of what all the small containers currently use, but a cap does not reclaim usage — it only bounds a worst case, and their worst case is ~65 MiB combined. Not worth a change.

The real peak is elsewhere: 4 shard JVMs each hold a singleton ES that never stops, and the heavy-suite gate allows 2 more heavy suites on top (worst case 11 ES containers). That is a separate proposal, for coutoPL.

JIRA: [RORDEV-2177](https://readonlyrest.atlassian.net/browse/RORDEV-2177)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Monitoring Improvements**
  - Memory telemetry now records container termination and out-of-memory events.
  - Reports clearly distinguish containers that remain active when monitoring ends.
  - Stopping monitoring now shuts down all related processes cleanly.

- **Reliability Improvements**
  - Proxy startup automatically retries after temporary creation failures.
  - Partially created proxies are cleaned up before retrying.
  - Cleanup errors no longer interrupt subsequent startup attempts.
  - These improvements make monitoring and proxy-based testing more resilient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->