### PR TITLE
[RORDEV-2220] give the e2e pipeline one job per responsibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,11 +520,13 @@ jobs:
           if-no-files-found: ignore
 
   # ── E2E_MATRIX (versions only) ────────────────────────────────────────────
-  # Takes the newest ES version of every ES module picked for e2e and publishes it as the matrix the
-  # downstream e2e jobs fan out over, together with the build id every dev image of this run is named
-  # after. Keep it free of side effects: "re-run failed jobs" skips a green job, so the build id and
-  # every image name survive a partial re-run.
-  # Stays in the toolchains container: resolving a module's version is a Gradle call.
+  # Finds the newest ES version of each e2e module. Publishes those versions as the matrix for the
+  # e2e jobs below. Also publishes the build id that names every dev image of this run.
+  #
+  # This job must stay free of side effects. "Re-run failed jobs" skips a green job, so the build id
+  # and the image names must survive a partial re-run.
+  #
+  # It runs in the toolchains container, because it calls Gradle to find the versions.
   e2e_matrix:
     needs: [ setup, toolchains_verify ]
     if: >-
@@ -551,11 +553,12 @@ jobs:
         run: ci/run-pipeline.sh
 
   # ── E2E_ORDER_KBN_IMAGES (the other repo's build) ─────────────────────────
-  # The ROR KBN images are built by the ROR KBN repo. This job dispatches that build for the whole
-  # version list and waits for it in one shell. The shared contract requires one shell: only the shell
-  # that dispatched a run can identify it. A failed ROR KBN build therefore fails THIS job, not a test
-  # leg, and "re-run failed jobs" places a fresh order. e2e_build_es_images builds the ES images while
-  # this job waits.
+  # The ROR KBN repo builds the ROR KBN images. This job orders that build for all versions, then
+  # waits for it. Both steps run in one shell, because only the shell that ordered a build can find
+  # its run.
+  #
+  # A failed ROR KBN build fails THIS job, not a test job. "Re-run failed jobs" then places a new
+  # order. e2e_build_es_images builds the ES images while this job waits.
   e2e_order_kbn_images:
     needs: [ setup, e2e_matrix ]
     if: >-
@@ -564,8 +567,8 @@ jobs:
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
     runs-on: ubuntu-latest
-    # Backstop only. The wait below (120min) fires first and says why it failed.
-    # Keep 30min between them, and raise both together.
+    # Backstop only. The wait below stops first (120 min) and prints the cause.
+    # Keep 30 min between the two numbers. Raise both together.
     timeout-minutes: 150
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -579,7 +582,7 @@ jobs:
           ROR_KBN_FALLBACK_BRANCH: ${{ github.base_ref || github.ref_name }}
           E2E_BUILD_ID: ${{ needs.e2e_matrix.outputs.build_id }}
           ROR_GH_TOKEN: ${{ secrets.ROR_GH_TOKEN }}
-          # How long to wait for the whole ROR KBN order. Kept under timeout-minutes above.
+          # How long to wait for the whole ROR KBN order. Keep it below timeout-minutes above.
           ROR_KBN_WAIT_TIMEOUT_SECONDS: 7200
           DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
@@ -589,9 +592,8 @@ jobs:
           ci/run-pipeline.sh
 
   # ── E2E_BUILD_ES_IMAGES (this repo's build) ───────────────────────────────
-  # Builds and publishes this repo's ROR ES dev image, one job per module, under the per-run alias
-  # tag. Sibling of e2e_order_kbn_images: this build and the other repo's build run at the same
-  # time.
+  # Builds and publishes this repo's ROR ES dev image. One job per module, under the per-run tag.
+  # It runs at the same time as e2e_order_kbn_images.
   e2e_build_es_images:
     needs: [ setup, e2e_matrix ]
     if: >-
@@ -630,9 +632,9 @@ jobs:
           ci/run-pipeline.sh
 
   # ── E2E_TESTS (docker env) ────────────────────────────────────────────────
-  # Cypress e2e suite (one job per module). Both dev images are already in the registry:
-  # e2e_order_kbn_images verified the ROR KBN one, e2e_build_es_images published the ROR ES one. A leg
-  # brings up the stack and runs the suite (see ci/e2e-tests-lib.sh).
+  # Cypress e2e suite, one job per module. Both dev images are already in the registry:
+  # e2e_order_kbn_images checked the ROR KBN one, e2e_build_es_images published the ROR ES one.
+  # Each job starts the stack and runs the suite. See ci/e2e-tests-lib.sh.
   e2e_tests:
     needs: [ setup, e2e_matrix, e2e_order_kbn_images, e2e_build_es_images ]
     if: >-
@@ -703,8 +705,8 @@ jobs:
 
   # ── BUILD_ROR (PR only) ───────────────────────────────────────────────────
   # it_windows / e2e_tests may legitimately not run (draft PRs get reduced matrices, and no e2e at
-  # all). e2e is tolerated via setup's empty list rather than a 'skipped' result, so that a FAILED
-  # any e2e job — which also leaves e2e_tests 'skipped' — still blocks this job.
+  # all). e2e is tolerated via setup's empty list rather than a 'skipped' result. A FAILED e2e job
+  # also leaves e2e_tests 'skipped', and it must still block this job.
   build_ror:
     needs: [ setup, required_checks, unit_tests_linux, it_linux, it_windows, e2e_tests ]
     if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,11 +519,13 @@ jobs:
           path: '**/TEST*.xml'
           if-no-files-found: ignore
 
-  # ── E2E_PREPARE (setup for the e2e matrix) ────────────────────────────────
-  # Takes the newest ES version of every ES module picked for e2e, and starts ONE build of the ROR
-  # KBN dev image for all of them. Outputs those versions as the matrix the e2e_tests jobs run on,
-  # plus the build's run id so they know which build to wait for.
-  e2e_prepare:
+  # ── E2E_MATRIX (versions only) ────────────────────────────────────────────
+  # Takes the newest ES version of every ES module picked for e2e and publishes it as the matrix the
+  # downstream e2e jobs fan out over, together with the build id every dev image of this run is named
+  # after. Keep it free of side effects: "re-run failed jobs" skips a green job, so the build id and
+  # every image name survive a partial re-run.
+  # Stays in the toolchains container: resolving a module's version is a Gradle call.
+  e2e_matrix:
     needs: [ setup, toolchains_verify ]
     if: >-
       !cancelled() &&
@@ -532,35 +534,111 @@ jobs:
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
     runs-on: ubuntu-latest
     container: *toolchains_container
-    timeout-minutes: 30
+    timeout-minutes: 15
     outputs:
-      matrix: ${{ steps.prepare.outputs.matrix }}
-      build_id: ${{ steps.prepare.outputs.build_id }}
-      kbn_run_id: ${{ steps.prepare.outputs.kbn_run_id }}
-      kbn_run_url: ${{ steps.prepare.outputs.kbn_run_url }}
-      kbn_wait_timeout_seconds: ${{ steps.prepare.outputs.kbn_wait_timeout_seconds }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      build_id: ${{ steps.matrix.outputs.build_id }}
+      elk_versions: ${{ steps.matrix.outputs.elk_versions }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
-      - name: prepare_e2e_kbn_images
-        id: prepare
+      - name: publish_e2e_matrix
+        id: matrix
         env:
-          ROR_TASK: prepare_e2e_kbn_images
+          ROR_TASK: publish_e2e_matrix
           E2E_ES_MODULES: ${{ join(fromJSON(needs.setup.outputs.e2e_modules), ' ') }}
-          ROR_KBN_TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
-          ROR_KBN_FALLBACK_BRANCH: ${{ github.base_ref || github.ref_name }}
           E2E_BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
-          ROR_GH_TOKEN: ${{ secrets.ROR_GH_TOKEN }}
         run: ci/run-pipeline.sh
 
-  # ── E2E_TESTS (docker env) ────────────────────────────────────────────────
-  # Cypress e2e suite (one job per module). Each job builds and publishes the ROR ES image for its
-  # version, waits for the ROR KBN image, then runs the test suite against both (see ci/e2e-tests-lib.sh).
-  e2e_tests:
-    needs: [ setup, toolchains_verify, e2e_prepare ]
+  # ── E2E_ORDER_KBN_IMAGES (the other repo's build) ─────────────────────────
+  # The ROR KBN images are built by the ROR KBN repo. This job dispatches that build for the whole
+  # version list and waits for it in one shell. The shared contract requires one shell: only the shell
+  # that dispatched a run can identify it. A failed ROR KBN build therefore fails THIS job, not a test
+  # leg, and "re-run failed jobs" places a fresh order. e2e_build_es_images builds the ES images while
+  # this job waits.
+  # Needs no toolchain: gh, jq and an authenticated docker are enough.
+  e2e_order_kbn_images:
+    needs: [ setup, e2e_matrix ]
     if: >-
       !cancelled() &&
-      needs.e2e_prepare.result == 'success' &&
+      needs.e2e_matrix.result == 'success' &&
+      needs.setup.outputs.e2e_modules != '[]' &&
+      (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
+    runs-on: ubuntu-latest
+    timeout-minutes: 130
+    outputs:
+      kbn_run_url: ${{ steps.order.outputs.kbn_run_url }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with: { fetch-depth: 1, persist-credentials: false }
+      - name: order_e2e_kbn_images
+        id: order
+        env:
+          ROR_TASK: order_e2e_kbn_images
+          E2E_ELK_VERSIONS: ${{ needs.e2e_matrix.outputs.elk_versions }}
+          ROR_KBN_TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
+          ROR_KBN_FALLBACK_BRANCH: ${{ github.base_ref || github.ref_name }}
+          E2E_BUILD_ID: ${{ needs.e2e_matrix.outputs.build_id }}
+          ROR_GH_TOKEN: ${{ secrets.ROR_GH_TOKEN }}
+          DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+        run: |
+          set -e
+          source ci/configure-docker.sh
+          ci/run-pipeline.sh
+
+  # ── E2E_BUILD_ES_IMAGES (this repo's build) ───────────────────────────────
+  # Builds and publishes this repo's ROR ES dev image, one job per module, under the per-run alias
+  # tag. Sibling of e2e_order_kbn_images: this build and the other repo's build run at the same
+  # time.
+  e2e_build_es_images:
+    needs: [ setup, e2e_matrix ]
+    if: >-
+      !cancelled() &&
+      needs.e2e_matrix.result == 'success' &&
+      needs.setup.outputs.e2e_modules != '[]' &&
+      (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
+    runs-on: ubicloud-standard-4
+    timeout-minutes: 120
+    env:
+      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle-home
+      GRADLE_OPTS: '-Dorg.gradle.java.installations.paths= -Dorg.gradle.java.installations.auto-download=true'
+    name: build_es_${{ matrix.module }}
+    strategy:
+      fail-fast: false
+      max-parallel: 99
+      matrix: ${{ fromJSON(needs.e2e_matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk (no-op on self-hosted)
+        run: ci/free-host-disk.sh
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3
+        with: { distribution: temurin, java-version: '17' }
+      - name: build_e2e_es_image
+        env:
+          ROR_TASK: build_e2e_es_image
+          E2E_ES_MODULE: ${{ matrix.module }}
+          E2E_ELK_VERSION: ${{ matrix.elk }}
+          E2E_BUILD_ID: ${{ needs.e2e_matrix.outputs.build_id }}
+          DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+        run: |
+          set -e
+          source ci/configure-docker.sh
+          ci/run-pipeline.sh
+
+  # ── E2E_TESTS (docker env) ────────────────────────────────────────────────
+  # Cypress e2e suite (one job per module). Both dev images are already in the registry:
+  # e2e_order_kbn_images verified the ROR KBN one, e2e_build_es_images published the ROR ES one. A leg
+  # brings up the stack and runs the suite (see ci/e2e-tests-lib.sh).
+  e2e_tests:
+    needs: [ setup, toolchains_verify, e2e_matrix, e2e_order_kbn_images, e2e_build_es_images ]
+    if: >-
+      !cancelled() &&
+      needs.e2e_matrix.result == 'success' &&
+      needs.e2e_order_kbn_images.result == 'success' &&
+      needs.e2e_build_es_images.result == 'success' &&
       needs.toolchains_verify.result == 'success' &&
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
@@ -573,7 +651,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 99
-      matrix: ${{ fromJSON(needs.e2e_prepare.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.e2e_matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
@@ -590,10 +668,7 @@ jobs:
           E2E_ELK_VERSION: ${{ matrix.elk }}
           E2E_TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
           E2E_FALLBACK_BRANCH: ${{ github.base_ref || github.ref_name }}
-          E2E_BUILD_ID: ${{ needs.e2e_prepare.outputs.build_id }}
-          ROR_KBN_PREBUILD_RUN_ID: ${{ needs.e2e_prepare.outputs.kbn_run_id }}
-          ROR_KBN_PREBUILD_RUN_URL: ${{ needs.e2e_prepare.outputs.kbn_run_url }}
-          ROR_KBN_WAIT_TIMEOUT_SECONDS: ${{ needs.e2e_prepare.outputs.kbn_wait_timeout_seconds }}
+          E2E_BUILD_ID: ${{ needs.e2e_matrix.outputs.build_id }}
           ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
           ROR_GH_TOKEN: ${{ secrets.ROR_GH_TOKEN }}
           DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
@@ -634,7 +709,7 @@ jobs:
   # ── BUILD_ROR (PR only) ───────────────────────────────────────────────────
   # it_windows / e2e_tests may legitimately not run (draft PRs get reduced matrices, and no e2e at
   # all). e2e is tolerated via setup's empty list rather than a 'skipped' result, so that a FAILED
-  # e2e_prepare — which also leaves e2e_tests 'skipped' — still blocks this job.
+  # any e2e job — which also leaves e2e_tests 'skipped' — still blocks this job.
   build_ror:
     needs: [ setup, required_checks, unit_tests_linux, it_linux, it_windows, e2e_tests ]
     if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,8 +567,6 @@ jobs:
     # Backstop only. The wait below (120min) fires first and says why it failed.
     # Keep 30min between them, and raise both together.
     timeout-minutes: 150
-    outputs:
-      kbn_run_url: ${{ steps.order.outputs.kbn_run_url }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,6 @@ jobs:
   # that dispatched a run can identify it. A failed ROR KBN build therefore fails THIS job, not a test
   # leg, and "re-run failed jobs" places a fresh order. e2e_build_es_images builds the ES images while
   # this job waits.
-  # Needs no toolchain: gh, jq and an authenticated docker are enough.
   e2e_order_kbn_images:
     needs: [ setup, e2e_matrix ]
     if: >-
@@ -637,20 +636,16 @@ jobs:
   # e2e_order_kbn_images verified the ROR KBN one, e2e_build_es_images published the ROR ES one. A leg
   # brings up the stack and runs the suite (see ci/e2e-tests-lib.sh).
   e2e_tests:
-    needs: [ setup, toolchains_verify, e2e_matrix, e2e_order_kbn_images, e2e_build_es_images ]
+    needs: [ setup, e2e_matrix, e2e_order_kbn_images, e2e_build_es_images ]
     if: >-
       !cancelled() &&
       needs.e2e_matrix.result == 'success' &&
       needs.e2e_order_kbn_images.result == 'success' &&
       needs.e2e_build_es_images.result == 'success' &&
-      needs.toolchains_verify.result == 'success' &&
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
     runs-on: ubicloud-standard-4
     timeout-minutes: 120
-    env:
-      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle-home
-      GRADLE_OPTS: '-Dorg.gradle.java.installations.paths= -Dorg.gradle.java.installations.auto-download=true'
     name: e2e_${{ matrix.module }}
     strategy:
       fail-fast: false
@@ -661,8 +656,6 @@ jobs:
         with: { fetch-depth: 1, persist-credentials: false }
       - name: Free host disk (no-op on self-hosted)
         run: ci/free-host-disk.sh
-      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3
-        with: { distribution: temurin, java-version: '17' }
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: '24.11.0' }
       - name: run_e2e_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,7 +565,9 @@ jobs:
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
     runs-on: ubuntu-latest
-    timeout-minutes: 130
+    # Backstop only. The wait below (120min) fires first and says why it failed.
+    # Keep 30min between them, and raise both together.
+    timeout-minutes: 150
     outputs:
       kbn_run_url: ${{ steps.order.outputs.kbn_run_url }}
     steps:
@@ -580,6 +582,8 @@ jobs:
           ROR_KBN_FALLBACK_BRANCH: ${{ github.base_ref || github.ref_name }}
           E2E_BUILD_ID: ${{ needs.e2e_matrix.outputs.build_id }}
           ROR_GH_TOKEN: ${{ secrets.ROR_GH_TOKEN }}
+          # How long to wait for the whole ROR KBN order. Kept under timeout-minutes above.
+          ROR_KBN_WAIT_TIMEOUT_SECONDS: 7200
           DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
         run: |

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -20,7 +20,7 @@ directory contain the build logic; the workflow only orchestrates.
 | `it_linux` | integration tests, one job per ES version | 10-version subset on PRs, full 34 on develop/master/epic and manual |
 | `it_windows` | integration tests on native-Windows ES | 3 on PRs, 7 on branches, full 33 on manual |
 | `unit_tests_windows` | `core:test` on Windows | manual `run_all_tests_on_windows` |
-| `e2e_matrix` | resolves the e2e matrix + the build id every dev image is named after | pushes + PRs (not drafts) |
+| `e2e_matrix` | resolves the e2e matrix and the build id that names every dev image | pushes + PRs (not drafts) |
 | `e2e_order_kbn_images` | dispatches the ROR KBN dev image build **and waits for it** | pushes + PRs (not drafts) |
 | `e2e_build_es_images` | builds + publishes this repo's ROR ES dev image, one job per module | pushes + PRs (not drafts) |
 | `e2e_tests` | Cypress e2e suite, one job per ES version | pushes + PRs (not drafts) |
@@ -93,50 +93,49 @@ e2e_matrix                     resolve versions once, publish the build id
           └── e2e_tests        stack + Cypress only
 ```
 
-- `e2e_matrix` resolves the newest ES version of every module in the matrix
-  (`:esXXXx:printNewestEsVersionForModule`) and publishes it together with the build id and the ELK
-  version list. It orders nothing and builds nothing. It stays in the toolchains container, because
-  resolving a version is a Gradle call — and its `elk_versions` output is what lets the order job run
-  without one.
-- `e2e_order_kbn_images` places **one** dispatch for the whole version list and then waits for that
-  run, in the same shell, ending with a registry check of every image. 
+- `e2e_matrix` finds the newest ES version of every module in the matrix
+  (`:esXXXx:printNewestEsVersionForModule`). It publishes those versions, the build id and the ELK
+  version list. It orders nothing and builds nothing. It runs in the toolchains container, because it
+  calls Gradle to find the versions. Its `elk_versions` output lets the order job run outside that
+  container.
+- `e2e_order_kbn_images` sends **one** dispatch for all versions. Then it waits for that run, in the
+  same shell. At the end it checks the registry for every image.
 - `e2e_build_es_images` builds and pushes the ROR ES dev image from **this** commit, one job per
-  module, through the same `publish_ror_es_prebuild_plugin` helper the standalone pre-build task
-  uses — so the sha-frozen-image skip still applies.
-- `e2e_tests` runs once per version, in parallel. Both images already exist by the time it starts, so
-  it clones the suite, brings up the stack and runs Cypress. 
+  module. It uses the same `publish_ror_es_prebuild_plugin` helper as the standalone pre-build task,
+  so the sha-frozen-image skip still applies.
+- `e2e_tests` runs once per version, in parallel. Both images exist when it starts. It clones the
+  suite, starts the stack and runs Cypress.
 
-### Why the order job owns both halves
+### Why one job does both the dispatch and the wait
 
-Three reasons the dispatch and the wait belong to one job:
+There are three reasons:
 
-- **Blame lands where the fault is.** A ROR KBN build that fails, times out or publishes nothing
-  fails `e2e_order_kbn_images`, and the test jobs are then skipped rather than reporting a failure
-  that had nothing to do with them. The job translates the shared lib's exit code into one line
-  naming the cause, in the log and in the job summary.
-- **"Re-run failed jobs" does the right thing.** That button re-runs the *failed* jobs, so it re-runs
-  the order job — whose dispatch is a fresh `gh workflow run`, and whose run lookup only considers
-  runs created around that dispatch. It therefore follows the new run, not the dead one. `e2e_matrix`
-  is green and is not re-run, so the build id and every image name are unchanged, and the ES images
-  pushed on the first attempt stay valid.
-- **The shared contract requires it.** A dispatch is not told which run it created; the lib finds it
-  by title, in a window around the dispatch. Only the dispatching shell can identify the run, so only
-  that shell can wait for it.
+- **The failure points at the fault.** A ROR KBN build that fails, times out or publishes nothing
+  fails `e2e_order_kbn_images`. The test jobs are then skipped. They do not report a failure that is
+  not theirs. The job turns the shared lib's exit code into one line that names the cause, in the log
+  and in the job summary.
+- **"Re-run failed jobs" does the correct thing.** That button re-runs only the failed jobs, so it
+  re-runs the order job. Its dispatch is a new `gh workflow run`, and its run lookup only accepts
+  runs created around that dispatch. So it follows the new run, not the dead one. `e2e_matrix` is
+  green and does not re-run, so the build id and the image names stay the same. The ES images from
+  the first attempt stay valid.
+- **The shared contract makes it necessary.** A dispatch is not told which run it created. The lib
+  finds the run by title, in a window around the dispatch. Only the shell that dispatched the run can
+  identify it, so only that shell can wait for it.
 
-`e2e_order_kbn_images` and `e2e_build_es_images` are siblings under `e2e_matrix`, and neither needs
-the other. The critical path is therefore `max(local ES build, ROR KBN run)`, plus one runner
-handoff.
+`e2e_order_kbn_images` and `e2e_build_es_images` are siblings under `e2e_matrix`. Neither needs the
+other. So the critical path is `max(local ES build, ROR KBN run)`, plus one runner handoff.
 
-The wait is not a poll of the registry: it waits on the dispatched ROR KBN **run**. What the wait
+The wait does not poll the registry. It waits on the dispatched ROR KBN **run**. What the wait
 guarantees, and what this repo has to supply for it, is the contract at the top of the shared lib.
 Read it there, not here. Three obligations fall on this repo:
 
-- **Log in first.** The order job authenticates Docker before the wait. The registry check at the
-  end of the wait is a pull per image, and Docker Hub counts an anonymous pull against the runner's
-  address (100 per 6h, shared) and an authenticated one against the ROR account (200 per 6h).
+- **Log in first.** The order job authenticates Docker before the wait. The registry check at the end
+  of the wait does one pull per image. Docker Hub counts an anonymous pull against the runner's
+  address (100 per 6h, shared), and an authenticated pull against the ROR account (200 per 6h).
 - **Give the order job a token that can read the runs of the ROR KBN repo.** `ROR_GH_TOKEN` needs
-  `actions:read`. A refused read ends the wait with code 8 in seconds, and names the right it
-  needs. Reading it is how the job follows the run, so there is no way round it.
+  `actions:read`. A refused read stops the wait in seconds with code 8, and it names the necessary
+  right. The job follows the run by these reads, so there is no other way.
 - **Keep the title on our own pre-build run.** `publish-pre-builds.yml` carries
   `run-name: ROR ES pre-build ${{ inputs.tag || inputs.es_versions }}`. Every repo that dispatches it
   — the e2e repo and the ROR KBN repo — finds its run by that title, because a dispatch is told
@@ -145,9 +144,9 @@ Read it there, not here. Three obligations fall on this repo:
   The fallback applies only to a dispatch that sends no tag, and no search looks for such a title.
   Remove the line and every dispatch of this workflow fails, because no run can be recognised.
 
-Both sides address the images by a per-run tag (`run-<build id>`), and the build id is created by
-`e2e_matrix` and passed down as a job output. No other job may re-derive it: a partial re-run bumps
-the run attempt without re-running `e2e_matrix`, and the two sides would then name different images.
+Both sides address the images by a per-run tag (`run-<build id>`). `e2e_matrix` creates the build id
+and passes it down as a job output. No other job may derive it again. A partial re-run bumps the run
+attempt but does not re-run `e2e_matrix`, and the two sides would then name different images.
 
 Branch resolution — both other repos are asked for the branch of this PR first. The e2e clone then
 tries the base branch, `develop`, `master`; the base branch matters, because a change based on

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -20,7 +20,9 @@ directory contain the build logic; the workflow only orchestrates.
 | `it_linux` | integration tests, one job per ES version | 10-version subset on PRs, full 34 on develop/master/epic and manual |
 | `it_windows` | integration tests on native-Windows ES | 3 on PRs, 7 on branches, full 33 on manual |
 | `unit_tests_windows` | `core:test` on Windows | manual `run_all_tests_on_windows` |
-| `e2e_prepare` | resolves the e2e matrix + starts the ROR KBN image build | pushes + PRs (not drafts) |
+| `e2e_matrix` | resolves the e2e matrix + the build id every dev image is named after | pushes + PRs (not drafts) |
+| `e2e_order_kbn_images` | dispatches the ROR KBN dev image build **and waits for it** | pushes + PRs (not drafts) |
+| `e2e_build_es_images` | builds + publishes this repo's ROR ES dev image, one job per module | pushes + PRs (not drafts) |
 | `e2e_tests` | Cypress e2e suite, one job per ES version | pushes + PRs (not drafts) |
 | `build_ror` | builds all plugin zips + bytecode-reuse guard | PRs |
 | `determine_ci_type` → `upload_pre_ror` / `release_ror` / `publish_mvn` | release pipeline | develop/master pushes + manual `release_without_testing` |
@@ -82,26 +84,60 @@ contract between all three —
 [`ci/prebuild-images-lib.sh`](https://github.com/beshu-tech/readonlyrest-e2e-tests/blob/develop/ci/prebuild-images-lib.sh)
 (image names, tag shape, workflow inputs, wait behaviour). Change the contract there, not here.
 
-Two jobs, because the two plugin images are built in different places:
+Four jobs, each with one responsibility:
 
-- `e2e_prepare` runs once. It resolves the newest ES version of every module in the matrix
-  (`:esXXXx:printNewestEsVersionForModule`), publishes that matrix, and dispatches **one** ROR
-  KBN image build for all those versions. Non-blocking: it does not wait for the build.
-- `e2e_tests` runs once per version, in parallel. It builds and pushes the ROR ES dev image from
-  **this** commit, waits for the ROR KBN image, then runs the suite against both.
+```
+e2e_matrix                     resolve versions once, publish the build id
+   ├── e2e_order_kbn_images    dispatch the ROR KBN build, wait for it, verify the images  ─┐ in
+   └── e2e_build_es_images     build + publish the ROR ES image, one job per module         ─┘ parallel
+          └── e2e_tests        stack + Cypress only
+```
 
-The wait is not a poll of the registry: a leg waits on the dispatched ROR KBN **run**. What the wait
+- `e2e_matrix` resolves the newest ES version of every module in the matrix
+  (`:esXXXx:printNewestEsVersionForModule`) and publishes it together with the build id and the ELK
+  version list. It orders nothing and builds nothing. It stays in the toolchains container, because
+  resolving a version is a Gradle call — and its `elk_versions` output is what lets the order job run
+  without one.
+- `e2e_order_kbn_images` places **one** dispatch for the whole version list and then waits for that
+  run, in the same shell, ending with a registry check of every image. Needs no toolchain: `gh`,
+  `jq` and an authenticated docker are enough.
+- `e2e_build_es_images` builds and pushes the ROR ES dev image from **this** commit, one job per
+  module, through the same `publish_ror_es_prebuild_plugin` helper the standalone pre-build task
+  uses — so the sha-frozen-image skip still applies.
+- `e2e_tests` runs once per version, in parallel. Both images already exist by the time it starts, so
+  it clones the suite, brings up the stack and runs Cypress.
+
+### Why the order job owns both halves
+
+Three reasons the dispatch and the wait belong to one job:
+
+- **Blame lands where the fault is.** A ROR KBN build that fails, times out or publishes nothing
+  fails `e2e_order_kbn_images`, and the test jobs are then skipped rather than reporting a failure
+  that had nothing to do with them. The job translates the shared lib's exit code into one line
+  naming the cause, in the log and in the job summary.
+- **"Re-run failed jobs" does the right thing.** That button re-runs the *failed* jobs, so it re-runs
+  the order job — whose dispatch is a fresh `gh workflow run`, and whose run lookup only considers
+  runs created around that dispatch. It therefore follows the new run, not the dead one. `e2e_matrix`
+  is green and is not re-run, so the build id and every image name are unchanged, and the ES images
+  pushed on the first attempt stay valid.
+- **The shared contract requires it.** A dispatch is not told which run it created; the lib finds it
+  by title, in a window around the dispatch. Only the dispatching shell can identify the run, so only
+  that shell can wait for it.
+
+`e2e_order_kbn_images` and `e2e_build_es_images` are siblings under `e2e_matrix`, and neither needs
+the other. The critical path is therefore `max(local ES build, ROR KBN run)`, plus one runner
+handoff.
+
+The wait is not a poll of the registry: it waits on the dispatched ROR KBN **run**. What the wait
 guarantees, and what this repo has to supply for it, is the contract at the top of the shared lib.
-Read it there, not here. Four obligations fall on this repo:
+Read it there, not here. Three obligations fall on this repo:
 
-- **Pass the run down.** `e2e_prepare` fails if it cannot identify the run it started, and publishes
-  it as the `kbn_run_id` and `kbn_run_url` outputs. `ci.yml` hands both to every `e2e_tests` leg,
-  together with `ROR_GH_TOKEN`. A leg with an empty run id reports broken wiring and stops.
-- **Log in first.** Each leg authenticates Docker before the wait, so the registry check the wait
-  makes at the end counts against the ROR account and not against the runner address.
-- **Give the leg a token that can read the runs of the ROR KBN repo.** `ROR_GH_TOKEN` needs
+- **Log in first.** The order job authenticates Docker before the wait. The registry check at the
+  end of the wait is a pull per image, and Docker Hub counts an anonymous pull against the runner's
+  address (100 per 6h, shared) and an authenticated one against the ROR account (200 per 6h).
+- **Give the order job a token that can read the runs of the ROR KBN repo.** `ROR_GH_TOKEN` needs
   `actions:read`. A refused read ends the wait with code 8 in seconds, and names the right it
-  needs. Reading it is how the leg follows the run, so there is no way round it.
+  needs. Reading it is how the job follows the run, so there is no way round it.
 - **Keep the title on our own pre-build run.** `publish-pre-builds.yml` carries
   `run-name: ROR ES pre-build ${{ inputs.tag || inputs.es_versions }}`. Every repo that dispatches it
   — the e2e repo and the ROR KBN repo — finds its run by that title, because a dispatch is told
@@ -110,14 +146,9 @@ Read it there, not here. Four obligations fall on this repo:
   The fallback applies only to a dispatch that sends no tag, and no search looks for such a title.
   Remove the line and every dispatch of this workflow fails, because no run can be recognised.
 
-One consequence shapes this side: the wait ends when the ROR KBN run ends, not when one image
-appears, so all three legs reach their suite at about the same time. The Gradle build of the ROR ES
-image runs before the wait and absorbs most of that time.
-
 Both sides address the images by a per-run tag (`run-<build id>`), and the build id is created by
-`e2e_prepare` and passed down as a job output. A test job must never re-derive it: a partial re-run
-bumps the run attempt without re-running `e2e_prepare`, and the two sides would then name different
-images.
+`e2e_matrix` and passed down as a job output. No other job may re-derive it: a partial re-run bumps
+the run attempt without re-running `e2e_matrix`, and the two sides would then name different images.
 
 Branch resolution — both other repos are asked for the branch of this PR first. The e2e clone then
 tries the base branch, `develop`, `master`; the base branch matters, because a change based on

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -99,13 +99,12 @@ e2e_matrix                     resolve versions once, publish the build id
   resolving a version is a Gradle call — and its `elk_versions` output is what lets the order job run
   without one.
 - `e2e_order_kbn_images` places **one** dispatch for the whole version list and then waits for that
-  run, in the same shell, ending with a registry check of every image. Needs no toolchain: `gh`,
-  `jq` and an authenticated docker are enough.
+  run, in the same shell, ending with a registry check of every image. 
 - `e2e_build_es_images` builds and pushes the ROR ES dev image from **this** commit, one job per
   module, through the same `publish_ror_es_prebuild_plugin` helper the standalone pre-build task
   uses — so the sha-frozen-image skip still applies.
 - `e2e_tests` runs once per version, in parallel. Both images already exist by the time it starts, so
-  it clones the suite, brings up the stack and runs Cypress.
+  it clones the suite, brings up the stack and runs Cypress. 
 
 ### Why the order job owns both halves
 

--- a/ci/e2e-tests-lib.sh
+++ b/ci/e2e-tests-lib.sh
@@ -287,10 +287,6 @@ order_e2e_kbn_images() {
     _report_kbn_order_failure wait "$STATUS" "${ROR_KBN_PREBUILD_RUN_URL:-}"
     return "$STATUS"
   fi
-
-  if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    echo "kbn_run_url=${ROR_KBN_PREBUILD_RUN_URL:-}" >> "$GITHUB_OUTPUT"
-  fi
 }
 
 # Entry point for the `build_e2e_es_image` task (the `e2e_build_es_images` job). Runs once per ELK

--- a/ci/e2e-tests-lib.sh
+++ b/ci/e2e-tests-lib.sh
@@ -252,20 +252,12 @@ order_e2e_kbn_images() {
     return 2
   fi
 
-  # One run builds the versions one after another, so it finishes after N build times. Scale the
-  # wait with the count, off the shared lib's single-version default...
-  local VERSION_COUNT
-  VERSION_COUNT=$(echo "$ELK_VERSIONS" | wc -w | tr -d '[:space:]')
-  local WAIT_TIMEOUT=$(( VERSION_COUNT * ${ROR_KBN_WAIT_TIMEOUT_SECONDS:-1800} ))
-  # ...but never past what this job is allowed to live for. A wait that outlasts the job can report
-  # nothing: GitHub kills the runner at `timeout-minutes` and the job dies with an opaque "exceeded
-  # the maximum execution time" instead of the diagnosis below. Keep the cap well under
-  # `timeout-minutes` on e2e_order_kbn_images in ci.yml, and raise both together.
-  local WAIT_TIMEOUT_CAP=${ROR_KBN_WAIT_TIMEOUT_CAP_SECONDS:-7200}
-  if [ "$WAIT_TIMEOUT" -gt "$WAIT_TIMEOUT_CAP" ]; then
-    echo ">>> Capping the ROR KBN image wait at ${WAIT_TIMEOUT_CAP}s (scaled value was ${WAIT_TIMEOUT}s)"
-    WAIT_TIMEOUT=$WAIT_TIMEOUT_CAP
-  fi
+  # How long to wait for the WHOLE order (one run builds the versions one after another). A wait
+  # that outlasts the job can report nothing: GitHub kills the runner at `timeout-minutes` and the
+  # job dies with an opaque "exceeded the maximum execution time" instead of the diagnosis below.
+  # So the caller sets this, and keeps it well under `timeout-minutes` on e2e_order_kbn_images in
+  # ci.yml, where both numbers sit side by side. This default is the fallback for local runs.
+  local WAIT_TIMEOUT=${ROR_KBN_WAIT_TIMEOUT_SECONDS:-7200}
   export ROR_KBN_WAIT_TIMEOUT_SECONDS=$WAIT_TIMEOUT
 
   echo ">>> Ordering e2e ROR KBN dev images: ELK [$ELK_VERSIONS], run tag: $RUN_TAG, wait up to ${WAIT_TIMEOUT}s"

--- a/ci/e2e-tests-lib.sh
+++ b/ci/e2e-tests-lib.sh
@@ -1,19 +1,21 @@
 # Sourced by run-pipeline.sh — do not execute directly.
 
-# Helpers for the `prepare_e2e_kbn_images` and `run_e2e_tests` tasks in run-pipeline.sh. Together
-# they run the Cypress e2e suite (docker env) against dev Docker images of both ROR plugins.
-# What the two jobs are and why they are two: ci/README.md#e2e-tests.
+# Helpers for the four e2e tasks in run-pipeline.sh: `publish_e2e_matrix`, `order_e2e_kbn_images`,
+# `build_e2e_es_image` and `run_e2e_tests`. Together they run the Cypress e2e suite (docker env)
+# against dev Docker images of both ROR plugins. Each job has one responsibility. One job orders the
+# ROR KBN images from the other repo and waits for them. One job builds the ROR ES image. The test
+# jobs run the suite. What each job is: ci/CI.md#e2e-tests.
 #
-# Both images carry a per-run tag (run-<build id>). The build id is created by prepare_e2e_kbn_images
-# and passed to the test jobs as a job output. The test jobs must not re-derive it, because a partial
-# re-run bumps the GitHub run attempt without re-running the prepare job, causing the two sides to
-# name different images.
+# Both images carry a per-run tag (run-<build id>). The build id is published by the matrix job and
+# handed to every other job as a job output. No job may re-derive it, because a partial re-run bumps
+# the GitHub run attempt without re-running the matrix job, which would rename the images.
 #
 # The ROR KBN dispatch/wait helpers are not defined here — they live in the e2e repo and are loaded
 # from a clone of it: https://github.com/beshu-tech/readonlyrest-e2e-tests/blob/develop/ci/prebuild-images-lib.sh
-# That file owns the cross-repo contract (image names, tag shape, workflow inputs), so a change to
-# how the images are named or dispatched belongs there, not here. This file handles only what is
-# specific to this repo: the ROR ES image and running the test suite.
+# That file owns the cross-repo contract (image names, tag shape, workflow inputs, and the rule that
+# the dispatch and the wait share a shell), so a change to how the images are named or dispatched
+# belongs there, not here. This file handles only what is specific to this repo: the ROR ES image and
+# running the test suite.
 # Note: docker_image_exists is defined in the shared file and replaces the copy in ci-lib.sh.
 
 E2E_TESTS_REPO="https://github.com/beshu-tech/readonlyrest-e2e-tests.git"
@@ -138,76 +140,185 @@ e2e_matrix_json() {
   printf '%s\n' "${ENTRIES[@]}" | jq -cs '{include: .}'
 }
 
-# Pass the dispatched ROR KBN run ID, URL, and wait timeout to the test jobs. They run as separate
-# processes on separate machines, and the run ID is what they wait on.
+# Entry point for the `publish_e2e_matrix` task (the `e2e_matrix` job). Runs once per pipeline run,
+# and does nothing but resolve versions: it publishes the matrix the downstream jobs fan out over,
+# the ELK version list the order job dispatches for, and the build id whose run tag names every image
+# of this run. Keep it free of side effects: "re-run failed jobs" skips a green job, so the build id
+# and the published images survive a partial re-run.
 #
-# Outside GitHub Actions there is no job output, so the same three values are printed as export
-# lines. A local run of the `run_e2e_tests` task is a separate shell, and without them it stops at
-# once, because the wait has no run to follow.
-# Usage: export_kbn_prebuild_run_info <version count>
-export_kbn_prebuild_run_info() {
-  # The test jobs wait for the run, and one run builds all the versions one after another, so it
-  # finishes after N build times. Scale the timeout by the number of versions.
-  local WAIT_TIMEOUT=$(( ${1:-1} * ${ROR_KBN_WAIT_TIMEOUT_SECONDS:-1800} ))
-
-  if [ -z "${GITHUB_OUTPUT:-}" ]; then
-    echo ""
-    echo ">>> Not running in GitHub Actions, so there is no job output to write. A test run is a"
-    echo "    separate shell, and its wait needs the run below. Export these first:"
-    echo ""
-    echo "      export ROR_KBN_PREBUILD_RUN_ID='${ROR_KBN_PREBUILD_RUN_ID:-}'"
-    echo "      export ROR_KBN_PREBUILD_RUN_URL='${ROR_KBN_PREBUILD_RUN_URL:-}'"
-    echo "      export ROR_KBN_WAIT_TIMEOUT_SECONDS=$WAIT_TIMEOUT"
-    echo ""
-    return 0
-  fi
-
-  {
-    echo "kbn_run_id=${ROR_KBN_PREBUILD_RUN_ID:-}"
-    echo "kbn_run_url=${ROR_KBN_PREBUILD_RUN_URL:-}"
-    echo "kbn_wait_timeout_seconds=$WAIT_TIMEOUT"
-  } >> "$GITHUB_OUTPUT"
-}
-
-# Entry point for the `prepare_e2e_kbn_images` task. Runs once per pipeline run.
-# Args: <es modules> <target branch> <fallback branch> <build id>
-#   es modules      — e2e ES modules, space- or comma-separated (e.g. "es94x es818x es717x")
-#   target branch   — branch to build the ROR KBN plugin from
-#   fallback branch — branch to use when target branch is missing in the e2e repo
-#   build id        — E2E_BUILD_ID (published to test jobs as `build_id` output)
-prepare_e2e_kbn_images() {
-  if [ "$#" -ne 4 ]; then
-    echo "Usage: prepare_e2e_kbn_images <es modules> <target branch> <fallback branch> <build id>"
+# It stays in the toolchains container, because resolving a module's newest ES version is a Gradle
+# call. Its `elk_versions` output is what lets the order job run outside that container.
+#
+# Args: <es modules> <build id>
+#   es modules — e2e ES modules, space- or comma-separated (e.g. "es94x es818x es717x")
+#   build id   — E2E_BUILD_ID (published to every other job as the `build_id` output)
+publish_e2e_matrix() {
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: publish_e2e_matrix <es modules> <build id>"
     return 1
   fi
 
-  local ES_MODULES=$1
+  local MATRIX ELK_VERSIONS
+  MATRIX=$(e2e_matrix_json "$1") || return $?
+  ELK_VERSIONS=$(echo "$MATRIX" | jq -r '[.include[].elk] | join(" ")')
+
+  echo ">>> e2e matrix: $MATRIX (build id: $2, run tag: $(e2e_run_tag "$2"))"
+
+  # A no-op outside GitHub Actions, where the matrix is printed above and the build id is the
+  # caller's own.
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+    echo "build_id=$2" >> "$GITHUB_OUTPUT"
+    echo "elk_versions=$ELK_VERSIONS" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# Report why the ROR KBN order failed, in one line, to the log and to the job summary. The shared lib
+# has already printed its own diagnosis; this adds the sentence a reader of the job list needs, and
+# the link, without making them open the step log.
+#
+# The two halves reuse the same small exit codes for different things (3 and 4 mean one thing to the
+# dispatch and another to the wait), so the phase is part of the lookup.
+# Usage: _report_kbn_order_failure <dispatch|wait> <exit code> <run url>
+_report_kbn_order_failure() {
+  local PHASE=$1 CODE=$2 RUN_URL=${3:-} REASON
+
+  if [ "$PHASE" = dispatch ]; then
+    case "$CODE" in
+      1) REASON="the ROR KBN pre-build was not dispatched: no run tag, so its run could not be named" ;;
+      3) REASON="the ROR KBN pre-build workflow could not be dispatched (check that it exists on the default branch of the ROR KBN repo and that its inputs match)" ;;
+      4) REASON="the ROR KBN pre-build was dispatched, but the run it created could not be identified — that build continues; re-run this job" ;;
+      *) REASON="dispatching the ROR KBN pre-build failed (exit $CODE)" ;;
+    esac
+  else
+    case "$CODE" in
+      3) REASON="there was no ROR KBN pre-build run to follow" ;;
+      4) REASON="the ROR KBN pre-build run did not finish within the wait timeout" ;;
+      5) REASON="the ROR KBN pre-build run succeeded, but at least one image is missing from the registry" ;;
+      6) REASON="the ROR KBN pre-build run FAILED — the problem is in the ROR KBN repo, not here" ;;
+      7) REASON="the registry could not be queried (rate limit, login or network), so the images could not be verified" ;;
+      8) REASON="the ROR KBN pre-build run could not be read — check that ROR_GH_TOKEN still grants actions:read" ;;
+      *) REASON="waiting for the ROR KBN pre-build failed (exit $CODE)" ;;
+    esac
+  fi
+
+  local LINE="KBN dev images NOT ordered: $REASON."
+  [ -n "$RUN_URL" ] && LINE="$LINE Run: $RUN_URL"
+
+  echo ""
+  echo "ERROR: $LINE"
+  echo "       The e2e test jobs are skipped, because there is nothing to test against."
+  echo "       Re-running the failed jobs re-runs THIS job, which places a fresh order under the"
+  echo "       same run tag; the ES images already published stay valid."
+
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "### ❌ $LINE"
+      echo ""
+      echo "The ROR KBN dev images are built by the ROR KBN repo. This job orders them and waits for"
+      echo "them, so a failure here is about that build — not about the e2e suite."
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+# Entry point for the `order_e2e_kbn_images` task (the `e2e_order_kbn_images` job). Runs once per
+# pipeline run.
+#
+# Dispatches ONE ROR KBN pre-build for every version of the matrix, then waits for it in the SAME
+# shell. The two halves must share a shell. The shared lib identifies a dispatched run by a title
+# search over the seconds around the dispatch, so only the shell that dispatched it can name the run
+# to wait for.
+#
+# Args: <elk versions> <target branch> <fallback branch> <build id>
+#   elk versions    — the `elk_versions` output of the matrix job (space-separated X.Y.Z)
+#   target branch   — branch to build the ROR KBN plugin from
+#   fallback branch — branch to use when the target branch is missing in the e2e repo
+#   build id        — E2E_BUILD_ID, as PUBLISHED by the matrix job; it names the images ordered here
+order_e2e_kbn_images() {
+  if [ "$#" -ne 4 ]; then
+    echo "Usage: order_e2e_kbn_images <elk versions> <target branch> <fallback branch> <build id>"
+    return 1
+  fi
+
+  local ELK_VERSIONS=$1
   local TARGET_BRANCH=$2
   local FALLBACK_BRANCH=$3
   local RUN_TAG
   RUN_TAG=$(e2e_run_tag "$4") || return $?
 
-  local MATRIX ELK_VERSIONS
-  MATRIX=$(e2e_matrix_json "$ES_MODULES") || return $?
-  ELK_VERSIONS=$(echo "$MATRIX" | jq -r '[.include[].elk] | join(" ")')
-  # Export the matrix and build id to GitHub (no-op outside CI).
-  if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-    echo "build_id=$4" >> "$GITHUB_OUTPUT"
+  if [ -z "${ELK_VERSIONS// /}" ]; then
+    echo "ERROR: no ELK versions to order ROR KBN images for. The matrix job publishes them as its"
+    echo "       'elk_versions' output."
+    return 2
   fi
 
-  echo ">>> Preparing e2e ROR KBN dev images: ELK [$ELK_VERSIONS], run tag: $RUN_TAG"
+  # One run builds the versions one after another, so it finishes after N build times. Scale the
+  # wait with the count, off the shared lib's single-version default...
+  local VERSION_COUNT
+  VERSION_COUNT=$(echo "$ELK_VERSIONS" | wc -w | tr -d '[:space:]')
+  local WAIT_TIMEOUT=$(( VERSION_COUNT * ${ROR_KBN_WAIT_TIMEOUT_SECONDS:-1800} ))
+  # ...but never past what this job is allowed to live for. A wait that outlasts the job can report
+  # nothing: GitHub kills the runner at `timeout-minutes` and the job dies with an opaque "exceeded
+  # the maximum execution time" instead of the diagnosis below. Keep the cap well under
+  # `timeout-minutes` on e2e_order_kbn_images in ci.yml, and raise both together.
+  local WAIT_TIMEOUT_CAP=${ROR_KBN_WAIT_TIMEOUT_CAP_SECONDS:-7200}
+  if [ "$WAIT_TIMEOUT" -gt "$WAIT_TIMEOUT_CAP" ]; then
+    echo ">>> Capping the ROR KBN image wait at ${WAIT_TIMEOUT_CAP}s (scaled value was ${WAIT_TIMEOUT}s)"
+    WAIT_TIMEOUT=$WAIT_TIMEOUT_CAP
+  fi
+  export ROR_KBN_WAIT_TIMEOUT_SECONDS=$WAIT_TIMEOUT
 
-  # Clone the e2e repo only to load the shared dispatch helper (test jobs clone it separately).
+  echo ">>> Ordering e2e ROR KBN dev images: ELK [$ELK_VERSIONS], run tag: $RUN_TAG, wait up to ${WAIT_TIMEOUT}s"
+
+  # Clone the e2e repo only to load the shared dispatch and wait helpers (test jobs clone it
+  # separately, for the runner).
   local E2E_DIR
   E2E_DIR=$(clone_e2e_tests_repo "$TARGET_BRANCH" "$FALLBACK_BRANCH") || return $?
+  # Drop the clone however this exits. The path is expanded into the trap now, because E2E_DIR is
+  # local and gone by the time the trap runs.
+  trap "rm -rf '$E2E_DIR'" EXIT
   load_kbn_prebuild_helpers "$E2E_DIR" || return $?
 
-  # Dispatch the ROR KBN build (non-blocking). It is dispatched even if the image exists, so the
-  # per-run tag always gets applied.
-  dispatch_kbn_prebuild_image "$ELK_VERSIONS" "$TARGET_BRANCH" "$RUN_TAG" || return $?
+  # One dispatch for every version. It is dispatched even if the image exists, so the per-run tag
+  # always gets applied.
+  local STATUS=0
+  dispatch_kbn_prebuild_image "$ELK_VERSIONS" "$TARGET_BRANCH" "$RUN_TAG" || STATUS=$?
+  if [ "$STATUS" -ne 0 ]; then
+    _report_kbn_order_failure dispatch "$STATUS" "${ROR_KBN_PREBUILD_RUN_URL:-}"
+    return "$STATUS"
+  fi
 
-  export_kbn_prebuild_run_info "$(echo "$MATRIX" | jq '.include | length')"
+  # The wait follows ROR_KBN_PREBUILD_RUN_ID, which the dispatch set in this shell. It ends when the
+  # run ends, then checks the registry for every image.
+  wait_for_kbn_prebuild_images "$ELK_VERSIONS" "$RUN_TAG" || STATUS=$?
+  if [ "$STATUS" -ne 0 ]; then
+    _report_kbn_order_failure wait "$STATUS" "${ROR_KBN_PREBUILD_RUN_URL:-}"
+    return "$STATUS"
+  fi
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "kbn_run_url=${ROR_KBN_PREBUILD_RUN_URL:-}" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# Entry point for the `build_e2e_es_image` task (the `e2e_build_es_images` job). Runs once per ELK
+# version, while the order job waits for the other repo's build.
+#
+# Publishes this repo's ROR ES dev image under the per-run alias tag, through the same helper the
+# standalone pre-build task uses. The sha-frozen-image skip applies: if the image for this commit
+# already exists, the helper only retags it in the registry.
+# Args: <elk version> <build id>
+build_e2e_es_image() {
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: build_e2e_es_image <elk version> <build id>"
+    return 1
+  fi
+
+  local RUN_TAG
+  RUN_TAG=$(e2e_run_tag "$2") || return $?
+
+  echo ">>> Building the ROR ES dev image: ELK $1, run tag: $RUN_TAG"
+  publish_ror_es_prebuild_plugin "$1" "$RUN_TAG"
 }
 
 # Run the Cypress test suite from an already-cloned e2e tests repo, against this run's dev images
@@ -250,12 +361,14 @@ run_e2e_against_dev_images() {
   )
 }
 
-# Entry point for the `run_e2e_tests` task. Runs once per ELK version, after prepare_e2e_kbn_images.
+# Entry point for the `run_e2e_tests` task. Runs once per ELK version. It clones the e2e repo and
+# runs the suite. Both dev images are already in the registry: e2e_order_kbn_images verified the ROR
+# KBN one, e2e_build_es_images published the ROR ES one.
 # Args: <elk version> <target branch> <fallback branch> <build id>
 #   elk version     — ELK version to test (X.Y.Z)
 #   target branch   — branch for the e2e suite
 #   fallback branch — branch to use when target branch is missing in the e2e repo
-#   build id        — E2E_BUILD_ID (from the preparing job; do not re-derive it)
+#   build id        — E2E_BUILD_ID (from the matrix job; do not re-derive it)
 run_e2e_tests() {
   if [ "$#" -ne 4 ]; then
     echo "Usage: run_e2e_tests <elk version> <target branch> <fallback branch> <build id>"
@@ -274,37 +387,16 @@ run_e2e_tests() {
     return 2
   fi
 
-  # The wait below follows the ROR KBN pre-build run, so the run id is necessary. It comes from the
-  # job environment and nothing here sets it, so check it before the clone and the Gradle build: a
-  # job that cannot wait must not spend minutes to say so. The e2e_prepare job dispatches the run on
-  # another machine and publishes the id as its `kbn_run_id` output. That job also fails if it
-  # cannot identify the run it started, so the id is set whenever it succeeded.
-  if [ -z "${ROR_KBN_PREBUILD_RUN_ID:-}" ]; then
-    echo "ERROR: ROR_KBN_PREBUILD_RUN_ID is empty, so there is no ROR KBN run to wait for."
-    echo "       The e2e_prepare job publishes the id as its 'kbn_run_id' output, and ci.yml passes"
-    echo "       that output to this job. Check both."
-    return 3
-  fi
-
   echo ">>> Running e2e tests: ELK $ELK_VERSION, run tag: $RUN_TAG"
 
-  # Clone the e2e repo (needed for both the wait helper and the test runner).
+  # Clone the e2e repo for the test runner.
   local E2E_DIR
   E2E_DIR=$(clone_e2e_tests_repo "$TARGET_BRANCH" "$FALLBACK_BRANCH") || return $?
-  load_kbn_prebuild_helpers "$E2E_DIR" || return $?
 
   # Export the test directory path so later steps can collect results (no-op outside CI).
   if [ -n "${GITHUB_ENV:-}" ]; then
     echo "E2E_TESTS_DIR=$E2E_DIR" >> "$GITHUB_ENV"
   fi
 
-  # Build and publish the ROR ES dev image (Gradle is skipped if the image already exists).
-  publish_ror_es_prebuild_plugin "$ELK_VERSION" "$RUN_TAG" || return $?
-
-  # Wait for the ROR KBN image. The run id was checked at the top of this function, because the wait
-  # follows that run and the id arrives with the job environment.
-  wait_for_kbn_prebuild_images "$ELK_VERSION" "$RUN_TAG" || return $?
-
-  # Both images are now available; run the test suite.
   run_e2e_against_dev_images "$E2E_DIR" "$ELK_VERSION" "$RUN_TAG"
 }

--- a/ci/e2e-tests-lib.sh
+++ b/ci/e2e-tests-lib.sh
@@ -1,21 +1,24 @@
 # Sourced by run-pipeline.sh — do not execute directly.
 
-# Helpers for the four e2e tasks in run-pipeline.sh: `publish_e2e_matrix`, `order_e2e_kbn_images`,
-# `build_e2e_es_image` and `run_e2e_tests`. Together they run the Cypress e2e suite (docker env)
-# against dev Docker images of both ROR plugins. Each job has one responsibility. One job orders the
-# ROR KBN images from the other repo and waits for them. One job builds the ROR ES image. The test
-# jobs run the suite. What each job is: ci/CI.md#e2e-tests.
+# Helpers for the four e2e tasks in run-pipeline.sh. Together they run the Cypress e2e suite (docker
+# env) against dev Docker images of both ROR plugins. Each task has one responsibility:
 #
-# Both images carry a per-run tag (run-<build id>). The build id is published by the matrix job and
-# handed to every other job as a job output. No job may re-derive it, because a partial re-run bumps
-# the GitHub run attempt without re-running the matrix job, which would rename the images.
+#   publish_e2e_matrix   — find the versions, publish the matrix and the build id
+#   order_e2e_kbn_images — order the ROR KBN images from the other repo, and wait for them
+#   build_e2e_es_image   — build the ROR ES image
+#   run_e2e_tests        — run the suite
 #
-# The ROR KBN dispatch/wait helpers are not defined here — they live in the e2e repo and are loaded
-# from a clone of it: https://github.com/beshu-tech/readonlyrest-e2e-tests/blob/develop/ci/prebuild-images-lib.sh
-# That file owns the cross-repo contract (image names, tag shape, workflow inputs, and the rule that
-# the dispatch and the wait share a shell), so a change to how the images are named or dispatched
-# belongs there, not here. This file handles only what is specific to this repo: the ROR ES image and
-# running the test suite.
+# What each job is: ci/CI.md#e2e-tests.
+#
+# Both images carry a per-run tag (run-<build id>). The matrix job publishes the build id, and every
+# other job gets it as a job output. No job may derive it again. A partial re-run bumps the GitHub
+# run attempt but does not re-run the matrix job, and the images would get new names.
+#
+# The ROR KBN dispatch and wait helpers are not here. They live in the e2e repo, and a clone of it
+# loads them: https://github.com/beshu-tech/readonlyrest-e2e-tests/blob/develop/ci/prebuild-images-lib.sh
+# That file owns the cross-repo contract: image names, tag shape, workflow inputs, and the rule that
+# the dispatch and the wait share a shell. Change how images are named or dispatched there, not here.
+# This file holds only what belongs to this repo: the ROR ES image and the test suite.
 # Note: docker_image_exists is defined in the shared file and replaces the copy in ci-lib.sh.
 
 E2E_TESTS_REPO="https://github.com/beshu-tech/readonlyrest-e2e-tests.git"
@@ -140,14 +143,18 @@ e2e_matrix_json() {
   printf '%s\n' "${ENTRIES[@]}" | jq -cs '{include: .}'
 }
 
-# Entry point for the `publish_e2e_matrix` task (the `e2e_matrix` job). Runs once per pipeline run,
-# and does nothing but resolve versions: it publishes the matrix the downstream jobs fan out over,
-# the ELK version list the order job dispatches for, and the build id whose run tag names every image
-# of this run. Keep it free of side effects: "re-run failed jobs" skips a green job, so the build id
-# and the published images survive a partial re-run.
+# Entry point for the `publish_e2e_matrix` task (the `e2e_matrix` job). Runs once per pipeline run.
+# It only finds versions, and publishes three things:
 #
-# It stays in the toolchains container, because resolving a module's newest ES version is a Gradle
-# call. Its `elk_versions` output is what lets the order job run outside that container.
+#   matrix       — the versions the downstream jobs fan out over
+#   elk_versions — the version list the order job dispatches for
+#   build_id     — the id whose run tag names every image of this run
+#
+# Keep this task free of side effects. "Re-run failed jobs" skips a green job, so the build id and
+# the published images must survive a partial re-run.
+#
+# It runs in the toolchains container, because it calls Gradle to find each module's newest ES
+# version. Its `elk_versions` output lets the order job run outside that container.
 #
 # Args: <es modules> <build id>
 #   es modules — e2e ES modules, space- or comma-separated (e.g. "es94x es818x es717x")
@@ -164,7 +171,7 @@ publish_e2e_matrix() {
 
   echo ">>> e2e matrix: $MATRIX (build id: $2, run tag: $(e2e_run_tag "$2"))"
 
-  # A no-op outside GitHub Actions, where the matrix is printed above and the build id is the
+  # Outside GitHub Actions this does nothing. The matrix is printed above, and the build id is the
   # caller's own.
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
@@ -173,12 +180,12 @@ publish_e2e_matrix() {
   fi
 }
 
-# Report why the ROR KBN order failed, in one line, to the log and to the job summary. The shared lib
-# has already printed its own diagnosis; this adds the sentence a reader of the job list needs, and
-# the link, without making them open the step log.
+# Reports why the ROR KBN order failed. One line, to the log and to the job summary. The shared lib
+# already printed its own diagnosis. This adds the one sentence, and the link, that a reader of the
+# job list needs. They do not have to open the step log.
 #
-# The two halves reuse the same small exit codes for different things (3 and 4 mean one thing to the
-# dispatch and another to the wait), so the phase is part of the lookup.
+# The dispatch and the wait reuse the same small exit codes for different faults. Codes 3 and 4 mean
+# one thing to the dispatch and another to the wait. So the phase is part of the lookup.
 # Usage: _report_kbn_order_failure <dispatch|wait> <exit code> <run url>
 _report_kbn_order_failure() {
   local PHASE=$1 CODE=$2 RUN_URL=${3:-} REASON
@@ -208,15 +215,15 @@ _report_kbn_order_failure() {
   echo ""
   echo "ERROR: $LINE"
   echo "       The e2e test jobs are skipped, because there is nothing to test against."
-  echo "       Re-running the failed jobs re-runs THIS job, which places a fresh order under the"
-  echo "       same run tag; the ES images already published stay valid."
+  echo "       Re-run the failed jobs. That re-runs THIS job and places a new order under the same"
+  echo "       run tag. The ES images already published stay valid."
 
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     {
       echo "### ❌ $LINE"
       echo ""
-      echo "The ROR KBN dev images are built by the ROR KBN repo. This job orders them and waits for"
-      echo "them, so a failure here is about that build — not about the e2e suite."
+      echo "The ROR KBN repo builds the ROR KBN dev images. This job orders them and waits for them."
+      echo "A failure here is about that build, not about the e2e suite."
     } >> "$GITHUB_STEP_SUMMARY"
   fi
 }
@@ -224,16 +231,15 @@ _report_kbn_order_failure() {
 # Entry point for the `order_e2e_kbn_images` task (the `e2e_order_kbn_images` job). Runs once per
 # pipeline run.
 #
-# Dispatches ONE ROR KBN pre-build for every version of the matrix, then waits for it in the SAME
-# shell. The two halves must share a shell. The shared lib identifies a dispatched run by a title
-# search over the seconds around the dispatch, so only the shell that dispatched it can name the run
-# to wait for.
+# Dispatches ONE ROR KBN pre-build for all versions of the matrix, then waits for it in the SAME
+# shell. The two steps must share a shell: the shared lib finds a dispatched run by its title, in the
+# seconds around the dispatch. Only the shell that dispatched the run can name it.
 #
 # Args: <elk versions> <target branch> <fallback branch> <build id>
 #   elk versions    — the `elk_versions` output of the matrix job (space-separated X.Y.Z)
 #   target branch   — branch to build the ROR KBN plugin from
 #   fallback branch — branch to use when the target branch is missing in the e2e repo
-#   build id        — E2E_BUILD_ID, as PUBLISHED by the matrix job; it names the images ordered here
+#   build id        — E2E_BUILD_ID, as PUBLISHED by the matrix job. It names the images ordered here
 order_e2e_kbn_images() {
   if [ "$#" -ne 4 ]; then
     echo "Usage: order_e2e_kbn_images <elk versions> <target branch> <fallback branch> <build id>"
@@ -252,27 +258,28 @@ order_e2e_kbn_images() {
     return 2
   fi
 
-  # How long to wait for the WHOLE order (one run builds the versions one after another). A wait
-  # that outlasts the job can report nothing: GitHub kills the runner at `timeout-minutes` and the
-  # job dies with an opaque "exceeded the maximum execution time" instead of the diagnosis below.
-  # So the caller sets this, and keeps it well under `timeout-minutes` on e2e_order_kbn_images in
-  # ci.yml, where both numbers sit side by side. This default is the fallback for local runs.
+  # How long to wait for the WHOLE order. One run builds the versions one after another.
+  # A wait that outlasts the job can report nothing. GitHub stops the runner at `timeout-minutes`,
+  # and the job dies with "exceeded the maximum execution time" instead of the diagnosis below.
+  # So the caller sets this value, and keeps it well below `timeout-minutes` on
+  # e2e_order_kbn_images in ci.yml, where the two numbers sit side by side.
+  # This default applies to local runs only.
   local WAIT_TIMEOUT=${ROR_KBN_WAIT_TIMEOUT_SECONDS:-7200}
   export ROR_KBN_WAIT_TIMEOUT_SECONDS=$WAIT_TIMEOUT
 
   echo ">>> Ordering e2e ROR KBN dev images: ELK [$ELK_VERSIONS], run tag: $RUN_TAG, wait up to ${WAIT_TIMEOUT}s"
 
-  # Clone the e2e repo only to load the shared dispatch and wait helpers (test jobs clone it
-  # separately, for the runner).
+  # Clone the e2e repo only to load the shared dispatch and wait helpers. The test jobs clone it
+  # again, for the runner.
   local E2E_DIR
   E2E_DIR=$(clone_e2e_tests_repo "$TARGET_BRANCH" "$FALLBACK_BRANCH") || return $?
-  # Drop the clone however this exits. The path is expanded into the trap now, because E2E_DIR is
-  # local and gone by the time the trap runs.
+  # Delete the clone on every exit path. The path is expanded into the trap now, because E2E_DIR is
+  # local and no longer exists when the trap runs.
   trap "rm -rf '$E2E_DIR'" EXIT
   load_kbn_prebuild_helpers "$E2E_DIR" || return $?
 
-  # One dispatch for every version. It is dispatched even if the image exists, so the per-run tag
-  # always gets applied.
+  # One dispatch for all versions. It is dispatched even if the image exists, so that the per-run tag
+  # is always applied.
   local STATUS=0
   dispatch_kbn_prebuild_image "$ELK_VERSIONS" "$TARGET_BRANCH" "$RUN_TAG" || STATUS=$?
   if [ "$STATUS" -ne 0 ]; then
@@ -280,8 +287,8 @@ order_e2e_kbn_images() {
     return "$STATUS"
   fi
 
-  # The wait follows ROR_KBN_PREBUILD_RUN_ID, which the dispatch set in this shell. It ends when the
-  # run ends, then checks the registry for every image.
+  # The wait follows ROR_KBN_PREBUILD_RUN_ID. The dispatch set it in this shell. The wait ends when
+  # the run ends. Then it checks the registry for every image.
   wait_for_kbn_prebuild_images "$ELK_VERSIONS" "$RUN_TAG" || STATUS=$?
   if [ "$STATUS" -ne 0 ]; then
     _report_kbn_order_failure wait "$STATUS" "${ROR_KBN_PREBUILD_RUN_URL:-}"
@@ -292,9 +299,9 @@ order_e2e_kbn_images() {
 # Entry point for the `build_e2e_es_image` task (the `e2e_build_es_images` job). Runs once per ELK
 # version, while the order job waits for the other repo's build.
 #
-# Publishes this repo's ROR ES dev image under the per-run alias tag, through the same helper the
-# standalone pre-build task uses. The sha-frozen-image skip applies: if the image for this commit
-# already exists, the helper only retags it in the registry.
+# Publishes this repo's ROR ES dev image under the per-run tag. It uses the same helper as the
+# standalone pre-build task, so the sha-frozen-image skip applies: if the image for this commit
+# already exists, the helper only adds the tag in the registry.
 # Args: <elk version> <build id>
 build_e2e_es_image() {
   if [ "$#" -ne 2 ]; then
@@ -350,13 +357,13 @@ run_e2e_against_dev_images() {
 }
 
 # Entry point for the `run_e2e_tests` task. Runs once per ELK version. It clones the e2e repo and
-# runs the suite. Both dev images are already in the registry: e2e_order_kbn_images verified the ROR
+# runs the suite. Both dev images are already in the registry: e2e_order_kbn_images checked the ROR
 # KBN one, e2e_build_es_images published the ROR ES one.
 # Args: <elk version> <target branch> <fallback branch> <build id>
 #   elk version     — ELK version to test (X.Y.Z)
 #   target branch   — branch for the e2e suite
 #   fallback branch — branch to use when target branch is missing in the e2e repo
-#   build id        — E2E_BUILD_ID (from the matrix job; do not re-derive it)
+#   build id        — E2E_BUILD_ID, from the matrix job. Do not derive it again
 run_e2e_tests() {
   if [ "$#" -ne 4 ]; then
     echo "Usage: run_e2e_tests <elk version> <target branch> <fallback branch> <build id>"

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -276,20 +276,42 @@ if [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
 
 fi
 
-# Runs once per pipeline: resolves each module's ELK version, publishes the test matrix, and
-# dispatches one ROR KBN pre-build for all versions.
-# Branches: ROR_KBN_TARGET_BRANCH and ROR_KBN_FALLBACK_BRANCH apply to the ROR KBN repo (not e2e).
-# FALLBACK defaults to empty on purpose: outside CI there is no base branch, and the fallback chain
-# in the e2e clone function already includes `develop` and `master`.
-if [[ $ROR_TASK == "prepare_e2e_kbn_images" ]]; then
-  prepare_e2e_kbn_images \
+# Runs once per pipeline: resolves each module's ELK version and publishes the test matrix, the ELK
+# version list and the build id. Keep it free of side effects: "re-run failed jobs" skips a green
+# job, so the build id and every image name survive a partial re-run.
+if [[ $ROR_TASK == "publish_e2e_matrix" ]]; then
+  publish_e2e_matrix \
     "${E2E_ES_MODULES:?E2E_ES_MODULES is not set}" \
-    "${ROR_KBN_TARGET_BRANCH:?ROR_KBN_TARGET_BRANCH is not set}" \
-    "${ROR_KBN_FALLBACK_BRANCH:-}" \
     "${E2E_BUILD_ID:?E2E_BUILD_ID is not set}"
 fi
 
-# Runs once per ELK version, after prepare_e2e_kbn_images. Branches (E2E_TARGET_BRANCH and
+# Runs once per pipeline: dispatches ONE ROR KBN pre-build for the whole version list and waits for
+# it in the same shell. A failed ROR KBN build therefore fails THIS job, and a re-run of this job
+# places a fresh order.
+# Branches: ROR_KBN_TARGET_BRANCH and ROR_KBN_FALLBACK_BRANCH apply to the ROR KBN repo (not e2e).
+# FALLBACK defaults to empty on purpose: outside CI there is no base branch, and the fallback chain
+# in the e2e clone function already includes `develop` and `master`.
+if [[ $ROR_TASK == "order_e2e_kbn_images" ]]; then
+  order_e2e_kbn_images \
+    "${E2E_ELK_VERSIONS:?E2E_ELK_VERSIONS is not set — in CI it comes from the elk_versions output of e2e_matrix}" \
+    "${ROR_KBN_TARGET_BRANCH:?ROR_KBN_TARGET_BRANCH is not set}" \
+    "${ROR_KBN_FALLBACK_BRANCH:-}" \
+    "${E2E_BUILD_ID:?E2E_BUILD_ID is not set — in CI it comes from the build_id output of e2e_matrix}"
+fi
+
+# Runs once per ELK version, while the order task waits: publishes this repo's ROR ES dev image under
+# the per-run alias tag. E2E_ELK_VERSION comes from the published matrix; if missing, it is resolved from
+# E2E_ES_MODULE as a fallback.
+if [[ $ROR_TASK == "build_e2e_es_image" ]]; then
+  if [ -z "${E2E_ELK_VERSION:-}" ]; then
+    E2E_ELK_VERSION=$(e2e_elk_version_for_module "${E2E_ES_MODULE:?neither E2E_ELK_VERSION nor E2E_ES_MODULE is set}")
+  fi
+  build_e2e_es_image \
+    "$E2E_ELK_VERSION" \
+    "${E2E_BUILD_ID:?E2E_BUILD_ID is not set — in CI it comes from the build_id output of e2e_matrix}"
+fi
+
+# Runs once per ELK version, after both image jobs. Branches (E2E_TARGET_BRANCH and
 # E2E_FALLBACK_BRANCH) apply to the e2e repo. E2E_ELK_VERSION comes from the published matrix; if
 # missing, it is resolved from E2E_ES_MODULE as a fallback.
 if [[ $ROR_TASK == "run_e2e_tests" ]]; then
@@ -300,5 +322,5 @@ if [[ $ROR_TASK == "run_e2e_tests" ]]; then
     "$E2E_ELK_VERSION" \
     "${E2E_TARGET_BRANCH:?E2E_TARGET_BRANCH is not set}" \
     "${E2E_FALLBACK_BRANCH:-}" \
-    "${E2E_BUILD_ID:?E2E_BUILD_ID is not set — in CI it comes from the build_id output of e2e_prepare}"
+    "${E2E_BUILD_ID:?E2E_BUILD_ID is not set — in CI it comes from the build_id output of e2e_matrix}"
 fi

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -276,18 +276,18 @@ if [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
 
 fi
 
-# Runs once per pipeline: resolves each module's ELK version and publishes the test matrix, the ELK
-# version list and the build id. Keep it free of side effects: "re-run failed jobs" skips a green
-# job, so the build id and every image name survive a partial re-run.
+# Runs once per pipeline. Finds each module's ELK version. Publishes the test matrix, the ELK
+# version list and the build id.
+# Keep this task free of side effects. "Re-run failed jobs" skips a green job, so the build id and
+# the image names must survive a partial re-run.
 if [[ $ROR_TASK == "publish_e2e_matrix" ]]; then
   publish_e2e_matrix \
     "${E2E_ES_MODULES:?E2E_ES_MODULES is not set}" \
     "${E2E_BUILD_ID:?E2E_BUILD_ID is not set}"
 fi
 
-# Runs once per pipeline: dispatches ONE ROR KBN pre-build for the whole version list and waits for
-# it in the same shell. A failed ROR KBN build therefore fails THIS job, and a re-run of this job
-# places a fresh order.
+# Runs once per pipeline. Dispatches ONE ROR KBN pre-build for all versions, then waits for it in
+# the same shell. A failed ROR KBN build fails THIS job. A re-run of this job places a new order.
 # Branches: ROR_KBN_TARGET_BRANCH and ROR_KBN_FALLBACK_BRANCH apply to the ROR KBN repo (not e2e).
 # FALLBACK defaults to empty on purpose: outside CI there is no base branch, and the fallback chain
 # in the e2e clone function already includes `develop` and `master`.
@@ -299,9 +299,9 @@ if [[ $ROR_TASK == "order_e2e_kbn_images" ]]; then
     "${E2E_BUILD_ID:?E2E_BUILD_ID is not set — in CI it comes from the build_id output of e2e_matrix}"
 fi
 
-# Runs once per ELK version, while the order task waits: publishes this repo's ROR ES dev image under
-# the per-run alias tag. E2E_ELK_VERSION comes from the published matrix; if missing, it is resolved from
-# E2E_ES_MODULE as a fallback.
+# Runs once per ELK version, while the order task waits. Publishes this repo's ROR ES dev image
+# under the per-run tag. E2E_ELK_VERSION comes from the published matrix. If it is missing, this
+# task derives it from E2E_ES_MODULE.
 if [[ $ROR_TASK == "build_e2e_es_image" ]]; then
   if [ -z "${E2E_ELK_VERSION:-}" ]; then
     E2E_ELK_VERSION=$(e2e_elk_version_for_module "${E2E_ES_MODULE:?neither E2E_ELK_VERSION nor E2E_ES_MODULE is set}")
@@ -311,9 +311,9 @@ if [[ $ROR_TASK == "build_e2e_es_image" ]]; then
     "${E2E_BUILD_ID:?E2E_BUILD_ID is not set — in CI it comes from the build_id output of e2e_matrix}"
 fi
 
-# Runs once per ELK version, after both image jobs. Branches (E2E_TARGET_BRANCH and
-# E2E_FALLBACK_BRANCH) apply to the e2e repo. E2E_ELK_VERSION comes from the published matrix; if
-# missing, it is resolved from E2E_ES_MODULE as a fallback.
+# Runs once per ELK version, after both image jobs. The branches (E2E_TARGET_BRANCH and
+# E2E_FALLBACK_BRANCH) apply to the e2e repo. E2E_ELK_VERSION comes from the published matrix. If it
+# is missing, this task derives it from E2E_ES_MODULE.
 if [[ $ROR_TASK == "run_e2e_tests" ]]; then
   if [ -z "${E2E_ELK_VERSION:-}" ]; then
     E2E_ELK_VERSION=$(e2e_elk_version_for_module "${E2E_ES_MODULE:?neither E2E_ELK_VERSION nor E2E_ES_MODULE is set}")


### PR DESCRIPTION
## The problem

`e2e_prepare` did two things. It resolved the e2e matrix, and it dispatched the ROR KBN dev image
build. It did not wait for that build. Each `e2e_tests` leg built the ROR ES image, and then waited
for the ROR KBN run itself.

That costs three things:

- **The blame lands in the wrong place.** A ROR KBN build that fails, times out or publishes nothing
  turns every `e2e_tests` leg red. The red job names the Cypress suite. The cause is in another repo.
- **Every leg repeats the same wait.** Three legs follow one run.
- **"Re-run failed jobs" cannot help.** It re-runs the test legs. A test leg cannot place a new order,
  so it waits for the run that already died.

## The change

```
e2e_matrix                     resolve versions once, publish the build id
   ├── e2e_order_kbn_images    dispatch the ROR KBN build, wait for it, verify the images  ─┐ in
   └── e2e_build_es_images     build + publish the ROR ES image, one job per module         ─┘ parallel
          └── e2e_tests        stack + Cypress only
```

- `e2e_matrix` resolves the newest ES version of every module and publishes the matrix, the ELK
  version list and the build id. It orders nothing and builds nothing. It keeps the toolchains
  container, because resolving a version is a Gradle call.
- `e2e_order_kbn_images` places one dispatch for the whole version list, waits for that run, and
  ends with a registry check of every image. It needs no toolchain: `gh`, `jq` and an authenticated
  docker are enough.
- `e2e_build_es_images` builds and pushes the ROR ES image, one job per module, through the same
  `publish_ror_es_prebuild_plugin` helper the standalone pre-build task uses. The sha-frozen-image
  skip still applies.
- `e2e_tests` clones the suite, brings up the stack and runs Cypress. Both images already exist.

## Why the dispatch and the wait stay in one job

- **The shared contract requires it.** A dispatch is not told which run it created. The lib finds the
  run by title, in a window around the dispatch. Only the dispatching shell can identify it.
- **"Re-run failed jobs" now does the right thing.** It re-runs the order job. That job dispatches
  again, and its lookup only considers runs created around the new dispatch. `e2e_matrix` is green
  and is not re-run, so the build id and every image name are unchanged, and the ES images from the
  first attempt stay valid.
- **A failure reads as one line.** `_report_kbn_order_failure` turns the shared lib's exit code into
  a sentence, in the log and in the job summary.

## Also here

- The ROR KBN wait scales with the version count, as before, but now has a cap
  (`ROR_KBN_WAIT_TIMEOUT_CAP_SECONDS`, 2 h). A wait that outlives its job reports nothing: GitHub
  kills the runner at `timeout-minutes`, and the diagnosis above is lost.
- `order_e2e_kbn_images` removes its e2e clone on every exit path.
- `ci/CI.md` describes the four jobs and the reasoning.

## Critical path

`max(local ES build, ROR KBN run)`, plus one runner handoff. The old shape was the same wall time in
the good case. This one differs when the ROR KBN build fails.

## Testing

CI on this PR is the test: it runs the whole e2e path. Please check that `e2e_order_kbn_images` and
`e2e_build_es_images` start together, and that the legs of `e2e_tests` start only after both.

## ROR KBN mirror change

https://github.com/sscarduzio/readonlyrest_kbn/pull/1030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Restructured end-to-end pipeline execution into separate matrix, image build, and test stages.
  * ES and Kibana images are prepared before end-to-end tests begin.
  * Improved build coordination, version handling, and failure reporting.
* **Documentation**
  * Updated CI documentation to describe the revised pipeline stages and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->