### PR TITLE
[RORDEV-2187] Fix ES 7.10 Docker image entrypoint

### DIFF
--- a/es710x/Dockerfile
+++ b/es710x/Dockerfile
@@ -45,4 +45,4 @@ COPY --link --chown=1000:0 per-version/ /usr/share/elasticsearch/plugins/readonl
 COPY init-readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY ror-entrypoint.sh /usr/local/bin/ror-entrypoint.sh
 
-ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/ror-entrypoint.sh"]


### PR DESCRIPTION
## Changelog entry:

```yaml
- type: fix
    components: [es]
    text: "fix startup of ES 7.10.x Docker images"
```

## Summary

Restore the `es710x` entrypoint from `/bin/tini` to `/tini`, matching the location used by the upstream Elasticsearch 7.10.x images.

Verified against the upstream images for ES 7.10.0, 7.10.1, and 7.10.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated container startup to use the correct Tini executable path, improving application initialization reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->