### PR TITLE
Suppress false-positive rest-client matches for CVE-2026-72649, CVE-2026-78607

### DIFF
--- a/suppressions_cve.xml
+++ b/suppressions_cve.xml
@@ -87,6 +87,8 @@ False positive: CVE-2021-34364 is for "Refined GitHub" (browser extension), not 
         <cve>CVE-2026-72685</cve>
         <cve>CVE-2026-72686</cve>
         <cve>CVE-2026-72687</cve>
+        <cve>CVE-2026-72649</cve>
+        <cve>CVE-2026-78607</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -145,6 +147,8 @@ False positive: CVE-2021-34364 is for "Refined GitHub" (browser extension), not 
         <cve>CVE-2026-72685</cve>
         <cve>CVE-2026-72686</cve>
         <cve>CVE-2026-72687</cve>
+        <cve>CVE-2026-72649</cve>
+        <cve>CVE-2026-78607</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[

--- a/suppressions_cve.xml
+++ b/suppressions_cve.xml
@@ -89,6 +89,7 @@ False positive: CVE-2021-34364 is for "Refined GitHub" (browser extension), not 
         <cve>CVE-2026-72687</cve>
         <cve>CVE-2026-72649</cve>
         <cve>CVE-2026-78607</cve>
+        <cve>CVE-2026-78605</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -149,6 +150,7 @@ False positive: CVE-2021-34364 is for "Refined GitHub" (browser extension), not 
         <cve>CVE-2026-72687</cve>
         <cve>CVE-2026-72649</cve>
         <cve>CVE-2026-78607</cve>
+        <cve>CVE-2026-78605</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
cve_check is red on every open PR since 09-04. Cause: three new Elasticsearch **server** CVEs that dependency-check maps onto the client jars via the shared `cpe:2.3:a:elastic:elasticsearch` CPE:

- CVE-2026-72649 — ML trained-model deserialization RCE (server, fixed 8.19.20 / 9.4.5)
- CVE-2026-78607 — inference service missing authorization (server, fixed 8.19.19 / 9.3.8 / 9.4.4)
- CVE-2026-78605 — HTTP request smuggling (server, fixed 8.19.20 / 9.4.5; flagged on the 9.x jars)

None of this code ships in `elasticsearch-rest-client` or `transport-netty4-client`. Added the three CVEs to the two existing false-positive suppression blocks that exist for exactly this pattern ("The CVEs affect the org.elasticsearch:elasticsearch package, which is not a dependency of ...").

tests-utils also prints CVE warnings (commons-fileupload 1.4, httpclient5 via docker-java) but its analyze task does not fail — left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)