### PR TITLE
[RORDEV-2220] document which branch a PR targets

### DIFF
--- a/.claude/skills/ror-dev-process/SKILL.md
+++ b/.claude/skills/ror-dev-process/SKILL.md
@@ -18,7 +18,7 @@ Source of truth: `beshu-tech/readonlyrest-internal/development_guide.md`. This s
   - `🐞**Fix** (KBN) fix crash in error handling`
 - PR text, review comments and commit messages use the repo writing style: Simplified Technical English (ASD-STE100) plus Zinsser — `docs/dev/writing-style.md`
 - Pipelines must pass. Set the next pre-version before opening the PR.
-- PRs are squash-and-merged into `develop`; `master` carries stable versions only (mechanics: see the `ror-release` skill; internal architecture: `ror-internals`).
+- PRs are squash-and-merged. Which branch a PR targets, and what to do after a merge to `master`: `docs/dev/branching.md` (version mechanics: `ror-release` skill; internal architecture: `ror-internals`).
 - New ES version support: mirror missing ES artifacts with the main repo's **Mirror ES Libs** workflow, which has the required S3 credentials. The step that gates CI build/test is `supportedEsVersions` in the module's `gradle.properties`, not `ci/upload-es-artifacts.sh`. Full checklist: `ror-release` skill, "Supporting a new ES version".
 
 **CI checks the first two conventions** (`PR Conventions` workflow): the Jira key in the title, and a changelog entry when the PR changes production sources or dependencies. Both changelog forms above are accepted. Run it yourself before opening the PR:

--- a/.claude/skills/ror-release/SKILL.md
+++ b/.claude/skills/ror-release/SKILL.md
@@ -11,7 +11,7 @@ Source: `beshu-tech/readonlyrest-internal` (`versioning.md`, `releasing.md`), re
 
 - Stable versions are semver `X.Y.Z`; unstable are `X.Y.Z-preN`. Both live in `/gradle.properties` → `pluginVersion`.
 - ES and Kibana plugins are released **in lockstep**: customers must install the same ROR version on both sides. Never release one without the other.
-- `master` holds **stable versions only** — a `-pre` version on master breaks CI. `develop` takes `-pre` versions; PRs are squash-and-merged into it.
+- `master` holds **stable versions only** — a `-pre` version on master breaks CI. `develop` takes `-pre` versions. Which branch a PR targets: `docs/dev/branching.md`.
 
 ## pluginVersion vs publishedPluginVersion (the iron rule)
 

--- a/.claude/skills/ror-release/SKILL.md
+++ b/.claude/skills/ror-release/SKILL.md
@@ -39,6 +39,7 @@ Verified against recent PRs (e.g. #1257). Files touched:
 Test locally first: `./gradlew integration-tests:test '-PesModule=es{NN}x'`.
 
 - **Adapt code keeping old-version compatibility at all costs.** Only when the new ES introduces true breaking changes: copy the latest module (`cp -r es93x es94x`), add it to `settings.gradle` and the files above.
+- The PR targets `master`, not `develop` — customers run released ES versions, so the support ships in a patch release. Merge `master` back into `develop` afterwards (`docs/dev/branching.md`).
 - The PR must come from the main repo, **not a fork** (artifact upload needs S3 credentials).
 - For unreleased/snapshot ES versions: build ES from source (`elastic/elasticsearch` repo) and publish deps to mavenLocal with `./gradlew clean publishElasticPublicationToMavenLocal` (needed jars: `elasticsearch` SDK, `transport-netty4`, `elasticsearch-plugin-classloader`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Settings can be loaded from a local file (`FileSettingsSource`) or from an ES in
 
 - Main branches: `master` (stable releases), `develop` (active development)
 - Feature branches: `feature/RORDEV-{issue}` pattern
-- PRs target `develop`
+- Which branch a PR targets, and what to do after a merge to `master`: `docs/dev/branching.md`
 
 ## Code Review
 

--- a/docs/dev/branching.md
+++ b/docs/dev/branching.md
@@ -3,7 +3,7 @@
 ## The two long-lived branches
 
 - `master` carries the released code. Its version in `gradle.properties` is always stable (`X.Y.Z`).
-- `develop` carries the code under development. Its version is always unstable (`X.Y.Z-preN`).
+- `develop` carries the code under development. Its version becomes unstable (`X.Y.Z-preN`) with the first change after a release, and stays unstable until the next release.
 
 A release merges `develop` into `master`. Version and artifact mechanics live in the `ror-release` skill.
 
@@ -15,7 +15,7 @@ A release merges `develop` into `master`. Version and artifact mechanics live in
 
 1. **Support for a new ES version.** Customers run released ES versions, so the support ships in a patch release. Most PRs to `master` are of this kind.
 2. **A fix that must ship immediately.** The released version has the bug, so the fix goes out in a patch release instead of waiting for the next feature release.
-3. **A CVE fix, or a suppression of a false positive in the CVE scan.** The scan runs on `master`, so a suppression that only lives on `develop` does not stop the alert.
+3. **A CVE fix, or a suppression of a false positive in the CVE scan.** The scan runs on both branches. A fix or a suppression that only lives on `develop` leaves `master` alerting until the next release.
 4. **A pipeline, build or publishing change.** The release runs from `master`, so the branch needs the current pipeline.
 5. **Docs and examples that describe the released version.**
 

--- a/docs/dev/branching.md
+++ b/docs/dev/branching.md
@@ -1,0 +1,37 @@
+# Branching
+
+## The two long-lived branches
+
+- `master` carries the released code. Its version in `gradle.properties` is always stable (`X.Y.Z`).
+- `develop` carries the code under development. Its version is always unstable (`X.Y.Z-preN`).
+
+A release merges `develop` into `master`. Version and artifact mechanics live in the `ror-release` skill.
+
+## Which branch does a PR target?
+
+**Target `develop`.** Every new feature, every change of behaviour, and every bugfix for code that is not released yet goes to `develop`.
+
+**Target `master` when the change belongs on the released code now, not at the next release.** These cases qualify:
+
+1. **Support for a new ES version.** Customers run released ES versions, so the support ships in a patch release. Most PRs to `master` are of this kind.
+2. **A fix that must ship immediately.** The released version has the bug, so the fix goes out in a patch release instead of waiting for the next feature release.
+3. **A CVE fix, or a suppression of a false positive in the CVE scan.** The scan runs on `master`, so a suppression that only lives on `develop` does not stop the alert.
+4. **A pipeline, build or publishing change.** The release runs from `master`, so the branch needs the current pipeline.
+5. **Docs and examples that describe the released version.**
+
+We merge these to `master` first because `master` must carry them as soon as they are ready. The branch produces the next release, and the pipeline and the CVE scan run on it.
+
+Everything else targets `develop`. Two questions decide a case that is not on the list. Does the released version need the change now? Does the change leave the released code untouched? If both answers are no, the PR targets `develop`.
+
+## After a merge to master
+
+Merge `master` back into `develop`:
+
+```bash
+git checkout develop && git pull
+git merge origin/master
+```
+
+The change must exist on both branches. Without the merge back, the next release drops it.
+
+When the two branches have moved apart too far for one merge, open one PR per branch. Say so in both descriptions and link them.


### PR DESCRIPTION
Follows the discussion in https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin/pull/1375#issuecomment-5585415085

We keep two long-lived branches, and nobody wrote down how to choose between them. `CLAUDE.md` said only "PRs target `develop`", which is wrong for most of the PRs that reach `master`.

`docs/dev/branching.md` is new. It names the five cases that belong on `master`, says why we put them there early, and gives the merge back into `develop`. I read the merged PRs that target `master` to build the list: new ES version support dominates, followed by pipeline and publishing work, CVE fixes and suppressions, fixes that must ship at once, and docs about the released version.

`CLAUDE.md` and the two skills now link to the file instead of repeating it.