### PR TITLE
[RORDEV-2183] Adopt the new pre-build wait from the e2e repo

### DIFF
--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -1,5 +1,11 @@
 name: ROR ES Publish Pre-Builds
 
+# Two repos dispatch this workflow, and a dispatch is told nothing about the run it creates. They
+# find their run by this title, so the tag has to stay in it: the tag holds a run id and an
+# attempt, which makes the title unique. The e2e repo builds the same string in
+# ci/prebuild-images-lib.sh, and the two must match.
+run-name: ROR ES pre-build ${{ inputs.tag }}
+
 # Manual-only: no push/pull_request triggers (Azure's `trigger: none` / `pr: none`).
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -3,8 +3,8 @@ name: ROR ES Publish Pre-Builds
 # Two repos dispatch this workflow, and a dispatch is told nothing about the run it creates. They
 # find their run by this title, so the tag has to stay in it: the tag holds a run id and an
 # attempt, which makes the title unique. The e2e repo builds the same string in
-# ci/prebuild-images-lib.sh, and the two must match. The tag is optional: a hand-made dispatch
-# without one falls back to the versions, so the title never ends in a dangling space.
+# ci/prebuild-images-lib.sh, and the two must match. The tag is optional. If a dispatch sends no
+# tag, the title shows the versions. Then no title stops after the word "pre-build".
 run-name: ROR ES pre-build ${{ inputs.tag || inputs.es_versions }}
 
 # Manual-only: no push/pull_request triggers (Azure's `trigger: none` / `pr: none`).

--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -3,8 +3,9 @@ name: ROR ES Publish Pre-Builds
 # Two repos dispatch this workflow, and a dispatch is told nothing about the run it creates. They
 # find their run by this title, so the tag has to stay in it: the tag holds a run id and an
 # attempt, which makes the title unique. The e2e repo builds the same string in
-# ci/prebuild-images-lib.sh, and the two must match.
-run-name: ROR ES pre-build ${{ inputs.tag }}
+# ci/prebuild-images-lib.sh, and the two must match. The tag is optional: a hand-made dispatch
+# without one falls back to the versions, so the title never ends in a dangling space.
+run-name: ROR ES pre-build ${{ inputs.tag || inputs.es_versions }}
 
 # Manual-only: no push/pull_request triggers (Azure's `trigger: none` / `pr: none`).
 on:

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -102,10 +102,12 @@ Read it there, not here. Four obligations fall on this repo:
   `actions:read`. A refused read ends the wait with code 8 in seconds, and names the right it
   needs. Reading it is how the leg follows the run, so there is no way round it.
 - **Keep the title on our own pre-build run.** `publish-pre-builds.yml` carries
-  `run-name: ROR ES pre-build ${{ inputs.tag }}`. Every repo that dispatches it — the e2e repo and
-  the ROR KBN repo — finds its run by that title, because a dispatch is told nothing about the run it
-  creates. Remove the line and every dispatch of this workflow fails, because no run can be
-  recognised.
+  `run-name: ROR ES pre-build ${{ inputs.tag || inputs.es_versions }}`. Every repo that dispatches it
+  — the e2e repo and the ROR KBN repo — finds its run by that title, because a dispatch is told
+  nothing about the run it creates. A dispatch always sends a tag. So a run that a job waits for
+  always shows `ROR ES pre-build <tag>`. The fallback applies only to a dispatch that sends no tag,
+  and no search looks for such a title. Remove the line and every dispatch of this workflow fails,
+  because no run can be recognised.
 
 One consequence shapes this side: the wait ends when the ROR KBN run ends, not when one image
 appears, so all three legs reach their suite at about the same time. The Gradle build of the ROR ES

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -104,10 +104,10 @@ Read it there, not here. Four obligations fall on this repo:
 - **Keep the title on our own pre-build run.** `publish-pre-builds.yml` carries
   `run-name: ROR ES pre-build ${{ inputs.tag || inputs.es_versions }}`. Every repo that dispatches it
   — the e2e repo and the ROR KBN repo — finds its run by that title, because a dispatch is told
-  nothing about the run it creates. A dispatch always sends a tag. So a run that a job waits for
-  always shows `ROR ES pre-build <tag>`. The fallback applies only to a dispatch that sends no tag,
-  and no search looks for such a title. Remove the line and every dispatch of this workflow fails,
-  because no run can be recognised.
+  nothing about the run it creates. A dispatcher must send a tag, and the shared lib refuses a
+  dispatch that sends none. So a run that a job waits for always shows `ROR ES pre-build <tag>`.
+  The fallback applies only to a dispatch that sends no tag, and no search looks for such a title.
+  Remove the line and every dispatch of this workflow fails, because no run can be recognised.
 
 One consequence shapes this side: the wait ends when the ROR KBN run ends, not when one image
 appears, so all three legs reach their suite at about the same time. The Gradle build of the ROR ES

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -79,7 +79,7 @@ Three repos take part, so no single one owns the whole thing: this repo builds t
 `readonlyrest_kbn` builds the ROR KBN image, and the e2e repo owns the suite, the runner, and the
 contract between all three —
 [`ci/prebuild-images-lib.sh`](https://github.com/beshu-tech/readonlyrest-e2e-tests/blob/develop/ci/prebuild-images-lib.sh)
-(image names, tag shape, workflow inputs, wait/poll behaviour). Change the contract there, not here.
+(image names, tag shape, workflow inputs, wait behaviour). Change the contract there, not here.
 
 Two jobs, because the two plugin images are built in different places:
 
@@ -88,6 +88,28 @@ Two jobs, because the two plugin images are built in different places:
   KBN image build for all those versions. Non-blocking: it does not wait for the build.
 - `e2e_tests` runs once per version, in parallel. It builds and pushes the ROR ES dev image from
   **this** commit, waits for the ROR KBN image, then runs the suite against both.
+
+The wait is not a poll of the registry: a leg waits on the dispatched ROR KBN **run**. What the wait
+guarantees, and what this repo has to supply for it, is the contract at the top of the shared lib.
+Read it there, not here. Four obligations fall on this repo:
+
+- **Pass the run down.** `e2e_prepare` fails if it cannot identify the run it started, and publishes
+  it as the `kbn_run_id` and `kbn_run_url` outputs. `ci.yml` hands both to every `e2e_tests` leg,
+  together with `ROR_GH_TOKEN`. A leg with an empty run id reports broken wiring and stops.
+- **Log in first.** Each leg authenticates Docker before the wait, so the registry check the wait
+  makes at the end counts against the ROR account and not against the runner address.
+- **Give the leg a token that can read the runs of the ROR KBN repo.** `ROR_GH_TOKEN` needs
+  `actions:read`. A refused read ends the wait with code 8 in seconds, and names the right it
+  needs. Reading it is how the leg follows the run, so there is no way round it.
+- **Keep the title on our own pre-build run.** `publish-pre-builds.yml` carries
+  `run-name: ROR ES pre-build ${{ inputs.tag }}`. Every repo that dispatches it — the e2e repo and
+  the ROR KBN repo — finds its run by that title, because a dispatch is told nothing about the run it
+  creates. Remove the line and every dispatch of this workflow fails, because no run can be
+  recognised.
+
+One consequence shapes this side: the wait ends when the ROR KBN run ends, not when one image
+appears, so all three legs reach their suite at about the same time. The Gradle build of the ROR ES
+image runs before the wait and absorbs most of that time.
 
 Both sides address the images by a per-run tag (`run-<build id>`), and the build id is created by
 `e2e_prepare` and passed down as a job output. A test job must never re-derive it: a partial re-run

--- a/ci/e2e-tests-lib.sh
+++ b/ci/e2e-tests-lib.sh
@@ -129,15 +129,29 @@ e2e_matrix_json() {
 }
 
 # Pass the dispatched ROR KBN run ID, URL, and wait timeout to the test jobs. They run as separate
-# processes on separate machines, and the run ID is what they wait on. A no-op outside GitHub
-# Actions.
+# processes on separate machines, and the run ID is what they wait on.
+#
+# Outside GitHub Actions there is no job output, so the same three values are printed as export
+# lines. A local run of the `run_e2e_tests` task is a separate shell, and without them it stops at
+# once, because the wait has no run to follow.
 # Usage: export_kbn_prebuild_run_info <version count>
 export_kbn_prebuild_run_info() {
-  [ -n "${GITHUB_OUTPUT:-}" ] || return 0
-
   # The test jobs wait for the run, and one run builds all the versions one after another, so it
   # finishes after N build times. Scale the timeout by the number of versions.
   local WAIT_TIMEOUT=$(( ${1:-1} * ${ROR_KBN_WAIT_TIMEOUT_SECONDS:-1800} ))
+
+  if [ -z "${GITHUB_OUTPUT:-}" ]; then
+    echo ""
+    echo ">>> Not running in GitHub Actions, so there is no job output to write. A test run is a"
+    echo "    separate shell, and its wait needs the run below. Export these first:"
+    echo ""
+    echo "      export ROR_KBN_PREBUILD_RUN_ID='${ROR_KBN_PREBUILD_RUN_ID:-}'"
+    echo "      export ROR_KBN_PREBUILD_RUN_URL='${ROR_KBN_PREBUILD_RUN_URL:-}'"
+    echo "      export ROR_KBN_WAIT_TIMEOUT_SECONDS=$WAIT_TIMEOUT"
+    echo ""
+    return 0
+  fi
+
   {
     echo "kbn_run_id=${ROR_KBN_PREBUILD_RUN_ID:-}"
     echo "kbn_run_url=${ROR_KBN_PREBUILD_RUN_URL:-}"

--- a/ci/e2e-tests-lib.sh
+++ b/ci/e2e-tests-lib.sh
@@ -65,7 +65,7 @@ clone_e2e_tests_repo() {
   return 3
 }
 
-# Load the ROR KBN pre-build helpers (dispatch_kbn_prebuild_image and wait_for_kbn_prebuild_image)
+# Load the ROR KBN pre-build helpers (dispatch_kbn_prebuild_image and wait_for_kbn_prebuild_images)
 # from the e2e tests repo clone.
 load_kbn_prebuild_helpers() {
   if [ "$#" -ne 1 ]; then
@@ -76,7 +76,7 @@ load_kbn_prebuild_helpers() {
   local LIB="$1/$E2E_PREBUILD_IMAGES_LIB"
   if [ ! -f "$LIB" ]; then
     echo "ERROR: $E2E_PREBUILD_IMAGES_LIB not found in the e2e tests clone ($1)"
-    echo "       The ROR KBN pre-build dispatch/poll helpers are owned by $E2E_TESTS_REPO."
+    echo "       The ROR KBN pre-build dispatch and wait helpers are owned by $E2E_TESTS_REPO."
     echo "       The checked-out e2e branch predates them — merge/rebase it so the file is present."
     return 2
   fi
@@ -128,14 +128,15 @@ e2e_matrix_json() {
   printf '%s\n' "${ENTRIES[@]}" | jq -cs '{include: .}'
 }
 
-# Pass the dispatched ROR KBN run ID, URL, and wait timeout to the test jobs. Without the run ID,
-# test jobs cannot stop early if the build fails. A no-op outside GitHub Actions.
+# Pass the dispatched ROR KBN run ID, URL, and wait timeout to the test jobs. They run as separate
+# processes on separate machines, and the run ID is what they wait on. A no-op outside GitHub
+# Actions.
 # Usage: export_kbn_prebuild_run_info <version count>
 export_kbn_prebuild_run_info() {
   [ -n "${GITHUB_OUTPUT:-}" ] || return 0
 
-  # One build runs all versions sequentially, so the last image takes N times longer. Scale the
-  # timeout by the number of versions.
+  # The test jobs wait for the run, and one run builds all the versions one after another, so it
+  # finishes after N build times. Scale the timeout by the number of versions.
   local WAIT_TIMEOUT=$(( ${1:-1} * ${ROR_KBN_WAIT_TIMEOUT_SECONDS:-1800} ))
   {
     echo "kbn_run_id=${ROR_KBN_PREBUILD_RUN_ID:-}"
@@ -264,12 +265,17 @@ run_e2e_tests() {
   # Build and publish the ROR ES dev image (Gradle is skipped if the image already exists).
   publish_ror_es_prebuild_plugin "$ELK_VERSION" "$RUN_TAG" || return $?
 
-  # Wait for the ROR KBN image. Without the run ID, the wait cannot stop early if the build fails.
+  # Wait for the ROR KBN image. The wait follows the dispatched run, so the run id is necessary. The
+  # e2e_prepare job dispatches that run on another machine and publishes the id as its `kbn_run_id`
+  # output, so an empty value here means broken wiring. That job also
+  # fails if it cannot identify the run it started, so the id is set whenever it succeeded.
   if [ -z "${ROR_KBN_PREBUILD_RUN_ID:-}" ]; then
-    echo ">>> ROR_KBN_PREBUILD_RUN_ID is not set: the wait cannot stop early if the ROR KBN"
-    echo "    pre-build fails, and will use its full timeout."
+    echo "ERROR: ROR_KBN_PREBUILD_RUN_ID is empty, so there is no ROR KBN run to wait for."
+    echo "       The e2e_prepare job publishes the id as its 'kbn_run_id' output, and ci.yml passes"
+    echo "       that output to this job. Check both."
+    return 3
   fi
-  wait_for_kbn_prebuild_image "$ELK_VERSION" "$RUN_TAG" || return $?
+  wait_for_kbn_prebuild_images "$ELK_VERSION" "$RUN_TAG" || return $?
 
   # Both images are now available; run the test suite.
   run_e2e_against_dev_images "$E2E_DIR" "$ELK_VERSION" "$RUN_TAG"

--- a/ci/e2e-tests-lib.sh
+++ b/ci/e2e-tests-lib.sh
@@ -250,6 +250,18 @@ run_e2e_tests() {
     return 2
   fi
 
+  # The wait below follows the ROR KBN pre-build run, so the run id is necessary. It comes from the
+  # job environment and nothing here sets it, so check it before the clone and the Gradle build: a
+  # job that cannot wait must not spend minutes to say so. The e2e_prepare job dispatches the run on
+  # another machine and publishes the id as its `kbn_run_id` output. That job also fails if it
+  # cannot identify the run it started, so the id is set whenever it succeeded.
+  if [ -z "${ROR_KBN_PREBUILD_RUN_ID:-}" ]; then
+    echo "ERROR: ROR_KBN_PREBUILD_RUN_ID is empty, so there is no ROR KBN run to wait for."
+    echo "       The e2e_prepare job publishes the id as its 'kbn_run_id' output, and ci.yml passes"
+    echo "       that output to this job. Check both."
+    return 3
+  fi
+
   echo ">>> Running e2e tests: ELK $ELK_VERSION, run tag: $RUN_TAG"
 
   # Clone the e2e repo (needed for both the wait helper and the test runner).
@@ -265,16 +277,8 @@ run_e2e_tests() {
   # Build and publish the ROR ES dev image (Gradle is skipped if the image already exists).
   publish_ror_es_prebuild_plugin "$ELK_VERSION" "$RUN_TAG" || return $?
 
-  # Wait for the ROR KBN image. The wait follows the dispatched run, so the run id is necessary. The
-  # e2e_prepare job dispatches that run on another machine and publishes the id as its `kbn_run_id`
-  # output, so an empty value here means broken wiring. That job also
-  # fails if it cannot identify the run it started, so the id is set whenever it succeeded.
-  if [ -z "${ROR_KBN_PREBUILD_RUN_ID:-}" ]; then
-    echo "ERROR: ROR_KBN_PREBUILD_RUN_ID is empty, so there is no ROR KBN run to wait for."
-    echo "       The e2e_prepare job publishes the id as its 'kbn_run_id' output, and ci.yml passes"
-    echo "       that output to this job. Check both."
-    return 3
-  fi
+  # Wait for the ROR KBN image. The run id was checked at the top of this function, because the wait
+  # follows that run and the id arrives with the job environment.
   wait_for_kbn_prebuild_images "$ELK_VERSION" "$RUN_TAG" || return $?
 
   # Both images are now available; run the test suite.


### PR DESCRIPTION
This PR comes out of #1346, which now carries the Docker Hub authentication only. The rewrite of the wait is beshu-tech/readonlyrest-e2e-tests#111. This PR is the ROR ES side of it.

## The old wait polled the registry

`wait_for_prebuild_image` ran `docker manifest inspect` every 60 seconds until the ROR KBN image appeared. Each `e2e_tests` job ran its own copy of that loop, with a timeout that grows with the number of versions in the matrix.

Three jobs, 90 minutes, one pull each minute: **up to 270 pulls for one pipeline run**, against 200 in 6 hours. This repository was the largest consumer of the limit.

## The new wait follows the run

A job now waits for the ROR KBN **run**, through the GitHub API. It asks the registry only after that run succeeds. One job spends 1 pull. A ROR KBN build that fails stops all the jobs at once, and costs no pulls.

| | Before | After |
|---|---|---|
| One `e2e_tests` job, waiting | up to 90 pulls | 1 |
| One pipeline run, three jobs | up to 270 | 3 |
| A ROR KBN build that fails | up to 90 pulls for each job | 0 pulls, 1 API request |

## What changes here

- `ci/e2e-tests-lib.sh` calls `wait_for_kbn_prebuild_images`.
- An empty `ROR_KBN_PREBUILD_RUN_ID` is now an error, and not a warning. The wait follows the run, and `e2e_prepare` fails if it cannot identify the run that it started. An empty value in a test job thus shows that the wiring in `ci.yml` is broken, and the job says so.
- `.github/workflows/publish-pre-builds.yml` gets `run-name: ROR ES pre-build ${{ inputs.tag }}`. This line is for the other side. The e2e repository and the ROR KBN repository dispatch **our** pre-build, and a dispatch is told nothing about the run that it starts. Without a title, all runs of the workflow look the same, and two dispatches a few seconds apart cannot be told apart. A job then follows a run that is not its own. The tag holds a run id and an attempt, so the title is unique.
- A job needs `ROR_GH_TOKEN` to read the runs of the ROR KBN repository. If GitHub refuses that read, the job now stops in seconds. The job also names the permission that the token needs. Before, the job waited for the full timeout, and the answer could not change.
- `ci/CI.md` records what this repository owes the shared wait: pass the run down, log in first, give the job a token that can read the runs, and keep the title. For the rest it points at the contract in the shared library, so this file cannot drift from the code.

`ci.yml` needs no change. It already passes `kbn_run_id`, `kbn_run_url`, `kbn_wait_timeout_seconds` and `ROR_GH_TOKEN` to each job.

## Merge order

This PR is one part of one change. beshu-tech/readonlyrest-e2e-tests#111, sscarduzio/elasticsearch-readonlyrest-plugin#1350 and sscarduzio/readonlyrest_kbn#1009 must merge together, in one sitting, when the three are approved and green. No one of them is safe alone:

| Merged alone | What breaks |
|---|---|
| the e2e PR | each dispatch in the three repositories. The `develop` of the plugin repositories has no `run-name:` line, so no run can be found (code 4) |
| a plugin PR | the e2e jobs on the `develop` of that repository. They call the plural names, which the e2e `develop` does not have (`command not found`, 127) |

Merge the two plugin PRs first, and the e2e PR immediately after. That order keeps the e2e repository correct at each moment, and only plugin CI is open to a fault in the gap. A run that starts in the gap fails, and it passes when you start it again. The ROR ES repository has scheduled runs, so look for one in the middle.

The three authentication PRs are different. beshu-tech/readonlyrest-e2e-tests#108, sscarduzio/elasticsearch-readonlyrest-plugin#1346 and sscarduzio/readonlyrest_kbn#1006 need nothing else, and each one can merge alone at any time.

Delete the two transitional aliases in `ci/prebuild-images-lib.sh` after the three merge. Nothing calls the singular names then.

## Tests

The wait was tested against a stub of `docker` and `gh` that counts the calls: the run succeeds and the image is there (1 pull), the image arrives late (3 pulls), the image never arrives (3 pulls, then a named error), the registry cannot be queried (a different named error), the run fails (0 pulls, 1 API request), and the run never finishes (0 pulls, and a timeout that names the run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pre-build workflow runs now display the selected dispatch tag, or the Elasticsearch version when no tag is provided.
  - Local end-to-end test runs now show the environment details needed for setup.

- **Bug Fixes**
  - End-to-end tests validate pre-build run information before starting and wait for image preparation to complete, reducing confusing failures and unnecessary work.

- **Documentation**
  - Clarified pre-build workflow integration, run tracking, fallback run titles, required workflow naming, authentication, and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

