### PR TITLE
[RORDEV-2183] Put the mirror in front of the container: image pull

### DIFF
--- a/.github/workflows/build-toolchains-image.yml
+++ b/.github/workflows/build-toolchains-image.yml
@@ -14,6 +14,13 @@ on:
     - cron: '0 3 * * 1'   # weekly rebuild
   workflow_dispatch:
 
+# One rebuild at a time. Two rebuilds push the same tag and file two cache entries, and setup takes
+# the newest entry, which need not hold the manifest that Docker Hub keeps. A second run waits: a
+# build takes up to four hours, and cancelling one wastes all of it.
+concurrency:
+  group: build-toolchains-image
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/build-toolchains-image.yml
+++ b/.github/workflows/build-toolchains-image.yml
@@ -77,7 +77,9 @@ jobs:
           [ -n "$DIGEST" ] || { echo "::error::The push of $TOOLCHAINS_IMAGE printed no digest."; exit 1; }
           echo ">>> Pushed digest: $DIGEST"
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-          echo "key=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+          # Two hyphens after the tag. ci.yml restores by prefix, and one hyphen would let a tag
+          # that extends another, such as ...-9.2.1-arm64, answer the prefix of ...-9.2.1.
+          echo "key=toolchains-digest-${TOOLCHAINS_IMAGE##*:}--${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 
   # ── RECORD_DIGEST ─────────────────────────────────────────────────────────
   # An Ubicloud runner keeps its own Actions cache. A save there is invisible to a GitHub-hosted

--- a/.github/workflows/build-toolchains-image.yml
+++ b/.github/workflows/build-toolchains-image.yml
@@ -1,0 +1,94 @@
+name: Build toolchains image
+
+# Builds the CI toolchains image and pushes it to Docker Hub. Every container: job of ci.yml pulls
+# that image, and it bakes the JDKs, Gradle and this commit's Gradle dependencies.
+#
+# It is not part of CI. A rebuild takes up to four hours, and no test run waits for it. Run it
+# weekly, and by hand after a JDK or Gradle bump.
+#
+# ci/toolchains/image.env holds the tag. ci.yml sources the same file.
+# See "The container: image" in ci/CI.md.
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'   # weekly rebuild
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  # ── BUILD ─────────────────────────────────────────────────────────────────
+  build:
+    # A GitHub schedule fires on the default branch. The guard holds if that branch ever changes.
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/develop'
+    runs-on: ubicloud-standard-4
+    timeout-minutes: 240
+    # record_digest reads these. A digest is public, so an output carries it safely.
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+      key:    ${{ steps.push.outputs.key }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with: { fetch-depth: 1, persist-credentials: false }
+      - name: Read the toolchains image tag
+        run: |
+          . ci/toolchains/image.env
+          [ -n "${TOOLCHAINS_IMAGE:-}" ] || { echo "::error::ci/toolchains/image.env sets no tag."; exit 1; }
+          echo "TOOLCHAINS_IMAGE=$TOOLCHAINS_IMAGE" >> "$GITHUB_ENV"
+      - name: docker build & push
+        id: push
+        env:
+          DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+        run: |
+          set -e
+          # Source before the build. It logs in and it sets ROR_DOCKER_HUB_MIRROR_PREFIX, which the
+          # FROM lines need. The Dockerfile pulls five images from Docker Hub in its FROM lines (four
+          # eclipse-temurin JDKs and the docker CLI), and those pulls are anonymous if the login
+          # comes after them.
+          source ci/configure-docker.sh
+          echo ">>> Building $TOOLCHAINS_IMAGE"
+          # MIRROR puts the pull-through cache in front of those five names. It is empty when the
+          # mirror is off, and the pulls then go to Docker Hub.
+          docker build --build-arg MIRROR="${ROR_DOCKER_HUB_MIRROR_PREFIX:-}" \
+            -f ci/toolchains/JdkToolchains.Dockerfile -t "$TOOLCHAINS_IMAGE" .
+          docker push "$TOOLCHAINS_IMAGE"
+          # The digest of this push, from the local daemon. A run takes the mirror only when the
+          # mirror serves the same digest. See ci/resolve-toolchains-image.sh.
+          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$TOOLCHAINS_IMAGE" \
+                     | grep "^${TOOLCHAINS_IMAGE%:*}@" | head -1 | sed 's/.*@//')
+          echo ">>> Pushed digest: ${DIGEST:-<none>}"
+          if [ -n "$DIGEST" ]; then
+            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+            echo "key=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::The daemon reports no digest for $TOOLCHAINS_IMAGE. Runs will pull from Docker Hub."
+          fi
+
+  # ── RECORD_DIGEST ─────────────────────────────────────────────────────────
+  # An Ubicloud runner keeps its own Actions cache. A save there is invisible to a GitHub-hosted
+  # runner, and the setup job of ci.yml is GitHub-hosted. So the save runs here, on a GitHub-hosted
+  # runner, and both ends read one store.
+  record_digest:
+    needs: build
+    if: needs.build.outputs.key != ''
+    runs-on: ubuntu-latest   # GH-hosted, like setup. A different runner means a different store.
+    timeout-minutes: 5
+    steps:
+      - name: Write the digest file
+        env:
+          DIGEST: ${{ needs.build.outputs.digest }}
+        run: echo "$DIGEST" > .toolchains-digest
+      # A key is write-once, so the run id gives each rebuild its own entry. GitHub removes an entry
+      # that nothing reads for 7 days, and setup reads this one every run. A branch reads its own
+      # entries and those of the default branch, so dispatch this workflow on develop.
+      - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: .toolchains-digest
+          key: ${{ needs.build.outputs.key }}

--- a/.github/workflows/build-toolchains-image.yml
+++ b/.github/workflows/build-toolchains-image.yml
@@ -58,26 +58,24 @@ jobs:
           # mirror is off, and the pulls then go to Docker Hub.
           docker build --build-arg MIRROR="${ROR_DOCKER_HUB_MIRROR_PREFIX:-}" \
             -f ci/toolchains/JdkToolchains.Dockerfile -t "$TOOLCHAINS_IMAGE" .
-          docker push "$TOOLCHAINS_IMAGE"
-          # The digest of this push, from the local daemon. A run takes the mirror only when the
-          # mirror serves the same digest. See ci/resolve-toolchains-image.sh.
-          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$TOOLCHAINS_IMAGE" \
-                     | grep "^${TOOLCHAINS_IMAGE%:*}@" | head -1 | sed 's/.*@//')
-          echo ">>> Pushed digest: ${DIGEST:-<none>}"
-          if [ -n "$DIGEST" ]; then
-            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-            echo "key=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::The daemon reports no digest for $TOOLCHAINS_IMAGE. Runs will pull from Docker Hub."
-          fi
+          # docker push prints the digest of this push. A run takes the mirror only when the mirror
+          # can serve that digest. See ci/resolve-toolchains-image.sh.
+          PUSH_LOG=$(mktemp)
+          docker push "$TOOLCHAINS_IMAGE" 2>&1 | tee "$PUSH_LOG"
+          DIGEST=$(sed -n 's/.*digest: \(sha256:[0-9a-f]\{64\}\).*/\1/p' "$PUSH_LOG" | head -1)
+          # The push has succeeded here. Without a digest the mirror stays off for every run until
+          # the next rebuild, and nobody sees it. So this fails loudly.
+          [ -n "$DIGEST" ] || { echo "::error::The push of $TOOLCHAINS_IMAGE printed no digest."; exit 1; }
+          echo ">>> Pushed digest: $DIGEST"
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "key=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
 
   # ── RECORD_DIGEST ─────────────────────────────────────────────────────────
   # An Ubicloud runner keeps its own Actions cache. A save there is invisible to a GitHub-hosted
   # runner, and the setup job of ci.yml is GitHub-hosted. So the save runs here, on a GitHub-hosted
   # runner, and both ends read one store.
   record_digest:
-    needs: build
-    if: needs.build.outputs.key != ''
+    needs: build          # build fails without a digest, so this job needs no guard of its own
     runs-on: ubuntu-latest   # GH-hosted, like setup. A different runner means a different store.
     timeout-minutes: 5
     steps:

--- a/.github/workflows/build-toolchains-image.yml
+++ b/.github/workflows/build-toolchains-image.yml
@@ -33,6 +33,8 @@ jobs:
   # ── BUILD ─────────────────────────────────────────────────────────────────
   build:
     # A GitHub schedule fires on the default branch. The guard holds if that branch ever changes.
+    # A dispatch stays open to every branch. The image bakes this commit's Gradle dependencies, so a
+    # branch that bumps one needs its own tag and its own build. record_digest warns about the cost.
     if: github.event_name != 'schedule' || github.ref == 'refs/heads/develop'
     runs-on: ubicloud-standard-4
     timeout-minutes: 240
@@ -90,9 +92,14 @@ jobs:
         env:
           DIGEST: ${{ needs.build.outputs.digest }}
         run: echo "$DIGEST" > .toolchains-digest
+      # An entry belongs to the ref that saved it. A develop run reads develop, and a pull request
+      # run reads its merge ref and the base branch, but never the head branch.
+      - name: Warn when no CI run can read this entry
+        if: github.ref != 'refs/heads/develop'
+        run: |
+          echo "::warning::This rebuild ran on ${GITHUB_REF}. A cache entry belongs to the ref that saved it, so a develop run and a pull request run cannot read this one. Those runs pull the toolchains image from Docker Hub. Dispatch this workflow on develop after the merge."
       # A key is write-once, so the run id gives each rebuild its own entry. GitHub removes an entry
-      # that nothing reads for 7 days, and setup reads this one every run. A branch reads its own
-      # entries and those of the default branch, so dispatch this workflow on develop.
+      # that nothing reads for 7 days, and setup reads this one every run.
       - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: .toolchains-digest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,11 @@ defaults:
     shell: bash
 
 env:
-  # Single source of truth for the toolchains image tag: the &toolchains anchor. Every job's
-  # `container: *toolchains` resolves to it, so a JDK/Gradle bump edits ONE line. Kept per-branch
-  # (not a repo variable) on purpose: the tag is coupled to this commit's baked dependency cache.
-  TOOLCHAINS_IMAGE: &toolchains beshultd/ror-ci-toolchains:jdk-8-11-17-21-gradle-9.2.1
+  # Single source of truth for the toolchains image tag. A JDK/Gradle bump edits ONE line. Kept
+  # per-branch, not in a repo variable: the tag belongs to this commit's baked dependency cache.
+  # The value names Docker Hub, because build_toolchains_image pushes it.
+  # ci/resolve-toolchains-image.sh picks the name a pull uses.
+  TOOLCHAINS_IMAGE: beshultd/ror-ci-toolchains:jdk-8-11-17-21-gradle-9.2.1
   GRADLE_USER_HOME: /opt/gradle-home
   GRADLE_OPTS: '-Dorg.gradle.java.installations.auto-download=false'
   # 4 shards per leg + HeavySuiteGate (max 2 concurrent multi-cluster suites, machine-wide).
@@ -72,15 +73,19 @@ jobs:
   setup:
     runs-on: ubuntu-latest   # trivial job; GH-hosted so it runs even if the Ubicloud app is down
     outputs:
-      is_master:  ${{ steps.f.outputs.is_master }}
-      is_develop: ${{ steps.f.outputs.is_develop }}
-      is_epic:    ${{ steps.f.outputs.is_epic }}
+      is_master:  ${{ steps.flags.outputs.is_master }}
+      is_develop: ${{ steps.flags.outputs.is_develop }}
+      is_epic:    ${{ steps.flags.outputs.is_epic }}
       action:     ${{ github.event.inputs.actionToPerform || 'run_all_tests_on_linux' }}
-      it_linux_matrix:   ${{ steps.m.outputs.linux }}
-      it_windows_matrix: ${{ steps.m.outputs.windows }}
-      e2e_modules:       ${{ steps.m.outputs.e2e }}
+      it_linux_matrix:   ${{ steps.matrices.outputs.linux }}
+      it_windows_matrix: ${{ steps.matrices.outputs.windows }}
+      e2e_modules:       ${{ steps.matrices.outputs.e2e }}
+      toolchains_image:    ${{ steps.toolchains.outputs.image }}
+      toolchains_mirrored: ${{ steps.toolchains.outputs.mirrored }}
     steps:
-      - id: f
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with: { fetch-depth: 1, persist-credentials: false }
+      - id: flags
         env:
           REF: ${{ github.head_ref || github.ref_name }}
         run: |
@@ -88,7 +93,7 @@ jobs:
           echo "is_develop=${{ github.ref == 'refs/heads/develop' }}" >> "$GITHUB_OUTPUT"
           # contains() semantics, matching Azure's isEpicBranchOrPr
           case "$REF" in *epic/*)  echo "is_epic=true"  >> "$GITHUB_OUTPUT";; *) echo "is_epic=false"  >> "$GITHUB_OUTPUT";; esac
-      - id: m
+      - id: matrices
         env:
           # Deliberately also true for epic/** refs — they get the same full matrices as master/develop.
           IS_MASTER_OR_DEVELOP: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || contains(github.head_ref || github.ref_name, 'epic/') }}
@@ -128,6 +133,19 @@ jobs:
           else
             echo "e2e=$E2E_FULL_SET" >> "$GITHUB_OUTPUT"
           fi
+      # The runner pulls the container: image before step 1, so ci/configure-docker.sh cannot reach
+      # it. This job can: container: image: reads a job output. build_toolchains_image put the
+      # digest of its push in the cache below. The key holds the tag, so a new tag reads no entry.
+      - id: digest_key
+        run: echo "prefix=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: .toolchains-digest
+          # An exact key needs the rebuild's run id. The prefix gives its newest entry.
+          key: ${{ steps.digest_key.outputs.prefix }}
+          restore-keys: ${{ steps.digest_key.outputs.prefix }}
+      - id: toolchains
+        run: ci/resolve-toolchains-image.sh
 
   # ── BUILD_TOOLCHAINS_IMAGE (schedule / manual) ────────────────────────────
   build_toolchains_image:
@@ -143,17 +161,12 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
       - name: docker build & push
+        id: push
         env:
           DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
         run: |
           set -e
-          # Drift guard: every ror-ci-toolchains tag in this workflow (env + all container: lines)
-          # must be identical — a bump that misses some lines would build one tag while jobs run another.
-          if grep -ohE 'beshultd/ror-ci-toolchains:[a-zA-Z0-9._-]+' .github/workflows/ci.yml | grep -vF "$TOOLCHAINS_IMAGE" | grep -q .; then
-            echo "::error::ci.yml container tags do not all match TOOLCHAINS_IMAGE=$TOOLCHAINS_IMAGE — bump them together"
-            exit 1
-          fi
           # Source before the build. It logs in and it sets ROR_DOCKER_HUB_MIRROR_PREFIX, which the
           # FROM lines need. The Dockerfile pulls five images from Docker Hub in its FROM lines (four
           # eclipse-temurin JDKs and the docker CLI), and those pulls are anonymous if the login
@@ -165,6 +178,25 @@ jobs:
           docker build --build-arg MIRROR="${ROR_DOCKER_HUB_MIRROR_PREFIX:-}" \
             -f ci/toolchains/JdkToolchains.Dockerfile -t "$TOOLCHAINS_IMAGE" .
           docker push "$TOOLCHAINS_IMAGE"
+          # The digest of this push, from the local daemon. A run takes the mirror only when the
+          # mirror serves the same digest. See ci/resolve-toolchains-image.sh.
+          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$TOOLCHAINS_IMAGE" \
+                     | grep "^${TOOLCHAINS_IMAGE%:*}@" | head -1 | sed 's/.*@//')
+          echo ">>> Pushed digest: ${DIGEST:-<none>}"
+          if [ -n "$DIGEST" ]; then
+            echo "$DIGEST" > .toolchains-digest
+            echo "key=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::The daemon reports no digest for $TOOLCHAINS_IMAGE. Runs will pull from Docker Hub."
+          fi
+      # A key is write-once, so the run id gives each rebuild its own entry. GitHub removes an entry
+      # that nothing reads for 7 days, and setup reads this one every run. A branch reads its own
+      # entries and those of the default branch, so dispatch this job on develop.
+      - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        if: steps.push.outputs.key != ''
+        with:
+          path: .toolchains-digest
+          key: ${{ steps.push.outputs.key }}
 
   # ── DISK_PROBE (manual run_disk_probe) — host-disk recon, ported from Azure ──────
   disk_probe:
@@ -185,14 +217,16 @@ jobs:
     needs: setup
     if: github.event_name != 'schedule' && github.event.inputs.actionToPerform != 'build_toolchains_image'
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
-    # The runner pulls this image before step 1 runs, so ci/configure-docker.sh cannot authenticate
-    # it. These credentials can. A fork supplies empty secrets, and the runner then skips the login
-    # and pulls anonymously. A read-only token is enough here, because a job only pulls this image.
+    # The runner pulls this image before step 1 runs, so ci/configure-docker.sh reaches neither the
+    # mirror nor the login for it. The setup job settles both. See ci/resolve-toolchains-image.sh.
+    # A mirrored name needs no login, and a login against mirror.gcr.io would fail, so the
+    # credentials go empty then. A fork also gives empty secrets, and the runner skips an empty
+    # login. A read-only token is enough: a job only pulls this image.
     container: &toolchains_container
-      image: *toolchains
+      image: ${{ needs.setup.outputs.toolchains_image }}
       credentials:
-        username: ${{ secrets.DOCKER_HUB_USER }}
-        password: ${{ secrets.DOCKER_HUB_RO_TOKEN }}
+        username: ${{ needs.setup.outputs.toolchains_mirrored != 'true' && secrets.DOCKER_HUB_USER || '' }}
+        password: ${{ needs.setup.outputs.toolchains_mirrored != 'true' && secrets.DOCKER_HUB_RO_TOKEN || '' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -735,11 +769,11 @@ jobs:
       )
     runs-on: ubuntu-latest
     outputs:
-      is_release: ${{ steps.r.outputs.is_release }}
+      is_release: ${{ steps.release_check.outputs.is_release }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
-      - id: r
+      - id: release_check
         run: |
           IS_RELEASE=true
           if grep '^pluginVersion=' gradle.properties | awk -F= '{print $2}' | grep -- '-pre'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,9 +219,10 @@ jobs:
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
     # The runner pulls this image before step 1 runs, so ci/configure-docker.sh reaches neither the
     # mirror nor the login for it. The setup job settles both. See ci/resolve-toolchains-image.sh.
-    # A mirrored name needs no login, and a login against mirror.gcr.io would fail, so the
-    # credentials go empty then. A fork also gives empty secrets, and the runner skips an empty
-    # login. A read-only token is enough: a job only pulls this image.
+    # A mirrored name carries the digest, so every job of a run pulls the same bytes. It needs no
+    # login, and a login against mirror.gcr.io would fail, so the credentials go empty then. A fork
+    # also gives empty secrets, and the runner skips an empty login. A read-only token is enough: a
+    # job only pulls this image.
     container: &toolchains_container
       image: ${{ needs.setup.outputs.toolchains_image }}
       credentials:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ on:
       - 'docs/**'
       - '.claude/**'
       - '**/*.md'
-  schedule:
-    - cron: '0 3 * * 1'   # weekly toolchains-image rebuild (build_toolchains_image only)
   workflow_dispatch:
     inputs:
       actionToPerform:
@@ -29,7 +27,6 @@ on:
           - run_all_tests_on_linux
           - run_all_tests_on_windows
           - run_e2e_tests
-          - build_toolchains_image
           - release_without_testing
           - run_disk_probe
 
@@ -131,8 +128,9 @@ jobs:
             echo "e2e=$E2E_FULL_SET" >> "$GITHUB_OUTPUT"
           fi
       # The runner pulls the container: image before step 1, so ci/configure-docker.sh cannot reach
-      # it. This job can: container: image: reads a job output. record_toolchains_digest put the
-      # digest of the last push in the cache below. The key holds the tag, so a new tag reads none.
+      # it. This job can: container: image: reads a job output. The Build toolchains image workflow
+      # put the digest of the last push in the cache below. The key holds the tag, so a new tag
+      # reads no entry.
       - name: Read the toolchains image tag
         run: |
           . ci/toolchains/image.env
@@ -148,79 +146,6 @@ jobs:
           restore-keys: ${{ steps.digest_key.outputs.prefix }}
       - id: toolchains
         run: ci/resolve-toolchains-image.sh
-
-  # ── BUILD_TOOLCHAINS_IMAGE (schedule / manual) ────────────────────────────
-  build_toolchains_image:
-    needs: setup
-    # Schedule runs are pinned to develop (Azure pinned the weekly rebuild to develop; GH schedules
-    # fire on the default branch — the ref guard protects us if the default branch ever changes).
-    if: >-
-      (github.event_name == 'schedule' && github.ref == 'refs/heads/develop') ||
-      (github.event_name == 'workflow_dispatch' && needs.setup.outputs.action == 'build_toolchains_image')
-    runs-on: ubicloud-standard-4
-    timeout-minutes: 240
-    # record_toolchains_digest reads these. A digest is public, so an output carries it safely.
-    outputs:
-      digest: ${{ steps.push.outputs.digest }}
-      key:    ${{ steps.push.outputs.key }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-        with: { fetch-depth: 1, persist-credentials: false }
-      - name: Read the toolchains image tag
-        run: |
-          . ci/toolchains/image.env
-          [ -n "${TOOLCHAINS_IMAGE:-}" ] || { echo "::error::ci/toolchains/image.env sets no tag."; exit 1; }
-          echo "TOOLCHAINS_IMAGE=$TOOLCHAINS_IMAGE" >> "$GITHUB_ENV"
-      - name: docker build & push
-        id: push
-        env:
-          DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
-          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-        run: |
-          set -e
-          # Source before the build. It logs in and it sets ROR_DOCKER_HUB_MIRROR_PREFIX, which the
-          # FROM lines need. The Dockerfile pulls five images from Docker Hub in its FROM lines (four
-          # eclipse-temurin JDKs and the docker CLI), and those pulls are anonymous if the login
-          # comes after them.
-          source ci/configure-docker.sh
-          echo ">>> Building $TOOLCHAINS_IMAGE"
-          # MIRROR puts the pull-through cache in front of those five names. It is empty when the
-          # mirror is off, and the pulls then go to Docker Hub.
-          docker build --build-arg MIRROR="${ROR_DOCKER_HUB_MIRROR_PREFIX:-}" \
-            -f ci/toolchains/JdkToolchains.Dockerfile -t "$TOOLCHAINS_IMAGE" .
-          docker push "$TOOLCHAINS_IMAGE"
-          # The digest of this push, from the local daemon. A run takes the mirror only when the
-          # mirror serves the same digest. See ci/resolve-toolchains-image.sh.
-          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$TOOLCHAINS_IMAGE" \
-                     | grep "^${TOOLCHAINS_IMAGE%:*}@" | head -1 | sed 's/.*@//')
-          echo ">>> Pushed digest: ${DIGEST:-<none>}"
-          if [ -n "$DIGEST" ]; then
-            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-            echo "key=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::The daemon reports no digest for $TOOLCHAINS_IMAGE. Runs will pull from Docker Hub."
-          fi
-
-  # ── RECORD_TOOLCHAINS_DIGEST ────────────────────────────────────────────
-  # An Ubicloud runner keeps its own Actions cache. A save there is invisible to a GitHub-hosted
-  # runner, and setup is GitHub-hosted. So the save runs here, and both ends read one store.
-  record_toolchains_digest:
-    needs: build_toolchains_image
-    if: needs.build_toolchains_image.outputs.key != ''
-    runs-on: ubuntu-latest   # GH-hosted, like setup. A different runner means a different store.
-    timeout-minutes: 5
-    steps:
-      - name: Write the digest file
-        env:
-          DIGEST: ${{ needs.build_toolchains_image.outputs.digest }}
-        run: echo "$DIGEST" > .toolchains-digest
-      # A key is write-once, so the run id gives each rebuild its own entry. GitHub removes an entry
-      # that nothing reads for 7 days, and setup reads this one every run. A branch reads its own
-      # entries and those of the default branch, so dispatch the rebuild on develop.
-      - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: .toolchains-digest
-          key: ${{ needs.build_toolchains_image.outputs.key }}
 
   # ── DISK_PROBE (manual run_disk_probe) — host-disk recon, ported from Azure ──────
   disk_probe:
@@ -239,7 +164,6 @@ jobs:
   # ── TOOLCHAINS_VERIFY ─────────────────────────────────────────────────────
   toolchains_verify:
     needs: setup
-    if: github.event_name != 'schedule' && github.event.inputs.actionToPerform != 'build_toolchains_image'
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
     # The runner pulls this image before step 1 runs, so ci/configure-docker.sh reaches neither the
     # mirror nor the login for it. The setup job settles both. See ci/resolve-toolchains-image.sh.
@@ -272,7 +196,7 @@ jobs:
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+      github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
     container: *toolchains_container
     continue-on-error: true
@@ -319,7 +243,7 @@ jobs:
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+      github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
     container: *toolchains_container
     name: ${{ matrix.ROR_TASK }}
@@ -347,7 +271,6 @@ jobs:
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      github.event_name != 'schedule' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_all_tests_on_linux')
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
     container: *toolchains_container
@@ -379,7 +302,6 @@ jobs:
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      github.event_name != 'schedule' &&
       needs.setup.outputs.it_linux_matrix != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_all_tests_on_linux')
     runs-on: ubicloud-standard-4
@@ -497,7 +419,6 @@ jobs:
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      github.event_name != 'schedule' &&
       needs.setup.outputs.it_windows_matrix != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_all_tests_on_windows')
     runs-on: windows-2025
@@ -635,7 +556,6 @@ jobs:
     if: >-
       !cancelled() &&
       needs.toolchains_verify.result == 'success' &&
-      github.event_name != 'schedule' &&
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
     runs-on: ubuntu-latest
@@ -670,7 +590,6 @@ jobs:
       !cancelled() &&
       needs.e2e_prepare.result == 'success' &&
       needs.toolchains_verify.result == 'success' &&
-      github.event_name != 'schedule' &&
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
     runs-on: ubicloud-standard-4
@@ -780,7 +699,7 @@ jobs:
       (needs.setup.outputs.is_develop == 'true' || needs.setup.outputs.is_master == 'true') &&
       (
         (
-          github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' &&
+          github.event_name != 'workflow_dispatch' &&
           needs.required_checks.result == 'success' &&
           needs.unit_tests_linux.result == 'success' &&
           needs.it_linux.result == 'success' &&
@@ -814,7 +733,7 @@ jobs:
       needs.determine_ci_type.result == 'success' &&
       needs.determine_ci_type.outputs.is_release == 'false' &&
       (needs.setup.outputs.is_develop == 'true' || needs.setup.outputs.is_master == 'true') &&
-      github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
+      github.event_name != 'workflow_dispatch'
     runs-on: ubicloud-standard-4
     container: *toolchains_container
     timeout-minutes: 600
@@ -854,7 +773,7 @@ jobs:
       (needs.setup.outputs.is_develop == 'true' || needs.setup.outputs.is_master == 'true') &&
       (
         (
-          github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' &&
+          github.event_name != 'workflow_dispatch' &&
           needs.required_checks.result == 'success' &&
           needs.unit_tests_linux.result == 'success' &&
           needs.it_linux.result == 'success' &&
@@ -906,7 +825,7 @@ jobs:
       needs.setup.outputs.is_master == 'true' &&
       (
         (
-          github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' &&
+          github.event_name != 'workflow_dispatch' &&
           needs.required_checks.result == 'success' &&
           needs.unit_tests_linux.result == 'success' &&
           needs.it_linux.result == 'success' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,8 @@ defaults:
     shell: bash
 
 env:
-  # Single source of truth for the toolchains image tag. A JDK/Gradle bump edits ONE line. Kept
-  # per-branch, not in a repo variable: the tag belongs to this commit's baked dependency cache.
-  # The value names Docker Hub, because build_toolchains_image pushes it.
-  # ci/resolve-toolchains-image.sh picks the name a pull uses.
-  TOOLCHAINS_IMAGE: beshultd/ror-ci-toolchains:jdk-8-11-17-21-gradle-9.2.1
+  # TOOLCHAINS_IMAGE is not here. It lives in ci/toolchains/image.env, which the two jobs that
+  # need it source. One file holds the tag, and every workflow reads that file.
   GRADLE_USER_HOME: /opt/gradle-home
   GRADLE_OPTS: '-Dorg.gradle.java.installations.auto-download=false'
   # 4 shards per leg + HeavySuiteGate (max 2 concurrent multi-cluster suites, machine-wide).
@@ -136,6 +133,11 @@ jobs:
       # The runner pulls the container: image before step 1, so ci/configure-docker.sh cannot reach
       # it. This job can: container: image: reads a job output. record_toolchains_digest put the
       # digest of the last push in the cache below. The key holds the tag, so a new tag reads none.
+      - name: Read the toolchains image tag
+        run: |
+          . ci/toolchains/image.env
+          [ -n "${TOOLCHAINS_IMAGE:-}" ] || { echo "::error::ci/toolchains/image.env sets no tag."; exit 1; }
+          echo "TOOLCHAINS_IMAGE=$TOOLCHAINS_IMAGE" >> "$GITHUB_ENV"
       - id: digest_key
         run: echo "prefix=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-" >> "$GITHUB_OUTPUT"
       - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
@@ -164,6 +166,11 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Read the toolchains image tag
+        run: |
+          . ci/toolchains/image.env
+          [ -n "${TOOLCHAINS_IMAGE:-}" ] || { echo "::error::ci/toolchains/image.env sets no tag."; exit 1; }
+          echo "TOOLCHAINS_IMAGE=$TOOLCHAINS_IMAGE" >> "$GITHUB_ENV"
       - name: docker build & push
         id: push
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,8 @@ jobs:
           [ -n "${TOOLCHAINS_IMAGE:-}" ] || { echo "::error::ci/toolchains/image.env sets no tag."; exit 1; }
           echo "TOOLCHAINS_IMAGE=$TOOLCHAINS_IMAGE" >> "$GITHUB_ENV"
       - id: digest_key
-        run: echo "prefix=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-" >> "$GITHUB_OUTPUT"
+        # Two hyphens. One would also match a tag that extends this one, such as -9.2.1-arm64.
+        run: echo "prefix=toolchains-digest-${TOOLCHAINS_IMAGE##*:}--" >> "$GITHUB_OUTPUT"
       - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: .toolchains-digest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,8 @@ jobs:
             echo "e2e=$E2E_FULL_SET" >> "$GITHUB_OUTPUT"
           fi
       # The runner pulls the container: image before step 1, so ci/configure-docker.sh cannot reach
-      # it. This job can: container: image: reads a job output. build_toolchains_image put the
-      # digest of its push in the cache below. The key holds the tag, so a new tag reads no entry.
+      # it. This job can: container: image: reads a job output. record_toolchains_digest put the
+      # digest of the last push in the cache below. The key holds the tag, so a new tag reads none.
       - id: digest_key
         run: echo "prefix=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-" >> "$GITHUB_OUTPUT"
       - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
@@ -157,6 +157,10 @@ jobs:
       (github.event_name == 'workflow_dispatch' && needs.setup.outputs.action == 'build_toolchains_image')
     runs-on: ubicloud-standard-4
     timeout-minutes: 240
+    # record_toolchains_digest reads these. A digest is public, so an output carries it safely.
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+      key:    ${{ steps.push.outputs.key }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
@@ -184,19 +188,32 @@ jobs:
                      | grep "^${TOOLCHAINS_IMAGE%:*}@" | head -1 | sed 's/.*@//')
           echo ">>> Pushed digest: ${DIGEST:-<none>}"
           if [ -n "$DIGEST" ]; then
-            echo "$DIGEST" > .toolchains-digest
+            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
             echo "key=toolchains-digest-${TOOLCHAINS_IMAGE##*:}-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::The daemon reports no digest for $TOOLCHAINS_IMAGE. Runs will pull from Docker Hub."
           fi
+
+  # ── RECORD_TOOLCHAINS_DIGEST ────────────────────────────────────────────
+  # An Ubicloud runner keeps its own Actions cache. A save there is invisible to a GitHub-hosted
+  # runner, and setup is GitHub-hosted. So the save runs here, and both ends read one store.
+  record_toolchains_digest:
+    needs: build_toolchains_image
+    if: needs.build_toolchains_image.outputs.key != ''
+    runs-on: ubuntu-latest   # GH-hosted, like setup. A different runner means a different store.
+    timeout-minutes: 5
+    steps:
+      - name: Write the digest file
+        env:
+          DIGEST: ${{ needs.build_toolchains_image.outputs.digest }}
+        run: echo "$DIGEST" > .toolchains-digest
       # A key is write-once, so the run id gives each rebuild its own entry. GitHub removes an entry
       # that nothing reads for 7 days, and setup reads this one every run. A branch reads its own
-      # entries and those of the default branch, so dispatch this job on develop.
+      # entries and those of the default branch, so dispatch the rebuild on develop.
       - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
-        if: steps.push.outputs.key != ''
         with:
           path: .toolchains-digest
-          key: ${{ steps.push.outputs.key }}
+          key: ${{ needs.build_toolchains_image.outputs.key }}
 
   # ── DISK_PROBE (manual run_disk_probe) — host-disk recon, ported from Azure ──────
   disk_probe:

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ docker-envs/eck/kind-cluster/subst-ror
 .bsp/
 .metals/
 .vscode/
+
+// CI
+// ci/resolve-toolchains-image.sh reads this file. The cache restore in the setup job writes it.
+/.toolchains-digest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
-# Single source of truth for the CI toolchains image (bump the tag here on a JDK/Gradle change).
-# Declared as a container resource (NOT a variable) because the job-level `container:` property is
-# resolved at compile time and does not expand $(variables).
+# The CI toolchains image. ci/toolchains/image.env holds the tag, and a JDK or Gradle change bumps
+# it there. The copy below must say the same. Azure resolves the job-level `container:` property at
+# compile time and does not expand $(variables), so this one cannot read the file.
 resources:
   containers:
     - container: ror-toolchains
@@ -37,7 +37,7 @@ trigger: none
 
 pr: none
 
-# (weekly toolchains-image rebuild now lives in the GitHub Actions workflow's schedule)
+# (the weekly toolchains-image rebuild now lives in .github/workflows/build-toolchains-image.yml)
 
 parameters:
   - name: actionToPerform
@@ -149,8 +149,10 @@ stages:
             displayName: 'Free up disk space'
           - script: |
               set -e
-              # The image tag lives in the resources.containers block of this file (single source of truth)
-              IMAGE=$(grep -oE 'beshultd/ror-ci-toolchains:[^ ]+' azure-pipelines.yml | head -1)
+              # ci/toolchains/image.env holds the tag. The resources.containers block at the top of
+              # this file carries a copy, because Azure cannot read the file there.
+              . ci/toolchains/image.env
+              IMAGE="$TOOLCHAINS_IMAGE"
               echo ">>> Building $IMAGE"
               docker build -f ci/toolchains/JdkToolchains.Dockerfile -t "$IMAGE" .
               echo "$var_docker_hub_rw_token" | docker login -u "$var_docker_hub_user" --password-stdin

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -327,6 +327,10 @@ and `setup` reads this one every run. A new tag matches no entry, so its runs us
 the next rebuild. The same holds now: run **Build toolchains image** once, on `develop`, to write the
 first digest.
 
+An entry belongs to the ref that saved it. Every run also reads the default branch, `develop`. A
+pull request run reads its merge ref and the base branch, but never the head branch. A rebuild
+dispatched from a feature branch therefore writes an entry that no pull request run finds.
+
 The rebuild does not save that entry. It runs on an Ubicloud runner, and an Ubicloud runner keeps
 its own Actions cache. A GitHub-hosted runner cannot read it, and `setup` is GitHub-hosted. So the
 digest travels as a job output to `record_digest`, a small job on `ubuntu-latest`, which saves it.

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -362,11 +362,19 @@ that Docker Hub keeps. A second run waits instead, because cancelling a four-hou
 A mirrored name needs no login, and a login against `mirror.gcr.io` would fail, so the `credentials:`
 block goes empty then. It goes empty for a fork as well, and the runner skips an empty login.
 
+A fork run gains the most. It has no secrets, so it pulled this image anonymously from Docker Hub,
+where the limit counts against the runner's address and every other anonymous puller shares it. The
+same run now pulls anonymously from `mirror.gcr.io`, which sets no limit. A fork run reads the base
+branch, so it finds the digest that a `develop` rebuild saved.
+
 One limit. The choice is made once, for the whole run. If the mirror stops answering during a run,
 the jobs that already took the mirrored name fail. The runner's pull has no fallback of its own.
 
-Publishing the image to `ghcr.io` would remove the digest bookkeeping, because the pull would no
-longer cross a cache.
+`ghcr.io` is the other direction. It would remove the digest bookkeeping, because the pull would no
+longer cross a cache, and a public package needs no `credentials:` block at all. It costs a tag in
+`image.env`, a `docker login ghcr.io` with `GITHUB_TOKEN`, `packages: write`, and a package the org
+makes public. It would not retire the mirror, which `buildx`, the test suite and the toolchains
+build still need for their own Docker Hub pulls. This change does not settle that question.
 
 ## Coverage: what happened to every Azure stage
 

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -303,23 +303,26 @@ share the image, which makes it the most pulled image of a run. Docker Hub answe
 once, and the `&toolchains_container` anchor reads its two outputs: the name to pull, and whether
 that name needs a Docker Hub login.
 
-The mirror is a cache and can serve an old image, and the weekly rebuild pushes the same tag. So
-the rebuild records the digest of its push in the Actions cache, and `setup` compares that digest
-with the one the mirror serves. The comparison sends no request to Docker Hub. When it does not
-agree, the run pulls from Docker Hub instead:
+A mirrored name carries the digest, not the tag: `mirror.gcr.io/beshultd/ror-ci-toolchains@sha256:…`.
+The jobs of one run start hours apart, and a tag can move between the check and a pull. A Docker Hub
+name keeps the tag, because no digest is proven in that case.
+
+So `setup` asks the mirror about the digest, not about the tag. A digest names the bytes, and a
+cache cannot answer it with the wrong image. The rebuild records the digest of its push in the
+Actions cache. `setup` then sends the mirror one HEAD request for that digest. The request downloads
+no image, and it reaches no Docker Hub:
 
 | What the script finds | What the run pulls |
 |---|---|
 | no digest on record | Docker Hub |
-| the mirror has no such tag | Docker Hub |
-| the digests differ | Docker Hub, with a warning |
-| the digests agree | the mirror |
+| the mirror cannot serve the digest | Docker Hub |
+| the mirror serves the digest | the mirror |
 
 Docker Hub is the safe answer, so a miss costs speed only.
 
-A mirrored name carries the digest, not the tag: `mirror.gcr.io/beshultd/ror-ci-toolchains@sha256:…`.
-The jobs of one run start hours apart, and a tag can move between the check and a pull. A Docker Hub
-name keeps the tag, because no digest is proven in that case.
+The mirror fetches a digest it has never held. So a run keeps the mirror in the hours after a
+rebuild, before the mirror knows the new tag. A question about the tag would lose the mirror in that
+window, where the recorded digest is newest.
 
 The cache key holds the tag and the rebuild's run id. A key is write-once, so each rebuild adds an
 entry and `setup` restores the newest by prefix. GitHub drops an entry that nothing reads for 7 days,

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -344,6 +344,10 @@ The rebuild lives in `build-toolchains-image.yml`, not in `ci.yml`. It takes up 
 no test run waits for it. A rebuild in `ci.yml` would also hold the `develop` concurrency group for
 those hours, and every push to `develop` would queue behind it.
 
+The rebuild keeps a concurrency group of its own, `build-toolchains-image`. Two rebuilds push one
+tag and file two cache entries, and `setup` takes the newest entry, which need not hold the manifest
+that Docker Hub keeps. A second run waits instead, because cancelling a four-hour build wastes it.
+
 A mirrored name needs no login, and a login against `mirror.gcr.io` would fail, so the `credentials:`
 block goes empty then. It goes empty for a fork as well, and the runner skips an empty login.
 

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -303,8 +303,8 @@ once, and the `&toolchains_container` anchor reads its two outputs: the name to 
 that name needs a Docker Hub login.
 
 The mirror is a cache and can serve an old image, and the weekly rebuild pushes the same tag. So
-`build_toolchains_image` writes the digest of its push to the Actions cache, and `setup` compares
-that digest with the one the mirror serves. No run calls Docker Hub.
+the rebuild records the digest of its push in the Actions cache, and `setup` compares that digest
+with the one the mirror serves. No run calls Docker Hub.
 
 | What the script finds | What the run pulls |
 |---|---|
@@ -325,6 +325,11 @@ and `setup` reads this one every run. A new tag matches no entry, so its runs us
 the next rebuild. The same holds now: run **Build toolchains image** once, on `develop`, to write the
 first digest.
 
+`record_toolchains_digest` saves that entry, not `build_toolchains_image`. The rebuild runs on an
+Ubicloud runner, and an Ubicloud runner keeps its own Actions cache. A GitHub-hosted runner cannot
+read it, and `setup` is GitHub-hosted. So the digest travels as a job output to a small job on
+`ubuntu-latest`, which saves it. Both ends then read one store.
+
 A mirrored name needs no login, and a login against `mirror.gcr.io` would fail, so the `credentials:`
 block goes empty then. It goes empty for a fork as well, and the runner skips an empty login.
 
@@ -343,7 +348,7 @@ Everything the Azure pipeline did is ported — nothing was dropped. The mapping
 | `SUPERSEDE_GUARD` | native `concurrency:` block (auto-cancel stale PR runs; branch pushes queue) |
 | `DETERMINE_CI_TYPE` | `setup` (branch flags, matrices) + `determine_ci_type` (release-type decision) |
 | `DISK_PROBE` | `disk_probe` (manual `run_disk_probe`) |
-| `BUILD_TOOLCHAINS_IMAGE` | `build_toolchains_image` (weekly cron + manual) |
+| `BUILD_TOOLCHAINS_IMAGE` | `build_toolchains_image` (weekly cron + manual) + `record_toolchains_digest` |
 | `TOOLCHAINS_VERIFY` | `toolchains_verify` |
 | `ES_S3_UP` | the standalone `mirror-es-libs.yml` workflow (manual; was a `newes/*` push trigger) |
 | `REQUIRED_CHECKS` | `required_checks` (same 4-task matrix) |

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -318,7 +318,8 @@ no image, and it reaches no Docker Hub:
 | the mirror cannot serve the digest | Docker Hub |
 | the mirror serves the digest | the mirror |
 
-Docker Hub is the safe answer, so a miss costs speed only.
+Docker Hub is the safe answer, so a miss costs speed only. `setup` writes the choice to the step
+summary, so the run page shows which registry a run used, and why.
 
 The mirror fetches a digest it has never held. So a run keeps the mirror in the hours after a
 rebuild, before the mirror knows the new tag. A question about the tag would lose the mirror in that

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -331,6 +331,12 @@ and `setup` reads this one every run. A new tag matches no entry, so its runs us
 the next rebuild. The same holds now: run **Build toolchains image** once, on `develop`, to write the
 first digest.
 
+The key and the prefix put two hyphens after the tag. One hyphen keeps `9.2.1` apart from `9.2.10`,
+but not from `9.2.1-arm64`: that key starts with the prefix of `9.2.1`. The runs of the shorter tag
+could then restore the digest of the longer one, and the mirror serves any digest of the repository,
+so those jobs would run the wrong image. Two hyphens keep the two apart, because no tag here ends
+with a hyphen.
+
 An entry belongs to the ref that saved it. Every run also reads the default branch, `develop`. A
 pull request run reads its merge ref and the base branch, but never the head branch. A rebuild
 dispatched from a feature branch therefore writes an entry that no pull request run finds.

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -335,6 +335,11 @@ An entry belongs to the ref that saved it. Every run also reads the default bran
 pull request run reads its merge ref and the base branch, but never the head branch. A rebuild
 dispatched from a feature branch therefore writes an entry that no pull request run finds.
 
+A dispatch off `develop` stays allowed. The image bakes the commit's Gradle dependencies, so a
+branch that bumps one needs its own tag and its own build, and the push is what that branch needs.
+Only the cache entry goes to waste, so `record_digest` raises a `::warning::` instead of a refusal.
+Dispatch the workflow again on `develop` after the merge.
+
 The rebuild does not save that entry. It runs on an Ubicloud runner, and an Ubicloud runner keeps
 its own Actions cache. A GitHub-hosted runner cannot read it, and `setup` is GitHub-hosted. So the
 digest travels as a job output to `record_digest`, a small job on `ubuntu-latest`, which saves it.

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -23,19 +23,18 @@ directory contain the build logic; the workflow only orchestrates.
 | `e2e_prepare` | resolves the e2e matrix + starts the ROR KBN image build | pushes + PRs (not drafts) |
 | `e2e_tests` | Cypress e2e suite, one job per ES version | pushes + PRs (not drafts) |
 | `build_ror` | builds all plugin zips + bytecode-reuse guard | PRs |
-| `build_toolchains_image` | rebuilds the toolchains image | weekly cron + manual |
-| `record_toolchains_digest` | puts the digest of that rebuild in the Actions cache | after `build_toolchains_image` |
 | `determine_ci_type` → `upload_pre_ror` / `release_ror` / `publish_mvn` | release pipeline | develop/master pushes + manual `release_without_testing` |
 | `disk_probe` | host-disk recon | manual `run_disk_probe` |
 
 Manual actions (`workflow_dispatch` → `actionToPerform`): `run_all_tests_on_linux`,
-`run_all_tests_on_windows`, `run_e2e_tests`, `build_toolchains_image`,
-`release_without_testing`, `run_disk_probe`.
+`run_all_tests_on_windows`, `run_e2e_tests`, `release_without_testing`, `run_disk_probe`.
 
 Other workflows in `.github/workflows/`, all manual or event-driven and independent of the
-above: `mirror-es-libs.yml` (mirrors ES jars into the libs store — see [S3 stores](#s3-stores)),
-`pr-conventions.yml` (PR title/changelog checks), `actionstrings_gen.yml` (regenerates the ES
-action-string lists in the docs repo), `publish-pre-builds.yml` (on-demand ROR+ES dev images).
+above: `build-toolchains-image.yml` (rebuilds the image every CI job runs in — weekly cron and
+manual; see [The `container:` image](#the-container-image)), `mirror-es-libs.yml` (mirrors ES jars
+into the libs store — see [S3 stores](#s3-stores)), `pr-conventions.yml` (PR title/changelog checks),
+`actionstrings_gen.yml` (regenerates the ES action-string lists in the docs repo),
+`publish-pre-builds.yml` (on-demand ROR+ES dev images).
 
 Two orchestration rules worth knowing before editing conditions:
 
@@ -276,7 +275,7 @@ own `ror-it-es:<hash>` image and then tried to pull it, which failed every `it_l
 the day the mirror cannot serve an image a job needs.
 
 The flag answers one question: may this job read a cached answer? It does not follow from what the
-job pushes. The two jobs that push most, `publish-pre-builds` and `build_toolchains_image`, need the
+job pushes. The two workflows that push most, `publish-pre-builds` and `build-toolchains-image`, need the
 mirror most, because a 429 hits their base-image pulls. A mirror rewrites pulls only. A push names
 `beshultd/...` and goes to Docker Hub whatever the mirror says.
 
@@ -328,10 +327,14 @@ and `setup` reads this one every run. A new tag matches no entry, so its runs us
 the next rebuild. The same holds now: run **Build toolchains image** once, on `develop`, to write the
 first digest.
 
-`record_toolchains_digest` saves that entry, not `build_toolchains_image`. The rebuild runs on an
-Ubicloud runner, and an Ubicloud runner keeps its own Actions cache. A GitHub-hosted runner cannot
-read it, and `setup` is GitHub-hosted. So the digest travels as a job output to a small job on
-`ubuntu-latest`, which saves it. Both ends then read one store.
+The rebuild does not save that entry. It runs on an Ubicloud runner, and an Ubicloud runner keeps
+its own Actions cache. A GitHub-hosted runner cannot read it, and `setup` is GitHub-hosted. So the
+digest travels as a job output to `record_digest`, a small job on `ubuntu-latest`, which saves it.
+Both ends then read one store.
+
+The rebuild lives in `build-toolchains-image.yml`, not in `ci.yml`. It takes up to four hours, and
+no test run waits for it. A rebuild in `ci.yml` would also hold the `develop` concurrency group for
+those hours, and every push to `develop` would queue behind it.
 
 A mirrored name needs no login, and a login against `mirror.gcr.io` would fail, so the `credentials:`
 block goes empty then. It goes empty for a fork as well, and the runner skips an empty login.
@@ -351,7 +354,7 @@ Everything the Azure pipeline did is ported — nothing was dropped. The mapping
 | `SUPERSEDE_GUARD` | native `concurrency:` block (auto-cancel stale PR runs; branch pushes queue) |
 | `DETERMINE_CI_TYPE` | `setup` (branch flags, matrices) + `determine_ci_type` (release-type decision) |
 | `DISK_PROBE` | `disk_probe` (manual `run_disk_probe`) |
-| `BUILD_TOOLCHAINS_IMAGE` | `build_toolchains_image` (weekly cron + manual) + `record_toolchains_digest` |
+| `BUILD_TOOLCHAINS_IMAGE` | the standalone `build-toolchains-image.yml` workflow (weekly cron + manual) |
 | `TOOLCHAINS_VERIFY` | `toolchains_verify` |
 | `ES_S3_UP` | the standalone `mirror-es-libs.yml` workflow (manual; was a `newes/*` push trigger) |
 | `REQUIRED_CHECKS` | `required_checks` (same 4-task matrix) |

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -2,7 +2,8 @@
 
 CI runs on GitHub Actions: `.github/workflows/ci.yml`. Linux jobs run on **Ubicloud**
 runners (`ubicloud-standard-4` = 4 vCPU / 16 GB) inside the `beshultd/ror-ci-toolchains`
-image; Windows jobs run on GitHub-hosted `windows-2025`.
+image; Windows jobs run on GitHub-hosted `windows-2025`. `ci/toolchains/image.env` holds that
+image's tag, and every workflow that needs it sources that file.
 
 Every Linux job calls `ci/run-pipeline.sh` with a `ROR_TASK` — the scripts in this
 directory contain the build logic; the workflow only orchestrates.

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -315,6 +315,10 @@ that digest with the one the mirror serves. No run calls Docker Hub.
 
 Docker Hub is the safe answer, so a miss costs speed only.
 
+A mirrored name carries the digest, not the tag: `mirror.gcr.io/beshultd/ror-ci-toolchains@sha256:…`.
+The jobs of one run start hours apart, and a tag can move between the check and a pull. A Docker Hub
+name keeps the tag, because no digest is proven in that case.
+
 The cache key holds the tag and the rebuild's run id. A key is write-once, so each rebuild adds an
 entry and `setup` restores the newest by prefix. GitHub drops an entry that nothing reads for 7 days,
 and `setup` reads this one every run. A new tag matches no entry, so its runs use Docker Hub until

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -23,6 +23,7 @@ directory contain the build logic; the workflow only orchestrates.
 | `e2e_tests` | Cypress e2e suite, one job per ES version | pushes + PRs (not drafts) |
 | `build_ror` | builds all plugin zips + bytecode-reuse guard | PRs |
 | `build_toolchains_image` | rebuilds the toolchains image | weekly cron + manual |
+| `record_toolchains_digest` | puts the digest of that rebuild in the Actions cache | after `build_toolchains_image` |
 | `determine_ci_type` → `upload_pre_ror` / `release_ror` / `publish_mvn` | release pipeline | develop/master pushes + manual `release_without_testing` |
 | `disk_probe` | host-disk recon | manual `run_disk_probe` |
 
@@ -304,7 +305,8 @@ that name needs a Docker Hub login.
 
 The mirror is a cache and can serve an old image, and the weekly rebuild pushes the same tag. So
 the rebuild records the digest of its push in the Actions cache, and `setup` compares that digest
-with the one the mirror serves. No run calls Docker Hub.
+with the one the mirror serves. The comparison sends no request to Docker Hub. When it does not
+agree, the run pulls from Docker Hub instead:
 
 | What the script finds | What the run pulls |
 |---|---|

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -225,10 +225,10 @@ Do not put a `docker login` in a workflow. Two mechanisms with different credent
 other, because a CLI that reads `DOCKER_AUTH_CONFIG` gives that variable priority over the login.
 
 The script cannot authenticate the `container:` image, because the runner pulls that image before
-step 1 starts. Each of the ten `container:` blocks carries a `credentials:` block for that pull.
-They share one anchor, `&toolchains_container`, so the credentials have one definition. A pull
-request from a fork supplies empty secrets, and the runner then skips the login and pulls
-anonymously.
+step 1 starts. The `&toolchains_container` anchor carries a `credentials:` block for that pull, and
+the ten `container:` blocks share it. A fork supplies empty secrets, and the runner then skips the
+login and pulls anonymously. A mirrored name skips it too — see
+[The `container:` image](#the-container-image).
 
 ### Docker Hub pull mirror
 
@@ -243,7 +243,9 @@ alone does not stop every rejection, because two limits apply:
   `429 Too Many Requests`, and no credential prevents it.
 
 The mirror serves `docker.io`. It cannot serve `docker.elastic.co` or `ghcr.io`, and it cannot accept
-a push. Three clients pull images, and the script sets all three from one variable:
+a push. Three clients pull images inside a job, and the script sets all three from one variable. A
+fourth pull happens before any step and needs an answer of its own — see
+[The `container:` image](#the-container-image):
 
 | Client | Setting | Reaches |
 |---|---|---|
@@ -289,9 +291,44 @@ Two more things stay off the mirror by themselves, and both must remain so:
   the variables above, so both address Docker Hub by themselves.
 - Every push. A pull-through cache is read-only, so `beshultd/*` images go to Docker Hub.
 
-The `container:` image cannot use a mirror at all, for the same reason it cannot use the login: the
-runner pulls it before step 1 starts. That is about 11 pulls per `ci.yml` run. Publishing the
-toolchains image to `ghcr.io` is the only way to take them off the Docker Hub budget.
+### The `container:` image
+
+The runner pulls the job `container:` image before step 1 starts. `ci/configure-docker.sh` cannot
+reach that pull, so it sets neither the mirror nor the login for it. Ten jobs and their matrices
+share the image, which makes it the most pulled image of a run. Docker Hub answered a whole run with
+`429 toomanyrequests` on 2026-08-26.
+
+`container: image:` can read a job output. The `setup` job runs `ci/resolve-toolchains-image.sh`
+once, and the `&toolchains_container` anchor reads its two outputs: the name to pull, and whether
+that name needs a Docker Hub login.
+
+The mirror is a cache and can serve an old image, and the weekly rebuild pushes the same tag. So
+`build_toolchains_image` writes the digest of its push to the Actions cache, and `setup` compares
+that digest with the one the mirror serves. No run calls Docker Hub.
+
+| What the script finds | What the run pulls |
+|---|---|
+| no digest on record | Docker Hub |
+| the mirror has no such tag | Docker Hub |
+| the digests differ | Docker Hub, with a warning |
+| the digests agree | the mirror |
+
+Docker Hub is the safe answer, so a miss costs speed only.
+
+The cache key holds the tag and the rebuild's run id. A key is write-once, so each rebuild adds an
+entry and `setup` restores the newest by prefix. GitHub drops an entry that nothing reads for 7 days,
+and `setup` reads this one every run. A new tag matches no entry, so its runs use Docker Hub until
+the next rebuild. The same holds now: run **Build toolchains image** once, on `develop`, to write the
+first digest.
+
+A mirrored name needs no login, and a login against `mirror.gcr.io` would fail, so the `credentials:`
+block goes empty then. It goes empty for a fork as well, and the runner skips an empty login.
+
+One limit. The choice is made once, for the whole run. If the mirror stops answering during a run,
+the jobs that already took the mirrored name fail. The runner's pull has no fallback of its own.
+
+Publishing the image to `ghcr.io` would remove the digest bookkeeping, because the pull would no
+longer cross a cache.
 
 ## Coverage: what happened to every Azure stage
 

--- a/ci/configure-docker.sh
+++ b/ci/configure-docker.sh
@@ -75,9 +75,8 @@
 #
 # ---------------------------------------------------------------------------------------------
 # TWO LIMITS
-# 1. This script cannot configure the job `container:` image. The runner pulls that image before
-#    step 1 starts, so no step can set a mirror or a login first. The `credentials:` block on each
-#    container does the login instead, and no mirror can reach that pull.
+# 1. This script cannot configure the job `container:` image. The runner pulls it before step 1
+#    starts. The setup job settles that pull instead. See ci/resolve-toolchains-image.sh.
 # 2. Docker CLI 27, which the toolchains image contains, ignores DOCKER_AUTH_CONFIG. This is why
 #    the login is necessary. A later CLI reads the variable and gives it priority over the login.
 #    That priority is safe here, because both halves use the same credentials. It is not safe if

--- a/ci/configure-docker.sh
+++ b/ci/configure-docker.sh
@@ -25,7 +25,7 @@
 #                          that points at build-base/buildkitd.toml
 #   - the test suite       ROR_DOCKER_HUB_MIRROR_PREFIX, which DockerHubMirror reads. This rewrites
 #                          the registry name directly, so these pulls cannot fall back to Docker Hub.
-#   - the toolchains build the same variable, which the build_toolchains_image job passes as the
+#   - the toolchains build the same variable, which build-toolchains-image.yml passes as the
 #                          MIRROR build argument of ci/toolchains/JdkToolchains.Dockerfile.
 #
 # Do NOT set TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX here. testcontainers applies that prefix to every

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -21,7 +21,9 @@
 #         Both go to $GITHUB_OUTPUT when it is set, and to stdout otherwise.
 #         The choice also goes to $GITHUB_STEP_SUMMARY, so the run page shows it.
 #
-# The script always exits 0. A mirror is an optimisation. It must never stop a run.
+# A mirror is an optimisation, so no mirror fault stops a run. The script takes Docker Hub and exits
+# 0. An empty TOOLCHAINS_IMAGE is a different matter. There is nothing safe to emit, the jobs would
+# take container: image: '', and that failure would not name this script. So that one exits 1.
 #
 # For the reason this script exists, see "The container: image" in ci/CI.md.
 set -uo pipefail
@@ -32,7 +34,7 @@ main() {
   local image="${TOOLCHAINS_IMAGE:-}"
   local pushed
 
-  [ -n "$image" ] || { echo "[CI] TOOLCHAINS_IMAGE is empty. Nothing to resolve." >&2; exit 0; }
+  [ -n "$image" ] || fail "TOOLCHAINS_IMAGE is empty. ci/toolchains/image.env must set it."
 
   has_tag "$image" || use_docker_hub "$image" "the image name has no tag."
   mirror_is_on     || use_docker_hub "$image" "ROR_DOCKER_HUB_MIRROR is false."
@@ -47,6 +49,13 @@ main() {
   # The name carries the digest, not the tag. A tag can move between this check and the pull, and
   # the jobs of one run start hours apart.
   use_mirror "$image" "$pushed"
+}
+
+# The one fault with no fallback. Silence here would give ten jobs an empty container: image:.
+fail() {
+  [ -n "${GITHUB_ACTIONS:-}" ] && echo "::error::$1"
+  echo "[CI] $1" >&2
+  exit 1
 }
 
 has_tag() {

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -33,18 +33,28 @@ main() {
 
   [ -n "$image" ] || { echo "[CI] TOOLCHAINS_IMAGE is empty. Nothing to resolve." >&2; exit 0; }
 
-  has_tag "$image" || use_docker_hub "$image" "the name carries no tag"
-  mirror_is_on     || use_docker_hub "$image" "the mirror is off"
+  has_tag "$image" || use_docker_hub "$image" \
+    "The image name has no tag: '${image}'. A digest check needs one."
+
+  mirror_is_on || use_docker_hub "$image" \
+    "ROR_DOCKER_HUB_MIRROR is false, so the mirror is off by request."
 
   pushed="$(recorded_digest)"
-  [ -n "$pushed" ] || use_docker_hub "$image" "no digest is on record. Run 'Build toolchains image'"
+  [ -n "$pushed" ] || use_docker_hub "$image" \
+    "No digest is on record for '${image}'." \
+    "The 'Build toolchains image' job records the digest of every push. Run that job once."
 
   served="$(mirror_digest "$image")"
-  [ -n "$served" ] || use_docker_hub "$image" "${MIRROR_HOST} does not serve the tag"
+  [ -n "$served" ] || use_docker_hub "$image" \
+    "${MIRROR_HOST} holds no image for '${image}'." \
+    "The mirror copies an image only after a pull asks for it."
 
   if [ "$served" != "$pushed" ]; then
-    warn "${MIRROR_HOST} serves ${served} for ${image}. The last push was ${pushed}."
-    use_docker_hub "$image" "the mirror has not caught up with the last push"
+    # The annotation is the headline. The log lines below carry the two digests.
+    warn "${MIRROR_HOST} has not caught up with the last push of ${image}. This run uses Docker Hub."
+    use_docker_hub "$image" \
+      "${MIRROR_HOST} holds an old image for '${image}'." \
+      "It serves ${served}. The last push was ${pushed}."
   fi
 
   # The name carries the digest, not the tag. A tag can move between this check and the pull, and
@@ -81,12 +91,20 @@ mirror_digest() {
     | tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" { print $2 }'
 }
 
+# $1 is the image. Every argument after it is one line of the reason. Each line says one fact: what
+# the script looked for, and what it found. The last line says what the run does about it.
 use_docker_hub() {
-  echo "[CI] Docker Hub, because $2."
-  emit "$1" "false"
+  local image="$1" line
+  shift
+  for line in "$@"; do echo "[CI] $line"; done
+  echo "[CI] So this run pulls from Docker Hub. The pull works."
+  echo "[CI] It is slower, and it counts against the Docker Hub rate limit."
+  emit "$image" "false"
 }
 
 use_mirror() {
+  echo "[CI] ${MIRROR_HOST} serves the digest of the last push: $2."
+  echo "[CI] So this run pulls from the mirror."
   emit "${MIRROR_HOST}/${1%:*}@$2" "true"
 }
 

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Chooses where a job pulls the toolchains image from: mirror.gcr.io or Docker Hub.
 #
-# mirror.gcr.io is a pull-through cache for docker.io. It can serve an old image, so the script
-# trusts it only when it serves the digest of the last push. TOOLCHAINS_DIGEST_FILE holds that
-# digest. The script asks the mirror for the digest behind the tag and compares the two. It sends
-# no request to Docker Hub.
+# mirror.gcr.io is a pull-through cache for docker.io. A job pulls by digest, and a digest names the
+# bytes. A cache cannot answer a digest with the wrong image. So the script asks one question: can
+# the mirror serve this digest? TOOLCHAINS_DIGEST_FILE holds the digest of the last push. No request
+# goes to Docker Hub.
 #
 # A mirrored name carries the digest, not the tag, because a tag can move between this check and
 # the pull. A Docker Hub name keeps the tag: no digest is proven in that case.
 #
-# main() holds the steps. Docker Hub is the answer whenever the mirror cannot be trusted, so a
+# main() holds the steps. Docker Hub is the answer when the mirror cannot serve the digest, so a
 # wrong choice costs speed only.
 #
 # INPUT   TOOLCHAINS_IMAGE        repository:tag, no registry host. See ci/toolchains/image.env
@@ -29,7 +29,7 @@ MIRROR_HOST="mirror.gcr.io"
 
 main() {
   local image="${TOOLCHAINS_IMAGE:-}"
-  local pushed served
+  local pushed
 
   [ -n "$image" ] || { echo "[CI] TOOLCHAINS_IMAGE is empty. Nothing to resolve." >&2; exit 0; }
 
@@ -40,18 +40,12 @@ main() {
   [ -n "$pushed" ] || use_docker_hub "$image" \
     "no digest recorded for this tag. Run 'Build toolchains image'."
 
-  served="$(mirror_digest "$image")"
-  [ -n "$served" ] || use_docker_hub "$image" "${MIRROR_HOST} has no copy of this tag."
-
-  if [ "$served" != "$pushed" ]; then
-    # The annotation carries the two digests. The line below stays short.
-    warn "${MIRROR_HOST} serves ${served} for ${image}. The last push was ${pushed}."
-    use_docker_hub "$image" "${MIRROR_HOST} is behind the last push."
-  fi
+  mirror_has_digest "$image" "$pushed" || use_docker_hub "$image" \
+    "${MIRROR_HOST} cannot serve ${pushed}."
 
   # The name carries the digest, not the tag. A tag can move between this check and the pull, and
   # the jobs of one run start hours apart.
-  use_mirror "$image" "$served"
+  use_mirror "$image" "$pushed"
 }
 
 has_tag() {
@@ -70,17 +64,17 @@ recorded_digest() {
   [ -r "$file" ] && tr -d '[:space:]' < "$file"
 }
 
-# One HEAD request. It downloads no image.
-mirror_digest() {
-  local repo="${1%:*}" tag="${1##*:}" accept
+# One HEAD request. It downloads no image. The mirror fetches a digest it has never held, so this
+# passes in the hours after a rebuild, before the mirror knows the new tag.
+mirror_has_digest() {
+  local repo="${1%:*}" digest="$2" accept
   accept='application/vnd.oci.image.index.v1+json'
   accept="${accept},application/vnd.docker.distribution.manifest.list.v2+json"
   accept="${accept},application/vnd.oci.image.manifest.v1+json"
   accept="${accept},application/vnd.docker.distribution.manifest.v2+json"
 
-  curl -fsS --max-time 15 -o /dev/null -D - -I -H "Accept: ${accept}" \
-       "https://${MIRROR_HOST}/v2/${repo}/manifests/${tag}" 2>/dev/null \
-    | tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" { print $2 }'
+  curl -fsS --max-time 15 -o /dev/null -I -H "Accept: ${accept}" \
+       "https://${MIRROR_HOST}/v2/${repo}/manifests/${digest}" >/dev/null 2>&1
 }
 
 # $2 is the reason, in one short sentence. It names the fact, not the decision.
@@ -101,10 +95,6 @@ emit() {
     printf 'image=%s\nmirrored=%s\n' "$1" "$2"
   fi
   exit 0
-}
-
-warn() {
-  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::warning::$1"; else echo "[CI] WARNING: $1"; fi
 }
 
 main "$@"

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -19,6 +19,7 @@
 # OUTPUT  image=<name>            the name to pull. Mirrored names end in @sha256:...
 #         mirrored=true|false     false means a Docker Hub name, which needs a login
 #         Both go to $GITHUB_OUTPUT when it is set, and to stdout otherwise.
+#         The choice also goes to $GITHUB_STEP_SUMMARY, so the run page shows it.
 #
 # The script always exits 0. A mirror is an optimisation. It must never stop a run.
 #
@@ -80,15 +81,29 @@ mirror_has_digest() {
 # $2 is the reason, in one short sentence. It names the fact, not the decision.
 use_docker_hub() {
   echo "[CI] This run skips the mirror: $2"
-  emit "$1" "false"
+  emit "$1" "false" "$2"
 }
 
 use_mirror() {
   emit "${MIRROR_HOST}/${1%:*}@$2" "true"
 }
 
+# The run page carries the choice. A step log hides it, and a run that left the mirror in silence is
+# the fault this note makes visible.
+summarise() {
+  local line
+  [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+  if [ "$2" = "true" ]; then
+    line="This run pulls the toolchains image from ${MIRROR_HOST}."
+  else
+    line="This run pulls the toolchains image from Docker Hub: $3"
+  fi
+  printf '### Toolchains image\n\n%s\n\n`%s`\n' "$line" "$1" >> "$GITHUB_STEP_SUMMARY"
+}
+
 emit() {
   echo "[CI] Toolchains image: $1"
+  summarise "$1" "$2" "${3:-}"
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     printf 'image=%s\nmirrored=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
   else

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Chooses where a job pulls the toolchains image from: mirror.gcr.io or Docker Hub.
+#
+# mirror.gcr.io is a pull-through cache for docker.io. It can serve an old image, so the script
+# trusts it only when it serves the digest of the last push. TOOLCHAINS_DIGEST_FILE holds that
+# digest. The script asks the mirror for the digest behind the tag and compares the two. It sends
+# no request to Docker Hub.
+#
+# main() holds the steps. Docker Hub is the answer whenever the mirror cannot be trusted, so a
+# wrong choice costs speed only.
+#
+# INPUT   TOOLCHAINS_IMAGE        repository:tag, no registry host
+#         TOOLCHAINS_DIGEST_FILE  the digest of the last push, written by build_toolchains_image.
+#                                 Default .toolchains-digest. An absent file means no digest.
+#         ROR_DOCKER_HUB_MIRROR   false skips the mirror
+# OUTPUT  image=<name>            the name to pull
+#         mirrored=true|false     false means a Docker Hub name, which needs a login
+#         Both go to $GITHUB_OUTPUT when it is set, and to stdout otherwise.
+#
+# The script always exits 0. A mirror is an optimisation. It must never stop a run.
+#
+# For the reason this script exists, see "The container: image" in ci/CI.md.
+set -uo pipefail
+
+MIRROR_HOST="mirror.gcr.io"
+
+main() {
+  local image="${TOOLCHAINS_IMAGE:-}"
+  local pushed served
+
+  [ -n "$image" ] || { echo "[CI] TOOLCHAINS_IMAGE is empty. Nothing to resolve." >&2; exit 0; }
+
+  has_tag "$image" || use_docker_hub "$image" "the name carries no tag"
+  mirror_is_on     || use_docker_hub "$image" "the mirror is off"
+
+  pushed="$(recorded_digest)"
+  [ -n "$pushed" ] || use_docker_hub "$image" "no digest is on record. Run 'Build toolchains image'"
+
+  served="$(mirror_digest "$image")"
+  [ -n "$served" ] || use_docker_hub "$image" "${MIRROR_HOST} does not serve the tag"
+
+  if [ "$served" != "$pushed" ]; then
+    warn "${MIRROR_HOST} serves ${served} for ${image}. The last push was ${pushed}."
+    use_docker_hub "$image" "the mirror has not caught up with the last push"
+  fi
+
+  use_mirror "$image"
+}
+
+has_tag() {
+  case "$1" in *:*) return 0 ;; *) return 1 ;; esac
+}
+
+mirror_is_on() {
+  local flag
+  flag="$(echo "${ROR_DOCKER_HUB_MIRROR:-true}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  [ "$flag" != "false" ]
+}
+
+# build_toolchains_image wrote this file. The Actions cache carried it here.
+recorded_digest() {
+  local file="${TOOLCHAINS_DIGEST_FILE:-.toolchains-digest}"
+  [ -r "$file" ] && tr -d '[:space:]' < "$file"
+}
+
+# One HEAD request. It downloads no image.
+mirror_digest() {
+  local repo="${1%:*}" tag="${1##*:}" accept
+  accept='application/vnd.oci.image.index.v1+json'
+  accept="${accept},application/vnd.docker.distribution.manifest.list.v2+json"
+  accept="${accept},application/vnd.oci.image.manifest.v1+json"
+  accept="${accept},application/vnd.docker.distribution.manifest.v2+json"
+
+  curl -fsS --max-time 15 -o /dev/null -D - -I -H "Accept: ${accept}" \
+       "https://${MIRROR_HOST}/v2/${repo}/manifests/${tag}" 2>/dev/null \
+    | tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" { print $2 }'
+}
+
+use_docker_hub() {
+  echo "[CI] Docker Hub, because $2."
+  emit "$1" "false"
+}
+
+use_mirror() {
+  emit "${MIRROR_HOST}/$1" "true"
+}
+
+emit() {
+  echo "[CI] Toolchains image: $1 (mirrored=$2)"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'image=%s\nmirrored=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  else
+    printf 'image=%s\nmirrored=%s\n' "$1" "$2"
+  fi
+  exit 0
+}
+
+warn() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then echo "::warning::$1"; else echo "[CI] WARNING: $1"; fi
+}
+
+main "$@"

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -33,28 +33,20 @@ main() {
 
   [ -n "$image" ] || { echo "[CI] TOOLCHAINS_IMAGE is empty. Nothing to resolve." >&2; exit 0; }
 
-  has_tag "$image" || use_docker_hub "$image" \
-    "The image name has no tag: '${image}'. A digest check needs one."
-
-  mirror_is_on || use_docker_hub "$image" \
-    "ROR_DOCKER_HUB_MIRROR is false, so the mirror is off by request."
+  has_tag "$image" || use_docker_hub "$image" "the image name has no tag."
+  mirror_is_on     || use_docker_hub "$image" "ROR_DOCKER_HUB_MIRROR is false."
 
   pushed="$(recorded_digest)"
   [ -n "$pushed" ] || use_docker_hub "$image" \
-    "No digest is on record for '${image}'." \
-    "The 'Build toolchains image' job records the digest of every push. Run that job once."
+    "no digest recorded for this tag. Run 'Build toolchains image'."
 
   served="$(mirror_digest "$image")"
-  [ -n "$served" ] || use_docker_hub "$image" \
-    "${MIRROR_HOST} holds no image for '${image}'." \
-    "The mirror copies an image only after a pull asks for it."
+  [ -n "$served" ] || use_docker_hub "$image" "${MIRROR_HOST} has no copy of this tag."
 
   if [ "$served" != "$pushed" ]; then
-    # The annotation is the headline. The log lines below carry the two digests.
-    warn "${MIRROR_HOST} has not caught up with the last push of ${image}. This run uses Docker Hub."
-    use_docker_hub "$image" \
-      "${MIRROR_HOST} holds an old image for '${image}'." \
-      "It serves ${served}. The last push was ${pushed}."
+    # The annotation carries the two digests. The line below stays short.
+    warn "${MIRROR_HOST} serves ${served} for ${image}. The last push was ${pushed}."
+    use_docker_hub "$image" "${MIRROR_HOST} is behind the last push."
   fi
 
   # The name carries the digest, not the tag. A tag can move between this check and the pull, and
@@ -91,25 +83,18 @@ mirror_digest() {
     | tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" { print $2 }'
 }
 
-# $1 is the image. Every argument after it is one line of the reason. Each line says one fact: what
-# the script looked for, and what it found. The last line says what the run does about it.
+# $2 is the reason, in one short sentence. It names the fact, not the decision.
 use_docker_hub() {
-  local image="$1" line
-  shift
-  for line in "$@"; do echo "[CI] $line"; done
-  echo "[CI] So this run pulls from Docker Hub. The pull works."
-  echo "[CI] It is slower, and it counts against the Docker Hub rate limit."
-  emit "$image" "false"
+  echo "[CI] This run skips the mirror: $2"
+  emit "$1" "false"
 }
 
 use_mirror() {
-  echo "[CI] ${MIRROR_HOST} serves the digest of the last push: $2."
-  echo "[CI] So this run pulls from the mirror."
   emit "${MIRROR_HOST}/${1%:*}@$2" "true"
 }
 
 emit() {
-  echo "[CI] Toolchains image: $1 (mirrored=$2)"
+  echo "[CI] Toolchains image: $1"
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     printf 'image=%s\nmirrored=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
   else

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -13,7 +13,7 @@
 # wrong choice costs speed only.
 #
 # INPUT   TOOLCHAINS_IMAGE        repository:tag, no registry host
-#         TOOLCHAINS_DIGEST_FILE  the digest of the last push, written by build_toolchains_image.
+#         TOOLCHAINS_DIGEST_FILE  the digest of the last push. record_toolchains_digest caches it.
 #                                 Default .toolchains-digest. An absent file means no digest.
 #         ROR_DOCKER_HUB_MIRROR   false skips the mirror
 # OUTPUT  image=<name>            the name to pull. Mirrored names end in @sha256:...
@@ -62,7 +62,7 @@ mirror_is_on() {
   [ "$flag" != "false" ]
 }
 
-# build_toolchains_image wrote this file. The Actions cache carried it here.
+# build_toolchains_image found this digest. The Actions cache carried it here.
 recorded_digest() {
   local file="${TOOLCHAINS_DIGEST_FILE:-.toolchains-digest}"
   [ -r "$file" ] && tr -d '[:space:]' < "$file"

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -13,7 +13,7 @@
 # wrong choice costs speed only.
 #
 # INPUT   TOOLCHAINS_IMAGE        repository:tag, no registry host. See ci/toolchains/image.env
-#         TOOLCHAINS_DIGEST_FILE  the digest of the last push. record_toolchains_digest caches it.
+#         TOOLCHAINS_DIGEST_FILE  the digest of the last push. record_digest caches it.
 #                                 Default .toolchains-digest. An absent file means no digest.
 #         ROR_DOCKER_HUB_MIRROR   false skips the mirror
 # OUTPUT  image=<name>            the name to pull. Mirrored names end in @sha256:...
@@ -64,7 +64,7 @@ mirror_is_on() {
   [ "$flag" != "false" ]
 }
 
-# build_toolchains_image found this digest. The Actions cache carried it here.
+# build-toolchains-image.yml found this digest. The Actions cache carried it here.
 recorded_digest() {
   local file="${TOOLCHAINS_DIGEST_FILE:-.toolchains-digest}"
   [ -r "$file" ] && tr -d '[:space:]' < "$file"

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -12,7 +12,7 @@
 # main() holds the steps. Docker Hub is the answer whenever the mirror cannot be trusted, so a
 # wrong choice costs speed only.
 #
-# INPUT   TOOLCHAINS_IMAGE        repository:tag, no registry host
+# INPUT   TOOLCHAINS_IMAGE        repository:tag, no registry host. See ci/toolchains/image.env
 #         TOOLCHAINS_DIGEST_FILE  the digest of the last push. record_toolchains_digest caches it.
 #                                 Default .toolchains-digest. An absent file means no digest.
 #         ROR_DOCKER_HUB_MIRROR   false skips the mirror

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -6,6 +6,9 @@
 # digest. The script asks the mirror for the digest behind the tag and compares the two. It sends
 # no request to Docker Hub.
 #
+# A mirrored name carries the digest, not the tag, because a tag can move between this check and
+# the pull. A Docker Hub name keeps the tag: no digest is proven in that case.
+#
 # main() holds the steps. Docker Hub is the answer whenever the mirror cannot be trusted, so a
 # wrong choice costs speed only.
 #
@@ -13,7 +16,7 @@
 #         TOOLCHAINS_DIGEST_FILE  the digest of the last push, written by build_toolchains_image.
 #                                 Default .toolchains-digest. An absent file means no digest.
 #         ROR_DOCKER_HUB_MIRROR   false skips the mirror
-# OUTPUT  image=<name>            the name to pull
+# OUTPUT  image=<name>            the name to pull. Mirrored names end in @sha256:...
 #         mirrored=true|false     false means a Docker Hub name, which needs a login
 #         Both go to $GITHUB_OUTPUT when it is set, and to stdout otherwise.
 #
@@ -44,7 +47,9 @@ main() {
     use_docker_hub "$image" "the mirror has not caught up with the last push"
   fi
 
-  use_mirror "$image"
+  # The name carries the digest, not the tag. A tag can move between this check and the pull, and
+  # the jobs of one run start hours apart.
+  use_mirror "$image" "$served"
 }
 
 has_tag() {
@@ -82,7 +87,7 @@ use_docker_hub() {
 }
 
 use_mirror() {
-  emit "${MIRROR_HOST}/$1" "true"
+  emit "${MIRROR_HOST}/${1%:*}@$2" "true"
 }
 
 emit() {

--- a/ci/toolchains/JdkToolchains.Dockerfile
+++ b/ci/toolchains/JdkToolchains.Dockerfile
@@ -16,12 +16,13 @@
 #   * JDK 21  -> ES 9.x adapters                                      (ES 9.x bundles Java 21)
 #
 # Build context MUST be the repo root (the build needs settings.gradle/*/build.gradle to
-# resolve dependencies during the priming step). Built & pushed by the BUILD_TOOLCHAINS_IMAGE
-# stage in azure-pipelines.yml — weekly on a schedule (keeps the baked cache fresh) or manually
-# (actionToPerform=build_toolchains_image) — or locally:
+# resolve dependencies during the priming step). Built & pushed by the Build toolchains image
+# workflow, .github/workflows/build-toolchains-image.yml — weekly on a schedule, which keeps the
+# baked cache fresh, or by hand — or locally:
 #
-#   docker build -f ci/toolchains/JdkToolchains.Dockerfile -t beshultd/ror-ci-toolchains:jdk-8-11-17-21-gradle-9.2.1 .
-#   docker push beshultd/ror-ci-toolchains:jdk-8-11-17-21-gradle-9.2.1
+#   . ci/toolchains/image.env
+#   docker build -f ci/toolchains/JdkToolchains.Dockerfile -t "$TOOLCHAINS_IMAGE" .
+#   docker push "$TOOLCHAINS_IMAGE"
 #
 # (BuildKit is required: the build context is filtered by the sibling
 # ci/toolchains/JdkToolchains.Dockerfile.dockerignore file.)
@@ -42,7 +43,7 @@
 #
 # A name that carries the mirror host is a different image identity, so these pulls do not fall back
 # to Docker Hub. Should the mirror stop serving one of them, set ROR_DOCKER_HUB_MIRROR=false on the
-# build_toolchains_image job.
+# build job of build-toolchains-image.yml.
 ARG MIRROR=
 
 # ---- JDK sources (all temurin images install to /opt/java/openjdk) ----------------------

--- a/ci/toolchains/image.env
+++ b/ci/toolchains/image.env
@@ -1,0 +1,11 @@
+# The toolchains image. Every container: job of the CI workflow pulls it. A JDK or Gradle bump
+# edits ONE line: the tag below.
+#
+# The tag lives in the repo, not in a repo variable. The image bakes this commit's Gradle
+# dependencies, so a branch that changes a dependency needs its own tag.
+#
+# The name points at Docker Hub, because the toolchains-image rebuild pushes it there.
+# ci/resolve-toolchains-image.sh decides whether a pull takes the mirror instead.
+#
+# Bash sources this file. Keep it to one assignment.
+TOOLCHAINS_IMAGE=beshultd/ror-ci-toolchains:jdk-8-11-17-21-gradle-9.2.1


### PR DESCRIPTION
## The problem

The runner pulls the job `container:` image before step 1 starts. `ci/configure-docker.sh` cannot
reach that pull, so it sets neither the mirror nor the login for it.

Ten jobs and their matrices share that image, which makes it the most pulled image of a run. On
2026-08-26 Docker Hub answered a whole run with `429 toomanyrequests`. Sixteen jobs died before
`actions/checkout`.

## The change

`container: image:` can read a job output. The `setup` job now runs `ci/resolve-toolchains-image.sh`
once and publishes the name to pull.

A job pulls by digest, and a digest names the bytes. A cache cannot answer a digest with the wrong
image. So the script asks one question: can `mirror.gcr.io` serve this digest? **Build toolchains
image** writes the digest of its push to the Actions cache, and `setup` sends one HEAD request for
that digest. No request goes to Docker Hub.

| What the script finds | What the run pulls |
|---|---|
| no digest on record | Docker Hub |
| the mirror cannot serve the digest | Docker Hub |
| the mirror serves the digest | the mirror |

Docker Hub is the safe answer in the first two rows, so a wrong choice costs speed only.

The mirror fetches a digest it has never held. So a run keeps the mirror in the hours after a
rebuild, before the mirror knows the new tag. A question about the tag would lose the mirror in that
window, where the recorded digest is newest.

`setup` writes the choice, and the reason for it, to the step summary. The run page then shows which
registry a run used, without opening a log.

## What a fork gains

A fork run has no secrets. It pulled this image anonymously from Docker Hub, where the limit counts
against a shared runner address, so a fork run met the 429 first. The same run now pulls anonymously
from `mirror.gcr.io`, which sets no limit. A fork run reads the base branch, so it finds the digest
a `develop` rebuild saved.

## The rebuild workflow

`build-toolchains-image.yml` holds the weekly rebuild. It takes up to four hours, and no test run
waits for it.

- It keeps a concurrency group of its own. Two rebuilds would push one tag and file two cache
  entries, and `setup` takes the newest, which need not hold the manifest Docker Hub keeps.
- The digest comes from the `docker push` output. An empty digest is an error and the job fails. A
  silent miss would leave the mirror off for every run until the next rebuild.
- A dispatch off `develop` raises a warning. A cache entry belongs to the ref that saved it, so no
  `develop` run and no pull request run can read that one. The dispatch stays allowed: a branch that
  bumps a Gradle dependency needs its own tag and its own build.

## Smaller things

The drift guard in `build_toolchains_image` is gone. `ci/toolchains/image.env` holds the tag now.
`azure-pipelines.yml` keeps a copy, because Azure resolves `container:` at compile time and cannot
read the file there. Its build step sources the file, so that fallback pipeline cannot build a stale
tag.

The cache key and the restore prefix put two hyphens after the tag. One hyphen would let the key of
`…-9.2.1-arm64` answer the prefix of `…-9.2.1`.

Five step ids said nothing. `f`, `m`, `dkey` and `img` are now `flags`, `matrices`, `digest_key` and
`toolchains`. `r` is `release_check`.

## After the merge

Run **Build toolchains image** once, on `develop`. Until a rebuild writes the first digest, every run
pulls from Docker Hub, as it does today.

## Two limits

The choice holds for the whole run. If the mirror stops answering during a run, the jobs that already
took the mirrored name fail. The runner's pull has no fallback of its own.

`ghcr.io` is the other direction. It would remove the digest bookkeeping, and a public package needs
no `credentials:` block at all. It would not retire the mirror, which `buildx`, the test suite and
the toolchains build still need for their own Docker Hub pulls. This change does not settle that
question.

## Tested

`ci/resolve-toolchains-image.sh` ran against the live registries on every path: a digest the mirror
can serve, a digest it cannot, no digest file, the mirror switched off, a name with no tag, and an
empty `TOOLCHAINS_IMAGE`. Each gave the right answer.

`mirror.gcr.io` served a digest it had never held. `beshultd/elasticsearch-readonlyrest:6.0.1-ror-1.54.0`
was asked by digest before any request for its tag, and answered 200. A fabricated digest answered
404.

Both workflows parse. The restore prefix matches the tag's own entries, and no longer matches the key
of a tag that extends it.

## Review

Nine commits answer @sscarduzio's review, one commit per point.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * CI now dynamically verifies and selects the toolchains image source.
  * Mirrored images use digest-pinned references, with Docker Hub authentication only when needed.
  * Improved fallback handling when mirrored images are unavailable, outdated, or unverifiable.
  * Toolchain image digests are reliably persisted across CI runs.

* **Documentation**
  * Updated CI and Docker guidance covering image resolution, authentication, mirroring, and pull behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
