### PR TITLE
ci: take the ES pre-build off the self-hosted pool

### DIFF
--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -41,18 +41,26 @@ defaults:
 jobs:
   publish:
     name: Publishing
-    # Self-hosted: a long build-and-push job, IO-bound, one at a time. Needs a registered
-    # self-hosted runner — see ci/self-hosted-runner.md.
-    runs-on: [self-hosted, Linux, X64]
+    # NOT self-hosted, even though this is a long IO-bound build. Two paid jobs in other runs wait
+    # on this workflow: the e2e legs of readonlyrest_kbn's pipeline (ubicloud-standard-8) and this
+    # repo's own e2e_prepare. They hold their runner for as long as the pre-build takes to FINISH,
+    # queue time included. The self-hosted pool is two slots on one box, so a release or upload job
+    # occupying both puts this workflow behind them and the waiters pay for the queue:
+    #
+    #   created 17:23:41, started 18:45:19  ->  81.6 min queued, 0.3 min of work
+    #
+    # Measured over the runs on either side of #1369: 0.0-0.6 min queued on ubicloud, and 0.0, 0.0,
+    # 18.2, 19.4, 81.6 min queued self-hosted. The minutes this workflow itself costs are small - it
+    # is 1-13 min of work per run - so moving it back buys the waiters far more than it spends.
+    # readonlyrest_kbn's twin of this workflow runs on ubuntu-latest for the same reason.
+    #
+    # The rest of what #1369 moved stays self-hosted: nothing waits on release_ror, upload_pre_ror,
+    # publish_mvn or mirror-es-libs.
+    runs-on: ubuntu-latest
     timeout-minutes: 600
     env:
       GRADLE_USER_HOME: ${{ github.workspace }}/.gradle-home
       GRADLE_OPTS: '-Dorg.gradle.java.installations.auto-download=true'
-      AGENT_ISSELFHOSTED: '1'
-      # This job talks to the box's docker daemon directly, and that daemon also serves the
-      # readonlyrest_kbn runners. No host-wide `docker system prune -a`, no removing containers that
-      # are not ours. See ci/run-pipeline.sh and ci/publish-ror-plugins.sh.
-      ROR_SHARED_DOCKER_HOST: '1'
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 0, persist-credentials: false }

--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -34,7 +34,7 @@ on:
 permissions:
   contents: read
 
-# NO concurrency group here, deliberately. See the note in ci/self-hosted-runner.md.
+# NO concurrency group here, deliberately. Why, and what that leaves open:
 #
 # The obvious guard would be `concurrency: {group: ..., cancel-in-progress: false}`, and it is a
 # trap. GitHub keeps ONE pending run per group and cancels any previously pending one, so a third

--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -34,19 +34,21 @@ on:
 permissions:
   contents: read
 
-# The self-hosted pool this workflow used to run on had two slots, and that was the only thing
-# serialising it. On ubuntu-latest it is unbounded, and the publish is not safe to run twice at
-# once: publishEsRorPreBuildDockerImage pushes the SHARED tag <esVersion>-ror-<pluginVersion>, and
-# retag_dev_image then freezes "this commit's image" FROM that shared tag (ci/ci-lib.sh:207-230).
-# Interleave A-push, B-push, A-retag and <esVersion>-ror-<shaA> points at B's image, so an e2e leg
-# tests the wrong build while believing it is commit-pinned.
+# NO concurrency group here, deliberately. See the note in ci/self-hosted-runner.md.
 #
-# Keyed on the versions and the branch actually built, not on github.ref: two dispatches for the
-# same branch and the same ES versions are the pair that collides. cancel-in-progress is false -
-# the loser waits, because cancelling a half-finished push is what leaves the shared tag dangling.
-concurrency:
-  group: publish-pre-builds-${{ inputs.target_branch || github.ref }}-${{ inputs.es_versions }}
-  cancel-in-progress: false
+# The obvious guard would be `concurrency: {group: ..., cancel-in-progress: false}`, and it is a
+# trap. GitHub keeps ONE pending run per group and cancels any previously pending one, so a third
+# dispatch cancels the second. Two repos wait on this workflow by run id
+# (wait_for_es_prebuild_images), and its `*)` branch treats `cancelled` exactly like `failure`:
+# "its images will never be published", exit 6. A group would turn a queued dispatch into a hard
+# failure for a waiter that did nothing wrong - the failure mode this PR exists to remove.
+#
+# That leaves a real, PRE-EXISTING race: publishEsRorPreBuildDockerImage pushes the shared tag
+# <esVersion>-ror-<pluginVersion>, and retag_dev_image then freezes "this commit's image" from it
+# (ci/ci-lib.sh:207-230). Interleave A-push, B-push, A-retag and <esVersion>-ror-<shaA> points at
+# B's image. Two self-hosted slots already allowed that; hosted runners widen the window.
+# The fix belongs in ci-lib.sh - push the immutable source tag directly instead of pushing a shared
+# tag and copying it - not in a workflow-level queue that breaks the callers.
 
 defaults:
   run:

--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -34,6 +34,20 @@ on:
 permissions:
   contents: read
 
+# The self-hosted pool this workflow used to run on had two slots, and that was the only thing
+# serialising it. On ubuntu-latest it is unbounded, and the publish is not safe to run twice at
+# once: publishEsRorPreBuildDockerImage pushes the SHARED tag <esVersion>-ror-<pluginVersion>, and
+# retag_dev_image then freezes "this commit's image" FROM that shared tag (ci/ci-lib.sh:207-230).
+# Interleave A-push, B-push, A-retag and <esVersion>-ror-<shaA> points at B's image, so an e2e leg
+# tests the wrong build while believing it is commit-pinned.
+#
+# Keyed on the versions and the branch actually built, not on github.ref: two dispatches for the
+# same branch and the same ES versions are the pair that collides. cancel-in-progress is false -
+# the loser waits, because cancelling a half-finished push is what leaves the shared tag dangling.
+concurrency:
+  group: publish-pre-builds-${{ inputs.target_branch || github.ref }}-${{ inputs.es_versions }}
+  cancel-in-progress: false
+
 defaults:
   run:
     shell: bash
@@ -57,7 +71,8 @@ jobs:
     # The rest of what #1369 moved stays self-hosted: nothing waits on release_ror, upload_pre_ror,
     # publish_mvn or mirror-es-libs.
     runs-on: ubuntu-latest
-    timeout-minutes: 600
+    # ubuntu-latest is capped at 6 h, so this is the real ceiling, not a choice.
+    timeout-minutes: 360
     env:
       GRADLE_USER_HOME: ${{ github.workspace }}/.gradle-home
       GRADLE_OPTS: '-Dorg.gradle.java.installations.auto-download=true'
@@ -112,9 +127,10 @@ jobs:
           echo ">>> Publishing pre-build docker images for: $BUILD_ROR_ES_VERSIONS"
           ci/run-pipeline.sh
 
-      # configure-docker.sh logs in with the Docker Hub RW token. On an ephemeral VM that credential
-      # died with the VM; here it would stay in the runner user's ~/.docker/config.json, where every
-      # later job on the box can read it.
+      # configure-docker.sh logs in with the Docker Hub RW token. The VM is ephemeral again, so the
+      # credential dies with it either way. The step stays: it costs nothing, and it is what keeps
+      # this job correct if it ever moves back to a shared host, where the token would otherwise sit
+      # in the runner user's ~/.docker/config.json for every later job on the box to read.
       - name: Log out of Docker Hub
         if: always()
         run: docker logout || true

--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -34,21 +34,16 @@ on:
 permissions:
   contents: read
 
-# NO concurrency group here, deliberately. Why, and what that leaves open:
+# Do NOT add a `concurrency` group to this workflow.
 #
-# The obvious guard would be `concurrency: {group: ..., cancel-in-progress: false}`, and it is a
-# trap. GitHub keeps ONE pending run per group and cancels any previously pending one, so a third
-# dispatch cancels the second. Two repos wait on this workflow by run id
-# (wait_for_es_prebuild_images), and its `*)` branch treats `cancelled` exactly like `failure`:
-# "its images will never be published", exit 6. A group would turn a queued dispatch into a hard
-# failure for a waiter that did nothing wrong - the failure mode this PR exists to remove.
+# GitHub keeps one pending run per group and cancels any run already pending. Two repos wait on
+# this workflow by run id (wait_for_es_prebuild_images), and that waiter treats `cancelled` the
+# same as `failure`. A group would therefore turn a queued dispatch into a hard failure for a
+# waiter that did nothing wrong.
 #
-# That leaves a real, PRE-EXISTING race: publishEsRorPreBuildDockerImage pushes the shared tag
-# <esVersion>-ror-<pluginVersion>, and retag_dev_image then freezes "this commit's image" from it
-# (ci/ci-lib.sh:207-230). Interleave A-push, B-push, A-retag and <esVersion>-ror-<shaA> points at
-# B's image. Two self-hosted slots already allowed that; hosted runners widen the window.
-# The fix belongs in ci-lib.sh - push the immutable source tag directly instead of pushing a shared
-# tag and copying it - not in a workflow-level queue that breaks the callers.
+# Concurrent runs that publish the same plugin version share the tag
+# <esVersion>-ror-<pluginVersion>. Keep that safe in ci/ci-lib.sh, by pushing each commit's
+# immutable tag in the build that produced it, not with a workflow-level queue.
 
 defaults:
   run:
@@ -57,21 +52,14 @@ defaults:
 jobs:
   publish:
     name: Publishing
-    # NOT self-hosted, even though this is a long IO-bound build. Two paid jobs in other runs wait
-    # on this workflow: the e2e legs of readonlyrest_kbn's pipeline (ubicloud-standard-8) and this
-    # repo's own e2e_prepare. They hold their runner for as long as the pre-build takes to FINISH,
-    # queue time included. The self-hosted pool is two slots on one box, so a release or upload job
-    # occupying both puts this workflow behind them and the waiters pay for the queue:
+    # NOT self-hosted, even though this is a long IO-bound build. Other runs wait on this workflow:
+    # the e2e legs of readonlyrest_kbn's pipeline and this repo's own e2e_prepare. Each waiter holds
+    # its runner until this workflow FINISHES, queue time included, and those runners are paid. The
+    # self-hosted pool has few slots, so one release job can put this workflow behind it and the
+    # waiters pay for the whole queue. A hosted runner starts at once and costs nothing here.
     #
-    #   created 17:23:41, started 18:45:19  ->  81.6 min queued, 0.3 min of work
-    #
-    # Measured over the runs on either side of #1369: 0.0-0.6 min queued on ubicloud, and 0.0, 0.0,
-    # 18.2, 19.4, 81.6 min queued self-hosted. The minutes this workflow itself costs are small - it
-    # is 1-13 min of work per run - so moving it back buys the waiters far more than it spends.
-    # readonlyrest_kbn's twin of this workflow runs on ubuntu-latest for the same reason.
-    #
-    # The rest of what #1369 moved stays self-hosted: nothing waits on release_ror, upload_pre_ror,
-    # publish_mvn or mirror-es-libs.
+    # The rule: a workflow that another run polls does not belong in a small fixed pool. Jobs that
+    # nothing waits on - release_ror, upload_pre_ror, publish_mvn, mirror-es-libs - do.
     runs-on: ubuntu-latest
     # ubuntu-latest is capped at 6 h, so this is the real ceiling, not a choice.
     timeout-minutes: 360
@@ -129,9 +117,8 @@ jobs:
           echo ">>> Publishing pre-build docker images for: $BUILD_ROR_ES_VERSIONS"
           ci/run-pipeline.sh
 
-      # configure-docker.sh logs in with the Docker Hub RW token. The VM is ephemeral again, so the
-      # credential dies with it either way. The step stays: it costs nothing, and it is what keeps
-      # this job correct if it ever moves back to a shared host, where the token would otherwise sit
+      # configure-docker.sh logs in with the Docker Hub RW token. On an ephemeral VM the credential
+      # dies with the runner. Keep this step anyway: on a shared host the token would otherwise stay
       # in the runner user's ~/.docker/config.json for every later job on the box to read.
       - name: Log out of Docker Hub
         if: always()

--- a/ci/self-hosted-runner.md
+++ b/ci/self-hosted-runner.md
@@ -105,7 +105,7 @@ The `container:` jobs in `ci.yml` run as root, and on a machine that survives th
 the whole workspace owned by root. The runner service runs as `runner`, so the next job that is
 **not** a container job dies in `actions/checkout`:
 
-```
+```text
 fatal: Unable to create '.../.git/index.lock': Permission denied
 EACCES: permission denied, rmdir '.../_work/...'
 ```

--- a/ci/self-hosted-runner.md
+++ b/ci/self-hosted-runner.md
@@ -148,11 +148,13 @@ EOS
 chown root:root /usr/local/sbin/job-started-hook.sh
 chmod 0755 /usr/local/sbin/job-started-hook.sh
 
-# .env itself must stay in the runner directory - that is where the runner reads it. Guarded, so
-# re-running this block on a runner that already has the hook does not add a second line.
-grep -q ACTIONS_RUNNER_HOOK_JOB_STARTED /home/runner/actions-runner/.env || \
-  echo 'ACTIONS_RUNNER_HOOK_JOB_STARTED=/usr/local/sbin/job-started-hook.sh' \
-    >> /home/runner/actions-runner/.env
+# .env itself must stay in the runner directory - that is where the runner reads it.
+# Delete then append, rather than `grep -q <name> || echo`: a name-only check passes on a runner
+# whose variable still points at an OLD, runner-owned hook, and would leave that path in place.
+sed -i '/ACTIONS_RUNNER_HOOK_JOB_STARTED/d' /home/runner/actions-runner/.env
+echo 'ACTIONS_RUNNER_HOOK_JOB_STARTED=/usr/local/sbin/job-started-hook.sh' \
+  >> /home/runner/actions-runner/.env
+rm -f /home/runner/actions-runner/job-started-hook.sh
 INNER
 # .env is read at start-up, so the service has to be restarted.
 incus exec --project github-ci gh-ror-es-$N -- bash -lc \

--- a/ci/self-hosted-runner.md
+++ b/ci/self-hosted-runner.md
@@ -97,3 +97,65 @@ gh api repos/sscarduzio/elasticsearch-readonlyrest-plugin/actions/runners \
 - Shared host, so the release scripts must not sweep the whole Docker daemon. `ROR_SHARED_DOCKER_HOST=1`
   is set on these jobs and downgrades `docker system prune -af --volumes` to dangling layers and
   build cache only. Without it, a retry would kill the Kibana runners' in-flight ELK stacks.
+
+## Required: the job-started hook
+
+The `container:` jobs in `ci.yml` run as root, and on a machine that survives the job they leave
+the whole workspace owned by root. The runner service runs as `runner`, so the next job that is
+**not** a container job dies in `actions/checkout`:
+
+```
+fatal: Unable to create '.../.git/index.lock': Permission denied
+EACCES: permission denied, rmdir '.../_work/...'
+```
+
+This wedges the runner permanently — every following job fails the same way in about six seconds.
+It happened on 4 September 2026: ~22,500 root-owned entries on each of `gh-ror-es-1` and
+`gh-ror-es-2`, and every `publish-pre-builds.yml` run after it failed until the workspaces were
+chowned back.
+
+A hosted runner never sees this, because the VM is destroyed after the job. Here the fix is a
+hook that gives the workspace back before every job. Install it on each runner:
+
+```bash
+incus exec --project github-ci gh-ror-es-$N -- bash -s <<'INNER'
+set -e
+cat > /usr/local/sbin/reclaim-runner-workspace <<'EOS'
+#!/bin/sh
+exec chown -R runner:runner /home/runner/actions-runner/_work
+EOS
+chmod 0755 /usr/local/sbin/reclaim-runner-workspace
+
+# The runner user has no sudo. Grant exactly this one command, nothing else.
+echo 'runner ALL=(root) NOPASSWD: /usr/local/sbin/reclaim-runner-workspace' \
+  > /etc/sudoers.d/50-runner-workspace
+chmod 0440 /etc/sudoers.d/50-runner-workspace
+visudo -c -q
+
+cat > /home/runner/actions-runner/job-started-hook.sh <<'EOS'
+#!/bin/bash
+set -euo pipefail
+sudo -n /usr/local/sbin/reclaim-runner-workspace
+echo ">>> workspace ownership reclaimed for the runner user"
+EOS
+chown runner:runner /home/runner/actions-runner/job-started-hook.sh
+chmod 0755 /home/runner/actions-runner/job-started-hook.sh
+
+echo 'ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/actions-runner/job-started-hook.sh' \
+  >> /home/runner/actions-runner/.env
+INNER
+# .env is read at start-up, so the service has to be restarted.
+incus exec --project github-ci gh-ror-es-$N -- bash -lc \
+  "cd /home/runner/actions-runner && ./svc.sh stop && ./svc.sh start"
+```
+
+The sudoers entry names a root-owned script rather than `chown` with arguments, so the grant
+cannot be widened by passing different paths. It adds no real privilege either way: `runner` is
+already in the `docker` group, which is root-equivalent on this box.
+
+If a runner starts failing every job at `actions/checkout`, check this first:
+
+```bash
+incus exec --project github-ci gh-ror-es-$N -- \
+  find /home/runner/actions-runner/_work ! -user runner | wc -l
+```

--- a/ci/self-hosted-runner.md
+++ b/ci/self-hosted-runner.md
@@ -11,7 +11,6 @@ Jobs that need a self-hosted runner:
 | `ci.yml` | `upload_pre_ror` | 4-leg matrix, ~45–57 min/leg, pre-release only |
 | `ci.yml` | `release_ror` | 4-leg matrix, ~16 min/leg, release only |
 | `ci.yml` | `publish_mvn` | seconds, after `release_ror` |
-| `publish-pre-builds.yml` | `publish` | manual, long build-and-push |
 | `mirror-es-libs.yml` | `mirror` | manual, short |
 
 ## The selector
@@ -95,8 +94,10 @@ gh api repos/sscarduzio/elasticsearch-readonlyrest-plugin/actions/runners \
 - Disk is the binding constraint, roughly 1.5 GB of base image per ES version. The 40 GB root disk
   in the profile is enough for two runners only because `ci/free-host-disk.sh` prunes between legs.
 - Shared host, so the release scripts must not sweep the whole Docker daemon. `ROR_SHARED_DOCKER_HOST=1`
-  is set on these jobs and downgrades `docker system prune -af --volumes` to dangling layers and
-  build cache only. Without it, a retry would kill the Kibana runners' in-flight ELK stacks.
+  is set on the `ci.yml` jobs above and downgrades `docker system prune -af --volumes` to dangling
+  layers and build cache only. Without it, a retry would kill the Kibana runners' in-flight ELK
+  stacks. `publish-pre-builds.yml` no longer sets it, because it runs on an ephemeral hosted VM
+  where the aggressive prune is what makes a multi-version build fit.
 
 ## Required: the job-started hook
 
@@ -127,22 +128,31 @@ EOS
 chmod 0755 /usr/local/sbin/reclaim-runner-workspace
 
 # The runner user has no sudo. Grant exactly this one command, nothing else.
-echo 'runner ALL=(root) NOPASSWD: /usr/local/sbin/reclaim-runner-workspace' \
-  > /etc/sudoers.d/50-runner-workspace
-chmod 0440 /etc/sudoers.d/50-runner-workspace
-visudo -c -q
+# Validate BEFORE installing: a bad line in /etc/sudoers.d breaks sudo for everyone in the
+# container, and under `set -e` a validate-after would abort with the broken file already in place.
+printf '%s\n' 'runner ALL=(root) NOPASSWD: /usr/local/sbin/reclaim-runner-workspace' \
+  > /tmp/50-runner-workspace
+visudo -c -q -f /tmp/50-runner-workspace
+install -o root -g root -m 0440 /tmp/50-runner-workspace /etc/sudoers.d/50-runner-workspace
+rm -f /tmp/50-runner-workspace
 
-cat > /home/runner/actions-runner/job-started-hook.sh <<'EOS'
+# Outside the runner application directory on purpose: GitHub requires it, `./svc.sh` self-update
+# rewrites that directory, and a script the `runner` user can edit is a foothold that survives
+# between jobs. Root-owned in /usr/local/sbin, like the command it calls.
+cat > /usr/local/sbin/job-started-hook.sh <<'EOS'
 #!/bin/bash
 set -euo pipefail
 sudo -n /usr/local/sbin/reclaim-runner-workspace
 echo ">>> workspace ownership reclaimed for the runner user"
 EOS
-chown runner:runner /home/runner/actions-runner/job-started-hook.sh
-chmod 0755 /home/runner/actions-runner/job-started-hook.sh
+chown root:root /usr/local/sbin/job-started-hook.sh
+chmod 0755 /usr/local/sbin/job-started-hook.sh
 
-echo 'ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/actions-runner/job-started-hook.sh' \
-  >> /home/runner/actions-runner/.env
+# .env itself must stay in the runner directory - that is where the runner reads it. Guarded, so
+# re-running this block on a runner that already has the hook does not add a second line.
+grep -q ACTIONS_RUNNER_HOOK_JOB_STARTED /home/runner/actions-runner/.env || \
+  echo 'ACTIONS_RUNNER_HOOK_JOB_STARTED=/usr/local/sbin/job-started-hook.sh' \
+    >> /home/runner/actions-runner/.env
 INNER
 # .env is read at start-up, so the service has to be restarted.
 incus exec --project github-ci gh-ror-es-$N -- bash -lc \
@@ -150,8 +160,15 @@ incus exec --project github-ci gh-ror-es-$N -- bash -lc \
 ```
 
 The sudoers entry names a root-owned script rather than `chown` with arguments, so the grant
-cannot be widened by passing different paths. It adds no real privilege either way: `runner` is
-already in the `docker` group, which is root-equivalent on this box.
+cannot be widened by passing different paths.
+
+It grants nothing the `runner` user does not already have: `runner` is in the `docker` group, and
+these containers run with `security.privileged: true` and no uid map, so container root is host
+root. Read that as the risk it is, not as a reason the grant is harmless. Anyone who can open a PR
+against a repo whose runners live on this box can run code here, and the same box holds the ES
+release secrets - `PGP_SECRET_KEY_B64`, `MAVEN_REPO_PASSWORD`, `DOCKER_HUB_RW_TOKEN` and the
+`ROR_S3_*` pair. The isolation is between this box and everything else, not between the pools on
+it. Sizing or splitting the pools is the lever if that stops being acceptable.
 
 If a runner starts failing every job at `actions/checkout`, check this first:
 

--- a/ci/self-hosted-runner.md
+++ b/ci/self-hosted-runner.md
@@ -110,10 +110,12 @@ fatal: Unable to create '.../.git/index.lock': Permission denied
 EACCES: permission denied, rmdir '.../_work/...'
 ```
 
-This wedges the runner permanently — every following job fails the same way in about six seconds.
-It happened on 4 September 2026: ~22,500 root-owned entries on each of `gh-ror-es-1` and
-`gh-ror-es-2`, and every `publish-pre-builds.yml` run after it failed until the workspaces were
-chowned back.
+This wedges the runner permanently — every following job fails the same way in seconds, until the
+workspace is chowned back. To check a runner:
+
+```bash
+find /home/runner/actions-runner/_work ! -user runner | wc -l
+```
 
 A hosted runner never sees this, because the VM is destroyed after the job. Here the fix is a
 hook that gives the workspace back before every job. Install it on each runner:


### PR DESCRIPTION
## The problem

#1369 moved `publish-pre-builds.yml` to the self-hosted pool. That pool has two slots.

Other jobs wait for this workflow. Three paid `ubicloud-standard-8` legs in `readonlyrest_kbn` poll it, for up to 120 minutes. When release jobs hold both slots, the pre-build waits in the queue, and the paid legs wait with it. One run waited 82 minutes in the queue for 0.3 minutes of work.

## The change

- `publish-pre-builds.yml` runs on `ubuntu-latest`. The repo is public, so this costs nothing.
- Removes `AGENT_ISSELFHOSTED` and `ROR_SHARED_DOCKER_HOST` from this workflow. On a hosted VM they stop the disk reclaim, and the build runs out of disk.
- Documents the job-started hook that the self-hosted runners need, in `ci/self-hosted-runner.md`.

## The rule

A job that other paid jobs wait for must run on a hosted runner. `release_ror`, `upload_pre_ror` and `publish_mvn` have no waiters, so they stay self-hosted.

## Not in this PR

- No `concurrency` group. GitHub keeps one pending run per group and cancels the others. The pollers treat a cancelled run as a failure.
- The shared-tag race. #1375 fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/Infrastructure**
  - The pre-build publishing workflow now runs on hosted Ubuntu runners with a shorter maximum runtime.
  - Publishing jobs no longer rely on self-hosted runner configuration or shared Docker host settings.
  - Workflow guidance and comments were streamlined to reflect the hosted runner environment.

- **Documentation**
  - Added setup guidance for preventing workspace permission issues on self-hosted runners.
  - Expanded security guidance for runner recovery permissions and updated troubleshooting instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->