### PR TITLE
ci: repeat the Sonatype staging-repository request

### DIFF
--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -133,9 +133,15 @@ is_docker_registry_error() {
 }
 
 # A --retry-if function for `./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository`.
-# True only when the run died in initializeSonatypeStagingRepository, which is the FIRST task of
-# that chain: it asks ossrh-staging-api for a staging repository and nothing has been uploaded yet.
-# Repeating from there cannot leave a second staging repository behind or half-release a version.
+# True only when the run died in initializeSonatypeStagingRepository's create-staging-repository
+# call AND the status is a transient one. That task is the FIRST of the chain: it asks
+# ossrh-staging-api for a staging repository and nothing has been uploaded yet, so repeating from
+# there cannot leave a second staging repository behind or half-release a version.
+#
+# Not every failure of that task is repeated, deliberately. `No response body` and the profile
+# lookup ("Failed to find staging profile for package group") do not match the second grep, so they
+# fail on the first attempt - a wrong MAVEN_STAGING_PROFILE_ID answers the same way every time, and
+# waiting three more times to say so helps nobody.
 #
 # Every later failure - an upload, the close, the release - is deliberately not repeated. Those run
 # against a staging repository that already exists, so a second attempt would open another one.

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -132,6 +132,22 @@ is_docker_registry_error() {
     "$1"
 }
 
+# A --retry-if function for `./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository`.
+# True only when the run died in initializeSonatypeStagingRepository, which is the FIRST task of
+# that chain: it asks ossrh-staging-api for a staging repository and nothing has been uploaded yet.
+# Repeating from there cannot leave a second staging repository behind or half-release a version.
+#
+# Every later failure - an upload, the close, the release - is deliberately not repeated. Those run
+# against a staging repository that already exists, so a second attempt would open another one.
+#
+# 401 is in the list because it is measured, not assumed: the same three secrets produced three
+# 401s (runs 33210133390, 33724419080, 33725765043) and one clean publish (33854480199). An
+# expired credential answers the same way every time, so a retry still fails and still reports it.
+is_sonatype_staging_init_error() {
+  grep -Fq "Execution failed for task ':initializeSonatypeStagingRepository'" "$1" &&
+    grep -Eq 'Failed to create staging repository.*status code (401|408|429|5[0-9][0-9])' "$1"
+}
+
 # Force-remove every container belonging to THIS CI job, scoped by the ror.ci-job=$ROR_CI_JOB_ID label so we
 # never touch a sibling CI job sharing the self-hosted Docker daemon. Single source of truth for "kill
 # this CI job's containers" — used by run-pipeline.sh's SIGTERM trap, the pipeline's always() cleanup

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -146,9 +146,9 @@ is_docker_registry_error() {
 # Every later failure - an upload, the close, the release - is deliberately not repeated. Those run
 # against a staging repository that already exists, so a second attempt would open another one.
 #
-# 401 is in the list because it is measured, not assumed: the same three secrets produced three
-# 401s (runs 33210133390, 33724419080, 33725765043) and one clean publish (33854480199). An
-# expired credential answers the same way every time, so a retry still fails and still reports it.
+# 401 is in the list. ossrh-staging-api answers 401 intermittently on credentials that work
+# minutes later, so a 401 here does not prove the secret is wrong. An expired credential answers
+# the same way every time, so a repeat still fails and still reports it.
 is_sonatype_staging_init_error() {
   grep -Fq "Execution failed for task ':initializeSonatypeStagingRepository'" "$1" &&
     grep -Eq 'Failed to create staging repository.*status code (401|408|429|5[0-9][0-9])' "$1"

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -149,9 +149,16 @@ is_docker_registry_error() {
 # 401 is in the list. ossrh-staging-api answers 401 intermittently on credentials that work
 # minutes later, so a 401 here does not prove the secret is wrong. An expired credential answers
 # the same way every time, so a repeat still fails and still reports it.
+#
+# ONLY the codes that prove the server made nothing. 401 and 429 are refusals: the request is
+# rejected before a staging repository exists, so a repeat cannot open a second one. A timeout
+# (408) or a server error (5xx) can arrive AFTER the POST took effect, and the plugin retries only
+# transitions, never the create - see AbstractTransitionNexusStagingRepositoryTask. Repeating those
+# would leave an orphan staging repository behind. Do not widen this list without checking that
+# again.
 is_sonatype_staging_init_error() {
   grep -Fq "Execution failed for task ':initializeSonatypeStagingRepository'" "$1" &&
-    grep -Eq 'Failed to create staging repository.*status code (401|408|429|5[0-9][0-9])' "$1"
+    grep -Eq 'Failed to create staging repository.*status code (401|429)' "$1"
 }
 
 # Force-remove every container belonging to THIS CI job, scoped by the ror.ci-job=$ROR_CI_JOB_ID label so we

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -250,12 +250,15 @@ if [[ $ROR_TASK == "publish_maven_artifacts" ]]; then
       echo ">>> Publishing audit module artifacts to sonatype repo"
       # ossrh-staging-api answers the staging-repository request with 401 intermittently, on
       # credentials that work minutes later: 3 of the last 4 real publishes died that way, each
-      # after 19 s. See is_sonatype_staging_init_error for why only that first task is repeated.
-      # Longer gaps than the default 15 s: this is a release, and the service needs time to settle.
+      # after 19-20 s. See is_sonatype_staging_init_error for why only that first task is repeated.
+      # The delay doubles, so 30 gives gaps of 30 / 60 / 120 s - about 3.5 min across 4 attempts.
+      # </dev/null matches the other two retried gradle calls: under --retry-if the command runs in
+      # a `tee` pipeline and would otherwise inherit the job's stdin, which is how a second attempt
+      # ends up behaving differently from the first.
       (
         export ROR_RETRY_ATTEMPTS=4 ROR_RETRY_DELAY_SECONDS=30
         retry_with_backoff --retry-if is_sonatype_staging_init_error \
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository </dev/null
       )
     fi
   else

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -249,9 +249,12 @@ if [[ $ROR_TASK == "publish_maven_artifacts" ]]; then
     else
       echo ">>> Publishing audit module artifacts to sonatype repo"
       # ossrh-staging-api answers the staging-repository request with 401 intermittently, on
-      # credentials that work minutes later: 3 of the last 4 real publishes died that way, each
-      # after 19-20 s. See is_sonatype_staging_init_error for why only that first task is repeated.
-      # The delay doubles, so 30 gives gaps of 30 / 60 / 120 s - about 3.5 min across 4 attempts.
+      # credentials that work minutes later. is_sonatype_staging_init_error owns the measurement and
+      # the reasoning about which failures are safe to repeat; do not restate the numbers here, they
+      # will drift.
+      #
+      # What is specific to this call site: it is a release, so it can afford to wait. The delay
+      # doubles, so 30 gives gaps of 30 / 60 / 120 s - about 3.5 min across 4 attempts.
       # </dev/null matches the other two retried gradle calls: under --retry-if the command runs in
       # a `tee` pipeline and would otherwise inherit the job's stdin, which is how a second attempt
       # ends up behaving differently from the first.

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -248,7 +248,15 @@ if [[ $ROR_TASK == "publish_maven_artifacts" ]]; then
       echo ">>> Skipping publishing audit module artifacts"
     else
       echo ">>> Publishing audit module artifacts to sonatype repo"
-      ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+      # ossrh-staging-api answers the staging-repository request with 401 intermittently, on
+      # credentials that work minutes later: 3 of the last 4 real publishes died that way, each
+      # after 19 s. See is_sonatype_staging_init_error for why only that first task is repeated.
+      # Longer gaps than the default 15 s: this is a release, and the service needs time to settle.
+      (
+        export ROR_RETRY_ATTEMPTS=4 ROR_RETRY_DELAY_SECONDS=30
+        retry_with_backoff --retry-if is_sonatype_staging_init_error \
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+      )
     fi
   else
     echo ">>> Version mismatch: current=$CURRENT_PLUGIN_VER, published=$PUBLISHED_PLUGIN_VER"

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -248,10 +248,8 @@ if [[ $ROR_TASK == "publish_maven_artifacts" ]]; then
       echo ">>> Skipping publishing audit module artifacts"
     else
       echo ">>> Publishing audit module artifacts to sonatype repo"
-      # ossrh-staging-api answers the staging-repository request with 401 intermittently, on
-      # credentials that work minutes later. is_sonatype_staging_init_error owns the measurement and
-      # the reasoning about which failures are safe to repeat; do not restate the numbers here, they
-      # will drift.
+      # is_sonatype_staging_init_error owns the rule about which failures are safe to repeat.
+      # Do not restate it here.
       #
       # What is specific to this call site: it is a release, so it can afford to wait. The delay
       # doubles, so 30 gives gaps of 30 / 60 / 120 s - about 3.5 min across 4 attempts.


### PR DESCRIPTION
## The problem

Three of the last four real Maven publishes failed with HTTP 401 from `ossrh-staging-api`. The fourth publish used the same secrets and passed. So the 401 is a temporary service error.

## The change

The retry repeats only `initializeSonatypeStagingRepository`. This is the first task of the chain, and nothing is uploaded before it. Later failures are not repeated, because a second attempt would create a second staging repository.

Four attempts, 30 s between them, doubling. A dead credential still fails after four attempts.

## Verification

The predicate matches the three real 401 logs. It does not match the clean publish, a 403, or the same message from a later task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when publishing packages by retrying eligible Sonatype staging initialization failures.
  * Retries are limited to authorization and rate-limit errors, with up to four attempts and increasing delays.
  * Prevented automated publishing runs from waiting for interactive input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->