### PR TITLE
[RORDEV-2197] Restore the per-module name of the it_linux memory telemetry artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,7 @@ jobs:
       - name: Free host disk (no-op on self-hosted)
         run: ci/free-host-disk.sh
       - name: Start memory telemetry
-        run: ci/mem-telemetry.sh start integration-tests/build/mem-telemetry-${{ matrix.ROR_TASK }}.log > "$RUNNER_TEMP/mem-telemetry.pid"
+        run: ci/mem-telemetry.sh start integration-tests/build/mem-telemetry-${{ matrix.ES_MODULE }}.log > "$RUNNER_TEMP/mem-telemetry.pid"
       - name: integration_${{ matrix.ES_MODULE }}
         env:
           # The pipeline task name run-pipeline.sh dispatches on — unchanged, only the matrix now
@@ -388,7 +388,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mem-telemetry-${{ matrix.ROR_TASK }}
+          name: mem-telemetry-${{ matrix.ES_MODULE }}
           path: integration-tests/build/mem-telemetry-*.log
           if-no-files-found: ignore
       # Drift guard for duration-balanced sharding: warns when measured suite times diverge from


### PR DESCRIPTION
## Problem

`9cbdb122f` ([#1268](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/pull/1268)) renamed the `it_linux` matrix key from `ROR_TASK` to `ES_MODULE`, but the two memory telemetry steps kept `ROR_TASK`. That key does not exist in the job any more, so it expands to the empty string:

- the sampler writes `integration-tests/build/mem-telemetry-.log`
- every leg uploads an artifact named `mem-telemetry-`

## Evidence

Run [32030458562](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/actions/runs/32030458562) (last run on #1268 before merge): all 10 `it_linux` legs green, and the run holds **9 artifacts all named `mem-telemetry-`**. `upload-artifact@v4` tolerates the duplicate names, so nothing turns red — the telemetry is simply not traceable to an ES module. On `develop` the full matrix is 34 legs.

## Fix

Two lines, both to `${{ matrix.ES_MODULE }}`, matching the sibling artifact names `it-linux-${{ matrix.ES_MODULE }}-results` and `sharded-logs-it-linux-${{ matrix.ES_MODULE }}`.

The `env: ROR_TASK: integration_${{ matrix.ES_MODULE }}` at line 334 is left alone — that one is the pipeline task name `run-pipeline.sh` dispatches on, not a matrix reference.

The "Memory telemetry report" step needs no change: its `mem-telemetry-*.log` glob matched the empty name too, so only the `::group::` header text changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)