### PR TITLE
Make the Docker Hub credential check real, not a variable check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_HUB_RO_TOKEN: ${{ secrets.DOCKER_HUB_RO_TOKEN }}
         run: |
-          source ci/docker-hub-auth.sh
+          source ci/docker-hub-auth.sh || exit 1
           ci/run-pipeline.sh
       - name: Publish test results
         if: failure()
@@ -351,7 +351,7 @@ jobs:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_HUB_RO_TOKEN: ${{ secrets.DOCKER_HUB_RO_TOKEN }}
         run: |
-          source ci/docker-hub-auth.sh
+          source ci/docker-hub-auth.sh || exit 1
           ci/run-pipeline.sh
       - name: Publish test results
         # always(): green-run XMLs feed suite-timings.json regeneration (duration-balanced sharding)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -337,7 +337,7 @@ stages:
             persistCredentials: true
           - script: |
               # core_tests starts testcontainers too (LDAP/WireMock) — same Docker Hub rate limit as IT.
-              source ci/docker-hub-auth.sh
+              source ci/docker-hub-auth.sh || exit 1
               echo "[TEST] executing ROR_TASK = $ROR_TASK"
               ci/run-pipeline.sh
             env:

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -150,7 +150,7 @@ every push on such a branch, and made five CI jobs depend on a job that almost a
 | `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD` | pushing ROR + toolchains images |
 | `ROR_ACTIVATION_KEY` | ROR PRO/Enterprise key the e2e stack boots with |
 | `KBN_REPO_GH_TOKEN` | dispatches the ROR KBN image build and reads its run status |
-| `DOCKER_HUB_USER` / `DOCKER_HUB_RO_TOKEN` | authenticated docker pulls (testcontainers rate limit); `ci/docker-hub-auth.sh` is a no-op when unset |
+| `DOCKER_HUB_USER` / `DOCKER_HUB_RO_TOKEN` | authenticated docker pulls (testcontainers rate limit); `ci/docker-hub-auth.sh` is a no-op when unset, and **fails the leg** when set but rejected by the registry |
 | `NVD_API_KEY`, `OSS_INDEX_USERNAME`, `OSS_INDEX_PASSWORD` | `cve_check` feeds |
 | `MAVEN_REPO_USER`, `MAVEN_REPO_PASSWORD`, `MAVEN_STAGING_PROFILE_ID`, `GPG_KEY_ID`, `GPG_PASSPHRASE` | Maven Central publishing |
 | `PGP_SECRET_KEY_B64` | base64 of `secret.pgp`; the publish step decodes it to `.travis/secret.pgp`. Create with `base64 -w0 secret.pgp \| gh secret set PGP_SECRET_KEY_B64` |

--- a/ci/azure-templates/integration-test-steps.yml
+++ b/ci/azure-templates/integration-test-steps.yml
@@ -32,7 +32,7 @@ steps:
 
       # Sourced in-process so DOCKER_AUTH_CONFIG reaches the testcontainers JVM when set, and stays
       # UNSET otherwise (an empty/literal Azure var would fail RegistryAuthLocator's JSON-parse).
-      source ci/docker-hub-auth.sh
+      source ci/docker-hub-auth.sh || exit 1
 
       echo "[TEST] executing ROR_TASK = $ROR_TASK"
       ci/run-pipeline.sh

--- a/ci/docker-hub-auth.sh
+++ b/ci/docker-hub-auth.sh
@@ -25,7 +25,30 @@ if [ -n "${DOCKER_HUB_RO_TOKEN:-}" ] && [ "${DOCKER_HUB_RO_TOKEN}" != '$(DOCKER_
   else
     echo "##vso[task.setvariable variable=DOCKER_AUTH_CONFIG;isSecret=true]$DOCKER_AUTH_CONFIG"
   fi
-  echo "[TEST] Docker Hub authenticated pulls ENABLED (user '$DOCKER_HUB_USER')"
+  # DOCKER_AUTH_CONFIG alone is not proof of anything: it says the two variables are non-empty, not
+  # that the credentials work. A revoked or mistyped token still produced "authenticated pulls
+  # ENABLED" here while every pull went out anonymous and died on "toomanyrequests" 25 minutes later.
+  #
+  # So log the daemon in as well, and let the login be the check. It covers pulls this script cannot
+  # reach through the environment (anything the daemon resolves on its own), and a bad credential now
+  # fails in the first seconds of the leg with a message that names the cause.
+  #
+  # `docker` is absent on some local machines that source this file; that is not a credential problem,
+  # so it warns instead of failing.
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "[TEST] docker CLI not found — skipping the login; DOCKER_AUTH_CONFIG is still exported"
+  elif printf '%s' "$DOCKER_HUB_RO_TOKEN" | docker login -u "$DOCKER_HUB_USER" --password-stdin >/dev/null 2>&1; then
+    echo "[TEST] Docker Hub authenticated pulls ENABLED (user '$DOCKER_HUB_USER', login verified)"
+  else
+    echo "[TEST] Docker Hub login FAILED for user '$DOCKER_HUB_USER'."
+    echo "[TEST] The credentials are set but the registry rejected them, so every pull in this leg"
+    echo "[TEST] would be anonymous and would hit the shared per-IP rate limit. Rotate"
+    echo "[TEST] DOCKER_HUB_RO_TOKEN (a Docker Hub read-only access token) and re-run."
+    # A sourced script cannot stop its caller on its own: `set -e` does NOT abort on a failing
+    # `source`. Every call site therefore reads `source ci/docker-hub-auth.sh || exit 1`, and this
+    # status is what that guard tests.
+    return 1
+  fi
 else
   echo "[TEST] Docker Hub authenticated pulls DISABLED (anonymous, rate-limited) — DOCKER_HUB_USER/DOCKER_HUB_RO_TOKEN not both set"
 fi


### PR DESCRIPTION
## The symptom

`it_linux_*` legs fail like this:

```
com.github.dockerjava.api.exception.InternalServerErrorException: Status 500:
{"message":"toomanyrequests: You have reached your unauthenticated pull rate limit."}
tc.osixia/openldap:1.5.0 - Retrying pull for image: osixia/openldap:1.5.0 (118s remaining)
```

`LdapIntegrationSuite`, `ImpersonationSuite` and `AdminApiAuthMockSuite` then fail with `initializationError`, and the leg dies after ~25 minutes.

Earlier in the **same log**:

```
[TEST] Docker Hub authenticated pulls ENABLED (user '***')
```

## Why both are true

`ci/docker-hub-auth.sh` checked that `DOCKER_HUB_USER` and `DOCKER_HUB_RO_TOKEN` are non-empty, exported `DOCKER_AUTH_CONFIG`, and printed ENABLED. It never asked the registry whether the credentials are accepted. A revoked, expired or mistyped token reads exactly like a working one.

So the message reports what we *configured*, not what the registry *does*, and the real answer arrives 25 minutes later as a rate limit we were supposed to be exempt from.

## The change

Log the daemon in too, and let the login be the check.

- The credentials now also cover pulls this script cannot reach through the environment.
- A bad credential fails in the first seconds of the leg, with a message that names the cause.

## One thing worth knowing

A sourced script **cannot** stop its caller. `set -e` does not abort on a failing `source` — I checked on this bash, with a bare `return 1` and with `return 1 2>/dev/null || exit 1`, and the caller continued in both cases. My first attempt did exactly that, printed a stern message, and then let the leg run anyway.

Every call site therefore guards explicitly, and the script returns 1 for that guard to test:

```bash
source ci/docker-hub-auth.sh || exit 1
```

Four call sites: two in `ci.yml` (`unit_tests_linux`, `it_linux`), plus `azure-pipelines.yml` and `ci/azure-templates/integration-test-steps.yml`.

## Verification

With a stub `docker` on `PATH`, all four paths, each observed rather than assumed:

| case | result | leg rc |
|---|---|---|
| no credentials | DISABLED, runs anonymously | 0 |
| credentials, login accepted | ENABLED (login verified) | 0 |
| credentials, login rejected | named error, leg aborts | 1 |
| credentials, no docker CLI | warns, still exports the config | 0 |

The rejected case is the negative control: before the call-site guard it printed the error and returned 0, which is how I found that `set -e` was not enough.

`bash -n` on the script and a YAML parse on all three workflow files are clean.

## What this does not answer

It does not tell us *why* the current token is not authenticating. This PR makes CI say so on the next run instead of hiding it. If the login fails, the token needs rotating; if it succeeds and pulls are still anonymous, the problem is in how testcontainers 2.0.3 resolves `DOCKER_AUTH_CONFIG` and I will chase that next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker Hub authentication validation during automated tests.
  * CI now fails clearly when configured credentials are rejected, preventing tests from continuing in an unauthenticated state.
  * Authentication failures now provide guidance for resolving credential issues.
  * Environments without configured credentials continue without authentication; unavailable Docker installations are handled with a warning.

* **Documentation**
  * Updated CI authentication guidance to reflect the new failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->