### PR TITLE
[RORDEV-2181] Stop the audit tests depending on wall-clock timing

### DIFF
--- a/core/src/test/scala/tech/beshu/ror/unit/acl/factory/AuditSettingsTests.scala
+++ b/core/src/test/scala/tech/beshu/ror/unit/acl/factory/AuditSettingsTests.scala
@@ -2687,6 +2687,7 @@ class AuditSettingsTests extends AnyWordSpec with Inside {
   private def circeJsonWithIgnoredTimestamp(json: JSONObject): Option[Json] = {
     json
       .withTimestampValue("IGNORED")
+      .withEventDurationValue("IGNORED")
       .circeJsonE
       .toOption
   }
@@ -2695,6 +2696,17 @@ class AuditSettingsTests extends AnyWordSpec with Inside {
 
     private def withTimestampValue(value: String): JSONObject = {
       jsonObject.put("@timestamp", value)
+    }
+
+    // `AuditResponseContext.duration` is `now - requestContext.timestamp`, and the two clock reads
+    // happen at different moments, so the value is 5000ms only when nothing elapses between them.
+    // Under CI load it becomes 5001 and the whole-document comparison fails (seen on
+    // integration_es78x). Normalise it on BOTH sides, exactly like @timestamp.
+    private def withEventDurationValue(value: String): JSONObject = {
+      if (jsonObject.has("event") && jsonObject.getJSONObject("event").has("duration")) {
+        jsonObject.getJSONObject("event").put("duration", value)
+      }
+      jsonObject
     }
 
     private def circeJsonE: Either[String, Json] =


### PR DESCRIPTION
## Why

`integration_es78x` on develop failed with the ECS-serializer cases in `AuditSettingsTests` comparing a whole JSON document that contains `event.duration`:

```
"duration" : 5001000000   (expected 5000000000)
```

`AuditResponseContext.duration` is `Instant.now() - requestContext.timestamp` — **two separate clock reads**. The value is exactly 5000ms only when nothing elapses between them, so under CI load it becomes 5001 and the whole-document comparison fails.

Worth noting what does *not* fix it: freezing the mock's `timestamp` in a `val`. `duration` is computed later, when the response context is built, so a nonzero gap remains — it would only narrow the window, not close it.

## What

`event.duration` is normalised to `"IGNORED"` on **both** sides of the comparison, exactly as `@timestamp` already is (same `circeJsonWithIgnoredTimestamp` helper). The test keeps asserting the whole document; it just stops asserting a wall-clock measurement it cannot control.

## Verification

A/B against an injected 3ms delay placed **between** the two clock reads (my first attempt put the delay before both, which cannot widen the gap — it proved nothing, and I only caught that because the control passed when it should have failed):

| | control (no fix) | with fix |
|---|---|---|
| same injected drift | **3 failures** — `5003000000` vs `5000000000` | **0 failures** |

Without drift: 104/104 green.

JIRA: [RORDEV-2181](https://readonlyrest.atlassian.net/browse/RORDEV-2181)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved audit JSON test comparisons by normalizing event durations alongside timestamps.
  * Added handling for expected results that include nested duration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
