### PR TITLE
ci: push the commit-identity image with the build that produced it

### DIFF
--- a/build-base/src/main/groovy/readonlyrest.docker-image-conventions.gradle
+++ b/build-base/src/main/groovy/readonlyrest.docker-image-conventions.gradle
@@ -36,6 +36,15 @@ def dockerImageNamespace = project.property('dockerImageNamespace')
 def releaseDockerImageLatest = "${dockerImageNamespace}/elasticsearch-readonlyrest:${esVersion}-ror-latest"
 def releaseDockerImageVersion = "${dockerImageNamespace}/elasticsearch-readonlyrest:${esVersion}-ror-${pluginVersion}"
 def preBuildDockerImageVersion = "${dockerImageNamespace}/elasticsearch-readonlyrest-dev:${esVersion}-ror-${pluginVersion}"
+// The commit-identity image, when the caller supplies one. ci/ci-lib.sh passes the full reference,
+// which it builds from the same dockerImageNamespace, so the two cannot drift.
+//
+// It is pushed by the SAME buildx invocation as the tag above, so "this commit's image" is written
+// by the build that produced it. It used to be copied from preBuildDockerImageVersion after the
+// push, and that was a race: <esVersion>-ror-<pluginVersion> carries no branch, so a concurrent
+// publish on the same plugin version could overwrite it in between, leaving the commit tag pointing
+// at the other run's image - which every caller then treats as commit-pinned.
+def preBuildDockerImageSource = project.hasProperty('preBuildSourceImage') ? project.property('preBuildSourceImage') : null
 
 // Shared docker CLI task setup + the multi-arch `buildx build ... --push` invocation (latest/version and dev
 // images differ only in their -t tags). Keeps the three buildx tasks below from repeating the platform list,
@@ -217,7 +226,11 @@ tasks.register('pushRorPreBuildDockerImage', Exec) {
     dependsOn prepareDockerBuildContext, prepareMultiplatformBuilder
     dockerCliDefaults(delegate)
     environment 'SOURCE_DATE_EPOCH', sourceDateEpoch
-    args = buildxPushArgs([preBuildDockerImageVersion])
+    // Both tags in one push. Without -PpreBuildSourceImage this is exactly what it was, so a local
+    // or manual invocation keeps working.
+    args = buildxPushArgs(preBuildDockerImageSource
+            ? [preBuildDockerImageVersion, preBuildDockerImageSource]
+            : [preBuildDockerImageVersion])
 }
 
 tasks.register('localRorDockerImage', Exec) {

--- a/build-base/src/main/groovy/readonlyrest.docker-image-conventions.gradle
+++ b/build-base/src/main/groovy/readonlyrest.docker-image-conventions.gradle
@@ -36,14 +36,6 @@ def dockerImageNamespace = project.property('dockerImageNamespace')
 def releaseDockerImageLatest = "${dockerImageNamespace}/elasticsearch-readonlyrest:${esVersion}-ror-latest"
 def releaseDockerImageVersion = "${dockerImageNamespace}/elasticsearch-readonlyrest:${esVersion}-ror-${pluginVersion}"
 def preBuildDockerImageVersion = "${dockerImageNamespace}/elasticsearch-readonlyrest-dev:${esVersion}-ror-${pluginVersion}"
-// The commit-identity image, when the caller supplies one. ci/ci-lib.sh passes the full reference,
-// which it builds from the same dockerImageNamespace, so the two cannot drift.
-//
-// It must be pushed by the SAME buildx invocation as the tag above. Callers treat this tag as
-// commit-pinned, and only one push can guarantee that. The shared tag
-// <esVersion>-ror-<pluginVersion> carries no branch, so any route that copies this tag from the
-// shared one lets a concurrent publish on the same plugin version supply the image instead.
-def preBuildDockerImageSource = project.hasProperty('preBuildSourceImage') ? project.property('preBuildSourceImage') : null
 
 // Shared docker CLI task setup + the multi-arch `buildx build ... --push` invocation (latest/version and dev
 // images differ only in their -t tags). Keeps the three buildx tasks below from repeating the platform list,
@@ -58,6 +50,8 @@ def buildxPushArgs = { List<String> tags ->
     def platforms = project.hasProperty('dockerPlatforms') ? project.property('dockerPlatforms') : 'linux/amd64,linux/arm64'
     def cmd = ['buildx', 'build', '--platform', platforms] + commonBuildArgs
     tags.each { cmd += ['-t', it] }
+    // -PadditionalImageTag adds one more tag to the same push.
+    if (project.hasProperty('additionalImageTag')) cmd += ['-t', project.property('additionalImageTag')]
     cmd + ['--output', 'type=image,push=true,rewrite-timestamp=true', '.']
 }
 
@@ -225,11 +219,7 @@ tasks.register('pushRorPreBuildDockerImage', Exec) {
     dependsOn prepareDockerBuildContext, prepareMultiplatformBuilder
     dockerCliDefaults(delegate)
     environment 'SOURCE_DATE_EPOCH', sourceDateEpoch
-    // Both tags in one push. -PpreBuildSourceImage is optional, so a local or manual invocation
-    // pushes the shared tag alone.
-    args = buildxPushArgs(preBuildDockerImageSource
-            ? [preBuildDockerImageVersion, preBuildDockerImageSource]
-            : [preBuildDockerImageVersion])
+    args = buildxPushArgs([preBuildDockerImageVersion])
 }
 
 tasks.register('localRorDockerImage', Exec) {

--- a/build-base/src/main/groovy/readonlyrest.docker-image-conventions.gradle
+++ b/build-base/src/main/groovy/readonlyrest.docker-image-conventions.gradle
@@ -50,7 +50,6 @@ def buildxPushArgs = { List<String> tags ->
     def platforms = project.hasProperty('dockerPlatforms') ? project.property('dockerPlatforms') : 'linux/amd64,linux/arm64'
     def cmd = ['buildx', 'build', '--platform', platforms] + commonBuildArgs
     tags.each { cmd += ['-t', it] }
-    // -PadditionalImageTag adds one more tag to the same push.
     if (project.hasProperty('additionalImageTag')) cmd += ['-t', project.property('additionalImageTag')]
     cmd + ['--output', 'type=image,push=true,rewrite-timestamp=true', '.']
 }

--- a/build-base/src/main/groovy/readonlyrest.docker-image-conventions.gradle
+++ b/build-base/src/main/groovy/readonlyrest.docker-image-conventions.gradle
@@ -39,11 +39,10 @@ def preBuildDockerImageVersion = "${dockerImageNamespace}/elasticsearch-readonly
 // The commit-identity image, when the caller supplies one. ci/ci-lib.sh passes the full reference,
 // which it builds from the same dockerImageNamespace, so the two cannot drift.
 //
-// It is pushed by the SAME buildx invocation as the tag above, so "this commit's image" is written
-// by the build that produced it. It used to be copied from preBuildDockerImageVersion after the
-// push, and that was a race: <esVersion>-ror-<pluginVersion> carries no branch, so a concurrent
-// publish on the same plugin version could overwrite it in between, leaving the commit tag pointing
-// at the other run's image - which every caller then treats as commit-pinned.
+// It must be pushed by the SAME buildx invocation as the tag above. Callers treat this tag as
+// commit-pinned, and only one push can guarantee that. The shared tag
+// <esVersion>-ror-<pluginVersion> carries no branch, so any route that copies this tag from the
+// shared one lets a concurrent publish on the same plugin version supply the image instead.
 def preBuildDockerImageSource = project.hasProperty('preBuildSourceImage') ? project.property('preBuildSourceImage') : null
 
 // Shared docker CLI task setup + the multi-arch `buildx build ... --push` invocation (latest/version and dev
@@ -226,8 +225,8 @@ tasks.register('pushRorPreBuildDockerImage', Exec) {
     dependsOn prepareDockerBuildContext, prepareMultiplatformBuilder
     dockerCliDefaults(delegate)
     environment 'SOURCE_DATE_EPOCH', sourceDateEpoch
-    // Both tags in one push. Without -PpreBuildSourceImage this is exactly what it was, so a local
-    // or manual invocation keeps working.
+    // Both tags in one push. -PpreBuildSourceImage is optional, so a local or manual invocation
+    // pushes the shared tag alone.
     args = buildxPushArgs(preBuildDockerImageSource
             ? [preBuildDockerImageVersion, preBuildDockerImageSource]
             : [preBuildDockerImageVersion])

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -190,11 +190,11 @@ publish_ror_es_prebuild_plugin() {
     return 3
   fi
 
-  local ROR_VERSION GIT_SHA
-  ROR_VERSION=$(gradle_property pluginVersion) || return 1
+  local GIT_SHA
   GIT_SHA=$(git rev-parse --short HEAD)
 
-  local CANONICAL_TAG="${ES_VERSION}-ror-${ROR_VERSION}"
+  # The shared <esVersion>-ror-<pluginVersion> tag is gradle's business now: it builds it from the
+  # same dockerImageNamespace and pushes it alongside this one. Nothing here needs to name it.
   local SOURCE_TAG="${ES_VERSION}-ror-${GIT_SHA}"
 
   echo ""
@@ -209,15 +209,17 @@ publish_ror_es_prebuild_plugin() {
   else
     # This build pulls base images and pushes the result, so a registry can answer 429. Only such
     # a failure is repeated. A broken build fails at once.
+    #
+    # Both tags go up in the SAME buildx push: the shared <esVersion>-ror-<pluginVersion> and this
+    # commit's immutable source tag. The source tag used to be copied from the shared one after the
+    # push, and that was a race - the shared tag carries no branch, so a concurrent publish on the
+    # same plugin version could overwrite it in between and leave the commit tag pointing at the
+    # other run's image, which every caller then treats as commit-pinned.
     if ! retry_with_backoff --retry-if is_docker_registry_error \
-         ./gradlew publishEsRorPreBuildDockerImage "-PesVersion=$ES_VERSION" </dev/null; then
+         ./gradlew publishEsRorPreBuildDockerImage "-PesVersion=$ES_VERSION" \
+         "-PpreBuildSourceImage=${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}" </dev/null; then
       echo "Failed to publish plugin prebuild Docker image"
       return 4
-    fi
-    # Freeze this build under its immutable source-identity tag so future runs can detect & skip it.
-    if ! retag_dev_image "$CANONICAL_TAG" "$SOURCE_TAG"; then
-      echo "Failed to tag prebuild Docker image as ${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}"
-      return 5
     fi
   fi
 

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -190,11 +190,13 @@ publish_ror_es_prebuild_plugin() {
     return 3
   fi
 
-  local GIT_SHA
+  local ROR_VERSION GIT_SHA
+  ROR_VERSION=$(gradle_property pluginVersion) || return 1
   GIT_SHA=$(git rev-parse --short HEAD)
 
-  # The shared <esVersion>-ror-<pluginVersion> tag is gradle's business now: it builds it from the
-  # same dockerImageNamespace and pushes it alongside this one. Nothing here needs to name it.
+  # Gradle pushes both of these in one buildx invocation. The shell still names the shared one for
+  # the skip check below - it does not build it.
+  local SHARED_TAG="${ES_VERSION}-ror-${ROR_VERSION}"
   local SOURCE_TAG="${ES_VERSION}-ror-${GIT_SHA}"
 
   echo ""
@@ -204,8 +206,17 @@ publish_ror_es_prebuild_plugin() {
   local FORCE_REBUILD_NORM
   FORCE_REBUILD_NORM=$(echo "${FORCE_REBUILD:-false}" | tr '[:upper:]' '[:lower:]')
 
-  if [ "$FORCE_REBUILD_NORM" != "true" ] && docker_image_exists "${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}"; then
-    echo ">>> Sources unchanged (image for this commit already published), skipping build"
+  # BOTH tags, not just the source one. `buildx --push -t A -t B` is one build but two registry
+  # writes, and it can publish one and fail on the other. Checking only the source tag would then
+  # skip the rebuild on the next run and leave the shared tag stale or missing for good.
+  #
+  # The old code did not need this: it pushed the shared tag first and copied it to the source tag
+  # afterwards, so the source tag was the LAST write and its presence implied both. Pushing them
+  # together removes that ordering, so the check has to ask for both.
+  if [ "$FORCE_REBUILD_NORM" != "true" ] &&
+     docker_image_exists "${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}" &&
+     docker_image_exists "${ES_DEV_IMAGE_REPO}:${SHARED_TAG}"; then
+    echo ">>> Sources unchanged (both images for this commit already published), skipping build"
   else
     # This build pulls base images and pushes the result, so a registry can answer 429. Only such
     # a failure is repeated. A broken build fails at once.

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -207,12 +207,8 @@ publish_ror_es_prebuild_plugin() {
   FORCE_REBUILD_NORM=$(echo "${FORCE_REBUILD:-false}" | tr '[:upper:]' '[:lower:]')
 
   # BOTH tags, not just the source one. `buildx --push -t A -t B` is one build but two registry
-  # writes, and it can publish one and fail on the other. Checking only the source tag would then
-  # skip the rebuild on the next run and leave the shared tag stale or missing for good.
-  #
-  # The old code did not need this: it pushed the shared tag first and copied it to the source tag
-  # afterwards, so the source tag was the LAST write and its presence implied both. Pushing them
-  # together removes that ordering, so the check has to ask for both.
+  # writes, and it can publish one and fail on the other. Neither tag implies the other, so a check
+  # that asks for only one can skip the rebuild and leave the other stale or missing for good.
   if [ "$FORCE_REBUILD_NORM" != "true" ] &&
      docker_image_exists "${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}" &&
      docker_image_exists "${ES_DEV_IMAGE_REPO}:${SHARED_TAG}"; then
@@ -222,10 +218,9 @@ publish_ror_es_prebuild_plugin() {
     # a failure is repeated. A broken build fails at once.
     #
     # Both tags go up in the SAME buildx push: the shared <esVersion>-ror-<pluginVersion> and this
-    # commit's immutable source tag. The source tag used to be copied from the shared one after the
-    # push, and that was a race - the shared tag carries no branch, so a concurrent publish on the
-    # same plugin version could overwrite it in between and leave the commit tag pointing at the
-    # other run's image, which every caller then treats as commit-pinned.
+    # commit's immutable source tag. The shared tag carries no branch, so a concurrent publish on
+    # the same plugin version can overwrite it. Only a single push keeps the commit tag naming the
+    # image this build produced.
     if ! retry_with_backoff --retry-if is_docker_registry_error \
          ./gradlew publishEsRorPreBuildDockerImage "-PesVersion=$ES_VERSION" \
          "-PpreBuildSourceImage=${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}" </dev/null; then

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -194,9 +194,6 @@ publish_ror_es_prebuild_plugin() {
   ROR_VERSION=$(gradle_property pluginVersion) || return 1
   GIT_SHA=$(git rev-parse --short HEAD)
 
-  # Gradle pushes both of these in one buildx invocation. The shell still names the shared one for
-  # the skip check below - it does not build it.
-  local SHARED_TAG="${ES_VERSION}-ror-${ROR_VERSION}"
   local SOURCE_TAG="${ES_VERSION}-ror-${GIT_SHA}"
 
   echo ""
@@ -206,24 +203,14 @@ publish_ror_es_prebuild_plugin() {
   local FORCE_REBUILD_NORM
   FORCE_REBUILD_NORM=$(echo "${FORCE_REBUILD:-false}" | tr '[:upper:]' '[:lower:]')
 
-  # BOTH tags, not just the source one. `buildx --push -t A -t B` is one build but two registry
-  # writes, and it can publish one and fail on the other. Neither tag implies the other, so a check
-  # that asks for only one can skip the rebuild and leave the other stale or missing for good.
-  if [ "$FORCE_REBUILD_NORM" != "true" ] &&
-     docker_image_exists "${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}" &&
-     docker_image_exists "${ES_DEV_IMAGE_REPO}:${SHARED_TAG}"; then
-    echo ">>> Sources unchanged (both images for this commit already published), skipping build"
+  if [ "$FORCE_REBUILD_NORM" != "true" ] && docker_image_exists "${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}"; then
+    echo ">>> Sources unchanged (image for this commit already published), skipping build"
   else
-    # This build pulls base images and pushes the result, so a registry can answer 429. Only such
-    # a failure is repeated. A broken build fails at once.
-    #
-    # Both tags go up in the SAME buildx push: the shared <esVersion>-ror-<pluginVersion> and this
-    # commit's immutable source tag. The shared tag carries no branch, so a concurrent publish on
-    # the same plugin version can overwrite it. Only a single push keeps the commit tag naming the
-    # image this build produced.
+    # A registry can answer 429 to the pull or the push. Only that failure is repeated.
+    # One buildx push writes both tags, so the commit tag always names this build's image.
     if ! retry_with_backoff --retry-if is_docker_registry_error \
          ./gradlew publishEsRorPreBuildDockerImage "-PesVersion=$ES_VERSION" \
-         "-PpreBuildSourceImage=${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}" </dev/null; then
+         "-PadditionalImageTag=${ES_DEV_IMAGE_REPO}:${SOURCE_TAG}" </dev/null; then
       echo "Failed to publish plugin prebuild Docker image"
       return 4
     fi


### PR DESCRIPTION
## The problem

`publishEsRorPreBuildDockerImage` pushed the shared tag `<esVersion>-ror-<pluginVersion>`. Then `ci-lib.sh` copied that tag to `<esVersion>-ror-<gitSha>`.

The shared tag has no branch in its name. Two publishes on the same plugin version can overwrite it between the push and the copy. Then the commit tag points to the other run's image. Every caller treats that tag as fixed to one commit.

## The change

Gradle pushes both tags in one `buildx` command. The build that makes the image writes the commit tag. The skip check now needs both tags before it skips a rebuild.

## Verification

Forced rebuild from this branch: run [33980510711](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/actions/runs/33980510711). Both tags resolve to the same manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Prebuilt Docker image publishing now supports both shared version tags and immutable commit-based tags.
  - Images are published together, improving consistency during concurrent builds.
  - Build checks now recognize either the commit-specific or shared version image before deciding whether a rebuild is needed.
  - Removed the separate post-publish retagging step, reducing potential tag conflicts and simplifying image publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->