### PR TITLE
[RORDEV-2220] add code style and writing style conventions

### DIFF
--- a/.claude/skills/ror-dev-process/SKILL.md
+++ b/.claude/skills/ror-dev-process/SKILL.md
@@ -16,6 +16,7 @@ Source of truth: `beshu-tech/readonlyrest-internal/development_guide.md`. This s
   - `🚀**New** (ES) 7.9.0 support`
   - `🧐**Enhancement** (ES) full support for ES Snapshots and Restore APIs`
   - `🐞**Fix** (KBN) fix crash in error handling`
+- PR text, review comments and commit messages use the repo writing style: Simplified Technical English (ASD-STE100) plus Zinsser — `docs/dev/writing-style.md`
 - Pipelines must pass. Set the next pre-version before opening the PR.
 - PRs are squash-and-merged into `develop`; `master` carries stable versions only (mechanics: see the `ror-release` skill; internal architecture: `ror-internals`).
 - New ES version support: mirror missing ES artifacts with the main repo's **Mirror ES Libs** workflow, which has the required S3 credentials. The step that gates CI build/test is `supportedEsVersions` in the module's `gradle.properties`, not `ci/upload-es-artifacts.sh`. Full checklist: `ror-release` skill, "Supporting a new ES version".

--- a/.claude/skills/ror-pr-review/SKILL.md
+++ b/.claude/skills/ror-pr-review/SKILL.md
@@ -48,6 +48,7 @@ Hunt for these categories on **every** PR, not just security-flagged ones:
 - `-Xfatal-warnings` violations (unused imports/params/locals/privates)
 - Identical change applied to one `es{version}x` module but missed in siblings where the same code path exists
 - Direct imports of un-shaded dependency packages (should go through `tech.beshu.ror` prefix)
+- Comment defects (`docs/dev/code-style.md`): narrating the change ("no longer set here", "moved from X") instead of the current state; explaining a function at its call site instead of at its definition; restating self-describing code
 - `Future.successful(...)` wrappers around already-synchronous values inside `Task` flows (anti-pattern: just lift directly with `Task.now`/`Task.pure`)
 
 ## Output format
@@ -61,6 +62,7 @@ Hunt for these categories on **every** PR, not just security-flagged ones:
 - NO "What I checked" narrative, NO "What looks good" section, NO methodology recap, NO restating the PR description. Do the investigation; don't serialize it.
 - **Open questions**: only if the answer would change a finding; max 2.
 - Genuinely no issues? One line: `No issues found — verified <the 3–5 highest-risk things you checked>.` That line IS the required backing; never a bare "No issues found".
+- Write the review itself in the repo style: Simplified Technical English plus Zinsser (`docs/dev/writing-style.md`). One idea per sentence, active voice, no metaphor.
 - **Hard cap: ~30 lines / ~350 words total.** With many findings, keep every Critical/Warning full and compress Nits to one line each.
 
 ## When the PR is small / docs-only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ ES module entry point pattern: `es{version}x/src/main/scala/tech/beshu/ror/es/Re
 - **Strict compilation**: `-Xfatal-warnings` with unused imports/params/locals/privates checks — no warnings are acceptable
 - **License headers**: GNU GPL v3 headers required on all source files. Pre-commit hook runs `./gradlew license --rerun-tasks` automatically
 - **Code formatting**: scalafmt (Scala) + Google Java Format (Java) via Spotless. Pre-commit hook formats staged files automatically. Run `./gradlew formatCode` manually or `./gradlew formatCodeCheck` to verify.
+- **Comments**: a comment explains the current state, not the change that made it — history belongs to the commit message and the PR. Full rule: `docs/dev/code-style.md`
+- **Writing style**: comments, commit messages, PR descriptions, review comments and answers to the user all use Simplified Technical English (ASD-STE100) plus Zinsser — one idea per sentence, active voice, no metaphor. See `docs/dev/writing-style.md`
 - **Internal Scala APIs**: avoid `scala.runtime.ScalaRunTime._*` and other `_`-prefixed runtime methods — they are implementation details
 - **Plugin ZIP output**: `es{version}x/build/distributions/readonlyrest-{pluginVersion}_es{esVersion}.zip`
 

--- a/docs/dev/code-style.md
+++ b/docs/dev/code-style.md
@@ -1,0 +1,44 @@
+# Code style
+
+## Comments
+
+**A comment explains the current state, and only when the state is not obvious. It does not explain the change that made it.**
+
+History belongs to the commit message and the PR description. `git log -S <symbol>` finds it there, forever, with the diff next to it. A comment that tells the story of a line that no longer exists gets no such support. Six months later nobody knows if it is still true.
+
+Example — a comment that tells the story of a line removed from `.github/workflows/ci.yml`:
+
+```yaml
+# Bad: the reader sees only that the variable is absent, which is the normal state.
+# AGENT_ISSELFHOSTED is deliberately NOT set here any more. Its only reader is
+# mirror-es-libs.yml, publish-pre-builds.yml, and the three release jobs...
+```
+
+```bash
+# Good: the rule sits in ci/free-host-disk.sh, at the guard that enforces it.
+# The disk reclaim runs only on GitHub-hosted runners.
+if [[ -n "${AGENT_ISSELFHOSTED:-}" ]]; then exit 0; fi
+```
+
+### Where a comment goes
+
+Put a comment at the code it describes. Do not explain how a function works at the place that calls it. The reader of the function must see that comment, and the caller changes more often than the logic.
+
+The same holds for a rule: put it at the code that enforces it, not at the place the rule once touched. Code and comment cannot drift apart there.
+
+Do not name other files in a comment when you can avoid it. Each rename makes the comment wrong, and no build step fails.
+
+### What deserves a comment
+
+Comment the things a reader cannot get from the code:
+
+- The non-obvious: why this value, why this order, which constraint forbids the simpler form.
+- A workaround: an ES-version quirk, an upstream bug, a limit you cannot remove. Say why the code must be like this, and what makes it safe to delete later.
+
+Do not comment self-describing code. A comment that repeats the line above it adds a second thing to keep true.
+
+Unreadable code is a defect, not a subject for a comment. Fix the code first — a better name, a smaller function, an early return. Comment it only when you cannot fix it now, and then explain the constraint that keeps it this way.
+
+## Language
+
+Every comment follows the repo writing style: `writing-style.md`.

--- a/docs/dev/code-style.md
+++ b/docs/dev/code-style.md
@@ -6,18 +6,20 @@
 
 History belongs to the commit message and the PR description. `git log -S <symbol>` finds it there, forever, with the diff next to it. A comment that tells the story of a line that no longer exists gets no such support. Six months later nobody knows if it is still true.
 
-Example — a comment that tells the story of a line removed from `.github/workflows/ci.yml`:
+Example — a comment that tells the story of a line in `.github/workflows/ci.yml`:
 
 ```yaml
-# Bad: the reader sees only that the variable is absent, which is the normal state.
-# AGENT_ISSELFHOSTED is deliberately NOT set here any more. Its only reader is
-# mirror-es-libs.yml, publish-pre-builds.yml, and the three release jobs...
+# Bad: the reader sees a line that is already there, plus a story about how it got there.
+# AGENT_ISSELFHOSTED was moved up to the workflow level in an earlier PR, because the
+# jobs kept forgetting it. Its only reader is ci/free-host-disk.sh...
+AGENT_ISSELFHOSTED: '1'
 ```
 
 ```bash
-# Good: the rule sits in ci/free-host-disk.sh, at the guard that enforces it.
-# The disk reclaim runs only on GitHub-hosted runners.
-if [[ -n "${AGENT_ISSELFHOSTED:-}" ]]; then exit 0; fi
+# Good: the rule sits at the guard that enforces it.
+#   shared self-hosted   the system directories belong to the box, so never touch them.
+elif [ "${AGENT_ISSELFHOSTED:-0}" != "1" ]; then
+  echo ">>> [host] freeing preinstalled toolchains to fit ES image builds"
 ```
 
 ### Where a comment goes

--- a/docs/dev/writing-style.md
+++ b/docs/dev/writing-style.md
@@ -1,0 +1,14 @@
+# Writing style
+
+The same language rule covers every text we write about the code: comments, commit messages, PR titles and descriptions, review comments, docs, and Jira notes.
+
+Write in Simplified Technical English (ASD-STE100). Follow Zinsser's four principles: simplicity, brevity, clarity, humanity.
+
+**Be concise. Say it once, then stop.** The shortest text that carries the fact wins. A comment takes one to three lines. A PR description fits on one screen. Length is not proof of care — the reader pays for every line.
+
+- One idea per sentence. A descriptive sentence takes at most 25 words, a procedural one at most 20.
+- Active voice, present tense. Say who does what.
+- Use the same word for the same thing each time. Keep our technical nouns (dispatch, run tag, leg).
+- Cut every word that does nothing. Delete the sentence that only restates the one before it.
+- No metaphor. Say what the code does, not what it "owes" or "reaches into".
+- Write for a person, not for a specification.


### PR DESCRIPTION
No changelog entry: the change adds team documentation. A client cannot see it.

## What

- `docs/dev/code-style.md` — where a comment goes, and what deserves one. A comment describes the current state, not the change that made it. History belongs to the commit message and the PR.
- `docs/dev/writing-style.md` — the language for every text we write about the code: Simplified Technical English (ASD-STE100) and Zinsser's four principles.

Both docs are linked from `CLAUDE.md`, from the `ror-dev-process` skill and from the `ror-pr-review` skill. The review checklist now names the comment defects, so a reviewer flags them without a discussion.

## Why

The rules come from this review discussion: https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/pull/1368#discussion_r3948461591

We have no written convention, so the same comment repeats on each PR. The docs end that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a writing style guide for clear, concise, consistent technical content.
  - Added guidance for code comments, including when comments are appropriate and what information they should provide.
  - Updated contribution and review guidance for pull request descriptions, review comments, commit messages, documentation, and related project text.
  - Added standards for active voice, consistent terminology, short sentences, and avoiding unnecessary words or metaphors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->