### PR TITLE
[RORDEV-2183] Let the e2e job use the Docker Hub mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,9 +648,6 @@ jobs:
           ROR_GH_TOKEN: ${{ secrets.ROR_GH_TOKEN }}
           DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-          # The only job that must not use the Docker Hub mirror. It pulls the ROR ES and ROR KBN
-          # images that two other runs pushed a moment before, and a cache can answer stale.
-          ROR_DOCKER_HUB_MIRROR: 'false'
           # Do not let corepack ask before it downloads yarn. CI has no operator.
           COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
         run: |

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -268,13 +268,19 @@ without a registry host, and a locally built name looks the same as a Docker Hub
 own `ror-it-es:<hash>` image and then tried to pull it, which failed every `it_linux` leg with
 "manifest unknown". Ryuk still comes from Docker Hub for the same reason.
 
-`ROR_DOCKER_HUB_MIRROR=false` switches the mirror off. `e2e_tests` is the only job that sets it: it
-pulls images that two other runs pushed a moment before, and a cache can answer stale.
+`ROR_DOCKER_HUB_MIRROR=false` switches the mirror off for one job. No job sets it. It is there for
+the day the mirror cannot serve an image a job needs.
 
 The flag answers one question: may this job read a cached answer? It does not follow from what the
-job pushes. `e2e_tests` holds a write token. The two jobs that push most, `publish-pre-builds` and
-`build_toolchains_image`, need the mirror most, because a 429 hits their base-image pulls. A mirror
-rewrites pulls only. A push names `beshultd/...` and goes to Docker Hub whatever the mirror says.
+job pushes. The two jobs that push most, `publish-pre-builds` and `build_toolchains_image`, need the
+mirror most, because a 429 hits their base-image pulls. A mirror rewrites pulls only. A push names
+`beshultd/...` and goes to Docker Hub whatever the mirror says.
+
+`e2e_tests` keeps the mirror as well, although it pulls the ROR ES and ROR KBN images that two other
+runs pushed a moment before, where a cached answer can be stale. The e2e repo settles that image by
+image: it names the images it takes from the cache, and the ROR images are not among them, so those
+two pulls go to Docker Hub. The job gains the rest: the digest-pinned gosu and corretto pulls of the
+ES image build, and every image the e2e stack takes from the cache.
 
 Two more things stay off the mirror by themselves, and both must remain so:
 

--- a/ci/configure-docker.sh
+++ b/ci/configure-docker.sh
@@ -33,8 +33,8 @@
 # rewrote our own ror-it-es:<hash> image and then tried to pull it from the mirror, which fails with
 # "manifest unknown". The test suite therefore names the images it mirrors, one by one.
 #
-# ROR_DOCKER_HUB_MIRROR=false switches the mirror off. The e2e job does that, because it pulls an
-# image that the publish job pushed a moment before, and a cache can hold a stale answer.
+# ROR_DOCKER_HUB_MIRROR=false switches the mirror off for one job. No job sets it. Use it when the
+# mirror cannot serve an image that a job needs.
 #
 # A mirror never stops the job by itself. BuildKit keeps the docker.io image identity, so it falls
 # back to Docker Hub. The two settings that rewrite the name, the test suite and the toolchains


### PR DESCRIPTION
The e2e job takes its images from Docker Hub, and not from the cache the other jobs use. It was set
that way because the job pulls the ROR ES and ROR KBN images that two other runs push a moment
before, and a cache can answer with what it saw earlier.

The e2e repo decides that image by image now. It names the few images it takes from the cache, and
the ROR images are not among them, so those two stay on the direct path. The rest of the job no
longer has to.

Merge this after the e2e repo change: https://github.com/beshu-tech/readonlyrest-e2e-tests/pull/114

The change it follows: https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/pull/1352


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker Hub mirror behavior across CI jobs.
  * Documented how to disable mirror usage for individual jobs.
  * Clarified which end-to-end test image pulls use or bypass the mirror.

* **Chores**
  * Enabled the default Docker mirror configuration for end-to-end test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->