### PR TITLE
[RORDEV-2220] Suppress false-positive rest-client matches for CVE-2026-56143, CVE-2026-72656

### DIFF
--- a/suppressions_cve.xml
+++ b/suppressions_cve.xml
@@ -90,6 +90,8 @@ False positive: CVE-2021-34364 is for "Refined GitHub" (browser extension), not 
         <cve>CVE-2026-72649</cve>
         <cve>CVE-2026-78607</cve>
         <cve>CVE-2026-78605</cve>
+        <cve>CVE-2026-56143</cve>
+        <cve>CVE-2026-72656</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -151,6 +153,8 @@ False positive: CVE-2021-34364 is for "Refined GitHub" (browser extension), not 
         <cve>CVE-2026-72649</cve>
         <cve>CVE-2026-78607</cve>
         <cve>CVE-2026-78605</cve>
+        <cve>CVE-2026-56143</cve>
+        <cve>CVE-2026-72656</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
`cve_check` is red on every open PR (for example [run 34209079888](https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/actions/runs/34209079888/job/102005862971), 19 `es*x` modules fail `dependencyCheckAnalyze`). Cause: two new Elasticsearch **server** CVEs that dependency-check maps onto the client jars via the shared `cpe:2.3:a:elastic:elasticsearch` CPE:

- CVE-2026-56143 — unbounded allocation denial of service (server, CPE range 8.0.0-8.19.20 and 9.0.0-9.3.0)
- CVE-2026-72656 — ES|QL query heap exhaustion (server, CPE range 8.11.0-8.18.0)

Neither code path ships in `elasticsearch-rest-client` or `transport-netty4-client`. Added the two CVEs to the two existing false-positive suppression blocks that exist for exactly this pattern ("The CVEs affect the org.elasticsearch:elasticsearch package, which is not a dependency of ...").

`tests-utils` also prints CVE warnings, but its analyze task does not fail. It stays out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability suppression rules for two additional CVEs affecting Elasticsearch client components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->