### PR TITLE
[RORDEV-2183] Pull the container: image without credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,7 @@ jobs:
       it_linux_matrix:   ${{ steps.matrices.outputs.linux }}
       it_windows_matrix: ${{ steps.matrices.outputs.windows }}
       e2e_modules:       ${{ steps.matrices.outputs.e2e }}
-      toolchains_image:    ${{ steps.toolchains.outputs.image }}
-      toolchains_mirrored: ${{ steps.toolchains.outputs.mirrored }}
+      toolchains_image: ${{ steps.toolchains.outputs.image }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
@@ -167,16 +166,18 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB); light job, speed barely matters
     # The runner pulls this image before step 1 runs, so ci/configure-docker.sh reaches neither the
-    # mirror nor the login for it. The setup job settles both. See ci/resolve-toolchains-image.sh.
-    # A mirrored name carries the digest, so every job of a run pulls the same bytes. It needs no
-    # login, and a login against mirror.gcr.io would fail, so the credentials go empty then. A fork
-    # also gives empty secrets, and the runner skips an empty login. A read-only token is enough: a
-    # job only pulls this image.
+    # mirror nor the login for it. ci/resolve-toolchains-image.sh settles the name in the setup job.
+    # A mirrored name carries the digest, so every job of a run pulls the same bytes.
+    #
+    # The pull carries no credentials. mirror.gcr.io needs none, and a Docker Hub login against it
+    # would fail. A credentials: block cannot hold that difference. Its two keys take an expression,
+    # but an expression that evaluates to nothing gives "Unexpected value ''", and the job then dies
+    # in template validation, before step 1. An empty string and null both do it.
+    #
+    # So the Docker Hub fallback pulls anonymously. Docker Hub then counts the pull against the
+    # runner's address, not against our account. That path is the rare one.
     container: &toolchains_container
       image: ${{ needs.setup.outputs.toolchains_image }}
-      credentials:
-        username: ${{ needs.setup.outputs.toolchains_mirrored != 'true' && secrets.DOCKER_HUB_USER || '' }}
-        password: ${{ needs.setup.outputs.toolchains_mirrored != 'true' && secrets.DOCKER_HUB_RO_TOKEN || '' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,13 @@ jobs:
     # mirror nor the login for it. ci/resolve-toolchains-image.sh settles the name in the setup job.
     # A mirrored name carries the digest, so every job of a run pulls the same bytes.
     #
-    # The pull carries no credentials. mirror.gcr.io needs none, and a Docker Hub login against it
-    # would fail. A credentials: block cannot hold that difference. Its two keys take an expression,
-    # but an expression that evaluates to nothing gives "Unexpected value ''", and the job then dies
-    # in template validation, before step 1. An empty string and null both do it.
+    # The pull sends no credentials. A Docker Hub login against mirror.gcr.io fails, so the block
+    # must be absent on the mirrored path. An empty value does not remove it. GitHub rejects it with
+    # "Unexpected value ''" and stops the run before step 1. YAML cannot drop a key on a condition,
+    # so the block is absent on both paths.
     #
-    # So the Docker Hub fallback pulls anonymously. Docker Hub then counts the pull against the
-    # runner's address, not against our account. That path is the rare one.
+    # Docker Hub then counts the fallback pull against the runner's address, not against our
+    # account. The mirror serves the normal path.
     container: &toolchains_container
       image: ${{ needs.setup.outputs.toolchains_image }}
     timeout-minutes: 10

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -176,7 +176,7 @@ every push on such a branch, and made five CI jobs depend on a job that almost a
 |---|---|
 | `ROR_S3_ACCESS_KEY_ID` / `ROR_S3_SECRET_ACCESS_KEY` | the one S3 key pair; writes `builds/`, `libs/` and `e2e_reports/` |
 | `DOCKER_HUB_USER` / `DOCKER_HUB_RW_TOKEN` | the push account. It pushes the ROR and toolchains images, and authenticates the pulls of the same job. A job maps it into `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD`, which is the one pair `configure-docker.sh` reads |
-| `DOCKER_HUB_USER` / `DOCKER_HUB_RO_TOKEN` | the read-only token; it cannot push — it is refused push scope. Each job that only pulls maps it into `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD` as well. Without it, a pull request from a fork continues with anonymous pulls, and every other event stops |
+| `DOCKER_HUB_USER` / `DOCKER_HUB_RO_TOKEN` | the read-only token; it cannot push — it is refused push scope. `unit_tests_linux` and `it_linux` map it into `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD`, which authenticates the pulls their steps make. No `container:` pull uses it, because the runner makes that pull before step 1. Without it, a pull request from a fork continues with anonymous pulls, and every other event stops |
 | `ROR_ENT_ACTIVATION_TOKEN` | ROR PRO/Enterprise key the e2e stack boots with. **The secret is renamed; the env var handed to the container stays `ROR_ACTIVATION_KEY`, which is the customer-facing name** |
 | `ROR_GH_TOKEN` | cross-repo GitHub PAT: dispatches the ROR KBN image build, reads run status, pushes docs |
 | `NVD_API_KEY`, `OSS_INDEX_USERNAME`, `OSS_INDEX_PASSWORD` | `cve_check` feeds |

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -226,8 +226,9 @@ Do not put a `docker login` in a workflow. Two mechanisms with different credent
 other, because a CLI that reads `DOCKER_AUTH_CONFIG` gives that variable priority over the login.
 
 The script cannot authenticate the `container:` image, because the runner pulls that image before
-step 1 starts. Nothing else authenticates it. That pull is anonymous, and the mirror answers it
-instead of Docker Hub. See [The `container:` image](#the-container-image).
+step 1 starts. Nothing else authenticates it. That pull is anonymous, and the registry that `setup`
+chose answers it: `mirror.gcr.io` on the normal path, Docker Hub on the fallback. See
+[The `container:` image](#the-container-image).
 
 ### Docker Hub pull mirror
 

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -176,7 +176,7 @@ every push on such a branch, and made five CI jobs depend on a job that almost a
 |---|---|
 | `ROR_S3_ACCESS_KEY_ID` / `ROR_S3_SECRET_ACCESS_KEY` | the one S3 key pair; writes `builds/`, `libs/` and `e2e_reports/` |
 | `DOCKER_HUB_USER` / `DOCKER_HUB_RW_TOKEN` | the push account. It pushes the ROR and toolchains images, and authenticates the pulls of the same job. A job maps it into `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD`, which is the one pair `configure-docker.sh` reads |
-| `DOCKER_HUB_USER` / `DOCKER_HUB_RO_TOKEN` | the read-only token; it cannot push — it is refused push scope. It pulls the `container:` image, and each job that only pulls maps it into `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD` as well. Without it, a pull request from a fork continues with anonymous pulls, and every other event stops |
+| `DOCKER_HUB_USER` / `DOCKER_HUB_RO_TOKEN` | the read-only token; it cannot push — it is refused push scope. Each job that only pulls maps it into `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD` as well. Without it, a pull request from a fork continues with anonymous pulls, and every other event stops |
 | `ROR_ENT_ACTIVATION_TOKEN` | ROR PRO/Enterprise key the e2e stack boots with. **The secret is renamed; the env var handed to the container stays `ROR_ACTIVATION_KEY`, which is the customer-facing name** |
 | `ROR_GH_TOKEN` | cross-repo GitHub PAT: dispatches the ROR KBN image build, reads run status, pushes docs |
 | `NVD_API_KEY`, `OSS_INDEX_USERNAME`, `OSS_INDEX_PASSWORD` | `cve_check` feeds |
@@ -226,10 +226,8 @@ Do not put a `docker login` in a workflow. Two mechanisms with different credent
 other, because a CLI that reads `DOCKER_AUTH_CONFIG` gives that variable priority over the login.
 
 The script cannot authenticate the `container:` image, because the runner pulls that image before
-step 1 starts. The `&toolchains_container` anchor carries a `credentials:` block for that pull, and
-the ten `container:` blocks share it. A fork supplies empty secrets, and the runner then skips the
-login and pulls anonymously. A mirrored name skips it too — see
-[The `container:` image](#the-container-image).
+step 1 starts. No other mechanism authenticates it either: that pull is anonymous, and the mirror is
+what protects it. See [The `container:` image](#the-container-image).
 
 ### Docker Hub pull mirror
 
@@ -300,8 +298,7 @@ share the image, which makes it the most pulled image of a run. Docker Hub answe
 `429 toomanyrequests` on 2026-08-26.
 
 `container: image:` can read a job output. The `setup` job runs `ci/resolve-toolchains-image.sh`
-once, and the `&toolchains_container` anchor reads its two outputs: the name to pull, and whether
-that name needs a Docker Hub login.
+once, and the `&toolchains_container` anchor reads its output: the name to pull.
 
 A mirrored name carries the digest, not the tag: `mirror.gcr.io/beshultd/ror-ci-toolchains@sha256:…`.
 The jobs of one run start hours apart, and a tag can move between the check and a pull. A Docker Hub
@@ -359,13 +356,22 @@ The rebuild keeps a concurrency group of its own, `build-toolchains-image`. Two 
 tag and file two cache entries, and `setup` takes the newest entry, which need not hold the manifest
 that Docker Hub keeps. A second run waits instead, because cancelling a four-hour build wastes it.
 
-A mirrored name needs no login, and a login against `mirror.gcr.io` would fail, so the `credentials:`
-block goes empty then. It goes empty for a fork as well, and the runner skips an empty login.
+The pull carries no `credentials:` block, so it is anonymous on both paths. `mirror.gcr.io` needs no
+login, and a Docker Hub login against it would fail, so the block would have to empty itself on the
+mirrored path. It cannot: `username:` and `password:` take an expression, but an expression that
+evaluates to nothing gives `Unexpected value ''`, and the job dies in template validation before step
+1. An empty string and `null` both do it.
 
-A fork run gains the most. It has no secrets, so it pulled this image anonymously from Docker Hub,
-where the limit counts against the runner's address and every other anonymous puller shares it. The
-same run now pulls anonymously from `mirror.gcr.io`, which sets no limit. A fork run reads the base
-branch, so it finds the digest that a `develop` rebuild saved.
+This costs the Docker Hub path its account limit. Docker Hub counts an anonymous pull against the
+runner's address, and an authenticated pull against the account. The path is the rare one, so the
+trade is worth it. A tag with no recorded digest takes that path, and the next rebuild closes the
+window.
+
+Every run now pulls this image the way a fork always did. A fork gains the most. It has no secrets,
+so it pulled this image anonymously from Docker Hub, where the limit counts against the runner's
+address and every other anonymous puller shares it. The same run now pulls anonymously from
+`mirror.gcr.io`, which sets no limit. A fork run reads the base branch, so it finds the digest that a
+`develop` rebuild saved.
 
 One limit. The choice is made once, for the whole run. If the mirror stops answering during a run,
 the jobs that already took the mirrored name fail. The runner's pull has no fallback of its own.

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -226,8 +226,8 @@ Do not put a `docker login` in a workflow. Two mechanisms with different credent
 other, because a CLI that reads `DOCKER_AUTH_CONFIG` gives that variable priority over the login.
 
 The script cannot authenticate the `container:` image, because the runner pulls that image before
-step 1 starts. No other mechanism authenticates it either: that pull is anonymous, and the mirror is
-what protects it. See [The `container:` image](#the-container-image).
+step 1 starts. Nothing else authenticates it. That pull is anonymous, and the mirror answers it
+instead of Docker Hub. See [The `container:` image](#the-container-image).
 
 ### Docker Hub pull mirror
 
@@ -356,22 +356,19 @@ The rebuild keeps a concurrency group of its own, `build-toolchains-image`. Two 
 tag and file two cache entries, and `setup` takes the newest entry, which need not hold the manifest
 that Docker Hub keeps. A second run waits instead, because cancelling a four-hour build wastes it.
 
-The pull carries no `credentials:` block, so it is anonymous on both paths. `mirror.gcr.io` needs no
-login, and a Docker Hub login against it would fail, so the block would have to empty itself on the
-mirrored path. It cannot: `username:` and `password:` take an expression, but an expression that
-evaluates to nothing gives `Unexpected value ''`, and the job dies in template validation before step
-1. An empty string and `null` both do it.
+The pull sends no credentials, on either path. `mirror.gcr.io` refuses a Docker Hub login, so the
+`credentials:` block must be absent when the name is mirrored. An empty value does not remove it.
+GitHub rejects `username: ''` with `Unexpected value ''` and stops the run before step 1. YAML cannot
+drop a key on a condition, and `credentials:` is a mapping, so no expression reaches it. The block is
+therefore absent on both paths.
 
-This costs the Docker Hub path its account limit. Docker Hub counts an anonymous pull against the
-runner's address, and an authenticated pull against the account. The path is the rare one, so the
-trade is worth it. A tag with no recorded digest takes that path, and the next rebuild closes the
-window.
+Docker Hub counts an anonymous pull against the runner's address, and an authenticated pull against
+the account. So the fallback pull shares an address limit with every other anonymous puller. That
+path is rare. It opens when a tag has no recorded digest, and the next rebuild closes it.
 
-Every run now pulls this image the way a fork always did. A fork gains the most. It has no secrets,
-so it pulled this image anonymously from Docker Hub, where the limit counts against the runner's
-address and every other anonymous puller shares it. The same run now pulls anonymously from
-`mirror.gcr.io`, which sets no limit. A fork run reads the base branch, so it finds the digest that a
-`develop` rebuild saved.
+Every run now pulls this image the way a fork always did, and a fork gains the most. It has no
+secrets, so Docker Hub always answered it anonymously. It now reads `mirror.gcr.io`, which sets no
+limit. A fork run reads the base branch, so it finds the digest that a `develop` rebuild saved.
 
 One limit. The choice is made once, for the whole run. If the mirror stops answering during a run,
 the jobs that already took the mirrored name fail. The runner's pull has no fallback of its own.

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -17,8 +17,7 @@
 #                                 Default .toolchains-digest. An absent file means no digest.
 #         ROR_DOCKER_HUB_MIRROR   false skips the mirror
 # OUTPUT  image=<name>            the name to pull. Mirrored names end in @sha256:...
-#         mirrored=true|false     true means a mirrored name, pinned to a digest
-#         Both go to $GITHUB_OUTPUT when it is set, and to stdout otherwise.
+#         It goes to $GITHUB_OUTPUT when it is set, and to stdout otherwise.
 #         The choice also goes to $GITHUB_STEP_SUMMARY, so the run page shows it.
 #
 # A mirror is an optimisation, so no mirror fault stops a run. The script takes Docker Hub and exits
@@ -114,9 +113,9 @@ emit() {
   echo "[CI] Toolchains image: $1"
   summarise "$1" "$2" "${3:-}"
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    printf 'image=%s\nmirrored=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+    printf 'image=%s\n' "$1" >> "$GITHUB_OUTPUT"
   else
-    printf 'image=%s\nmirrored=%s\n' "$1" "$2"
+    printf 'image=%s\n' "$1"
   fi
   exit 0
 }

--- a/ci/resolve-toolchains-image.sh
+++ b/ci/resolve-toolchains-image.sh
@@ -17,7 +17,7 @@
 #                                 Default .toolchains-digest. An absent file means no digest.
 #         ROR_DOCKER_HUB_MIRROR   false skips the mirror
 # OUTPUT  image=<name>            the name to pull. Mirrored names end in @sha256:...
-#         mirrored=true|false     false means a Docker Hub name, which needs a login
+#         mirrored=true|false     true means a mirrored name, pinned to a digest
 #         Both go to $GITHUB_OUTPUT when it is set, and to stdout otherwise.
 #         The choice also goes to $GITHUB_STEP_SUMMARY, so the run page shows it.
 #


### PR DESCRIPTION
Every CI run since 10:24 today fails. A job with a `container:` block stops before its first step:

```
The template is not valid. .github/workflows/ci.yml
(Line: 178, Col: 19): Unexpected value '', (Line: 179, Col: 19): Unexpected value ''
```

## Cause

The `credentials:` block held an expression that gives an empty string when the run pulls from the
mirror. GitHub rejects an empty `username:` and stops the run in template validation.

That path had never run. Every earlier run missed the digest cache and took Docker Hub, where the
expression gives the real secrets. A rebuild recorded the digest on `develop` at 10:24, the mirror
path opened, and the template broke.

## Change

The `credentials:` block is gone, and so is the `toolchains_mirrored` output that fed it.

No other shape works. A Docker Hub login against `mirror.gcr.io` fails, so the block must be absent
when the name is mirrored. An empty value does not remove it. YAML cannot drop a key on a condition,
and `credentials:` is a mapping, so no expression reaches it.

The notes also state how Docker Hub counts a pull. The earlier text had it backwards.

## Cost

The pull is anonymous on both paths. `mirror.gcr.io` sets no limit, and it serves the normal path.
Docker Hub counts the fallback pull against the runner's address, not against our account. That path
opens only when a tag has no recorded digest, and the next rebuild closes it.

A fork gains. It never had secrets for this pull, and it now reads the mirror.

## Checks

- `ci.yml` parses. 16 jobs. All ten `container:` blocks carry `image:` only.
- `docker login mirror.gcr.io` refuses `dummyuser`, `_token`, `oauth2accesstoken` and `anonymous`.
- An anonymous manifest request for `beshultd/ror-ci-toolchains` returns 200, so the fallback pull works.
- `ci/resolve-toolchains-image.sh` on all three paths: mirror hit, no digest, empty tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Updated toolchain image retrieval to use anonymous pulls without Docker Hub login credentials.
  * Simplified CI job outputs to report only the resolved toolchain image.
  * Improved support for mirrored images and fork-based workflows by avoiding unnecessary registry authentication.

* **Documentation**
  * Clarified image-pull behavior, token permissions, rate limits, and mirrored registry usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->