### PR TITLE
ci: e2e legs on GitHub-hosted runners, and a disk reclaim that detects its runner

### DIFF
--- a/.github/workflows/build-toolchains-image.yml
+++ b/.github/workflows/build-toolchains-image.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: Read the toolchains image tag
         run: |
           . ci/toolchains/image.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,12 +641,12 @@ jobs:
       needs.e2e_build_es_images.result == 'success' &&
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
-    runs-on: ubicloud-standard-4
+    # Not a container: job, so ci/free-host-disk.sh below can see the preinstalled toolchains.
+    runs-on: ubuntu-latest   # free for public repos (4cpu/16GB)
     timeout-minutes: 120
     name: e2e_${{ matrix.module }}
     strategy:
       fail-fast: false
-      max-parallel: 99
       matrix: ${{ fromJSON(needs.e2e_matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,7 +641,6 @@ jobs:
       needs.e2e_build_es_images.result == 'success' &&
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
-    # No container: the disk-reclaim step below must see the host's preinstalled toolchains.
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB)
     timeout-minutes: 120
     name: e2e_${{ matrix.module }}
@@ -782,11 +781,6 @@ jobs:
     runs-on: &self_hosted_runner [self-hosted, Linux, X64]
     container: *toolchains_container
     timeout-minutes: 600
-    # The job container gets the HOST docker socket, and that daemon also serves the readonlyrest_kbn
-    # runners on the same box. Tell the pipeline not to use host-wide docker cleanups. See
-    # cleanup_docker_and_build in ci/publish-ror-plugins.sh.
-    env: &shared_docker_host
-      ROR_SHARED_DOCKER_HOST: '1'
     strategy:
       fail-fast: false
       # At most 2 legs at a time: two runners, ~4 GB each, and the box is shared with other repos.
@@ -846,7 +840,6 @@ jobs:
     # Generous on purpose: a killed leg leaves the release without that ES major's artifacts,
     # and a self-hosted minute costs nothing.
     timeout-minutes: 600
-    env: *shared_docker_host
     strategy:
       fail-fast: false
       # Same bound as upload_pre_ror — see the note there.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - id: flags
         env:
           REF: ${{ github.head_ref || github.ref_name }}
@@ -167,6 +169,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: Verify baked Gradle home
         run: |
           set -e
@@ -198,6 +202,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: ${{ matrix.ROR_TASK }}
         uses: ./.github/actions/cve-check
         with:
@@ -228,6 +234,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: ${{ matrix.ROR_TASK }}
         env:
           ROR_TASK: ${{ matrix.ROR_TASK }}
@@ -252,6 +260,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: core_tests
         env:
           ROR_TASK: core_tests
@@ -760,6 +770,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - id: release_check
         run: |
           IS_RELEASE=true
@@ -791,6 +803,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: ${{ matrix.ROR_TASK }}
         env:
           ROR_S3_ENDPOINT_URL: ${{ vars.ROR_S3_ENDPOINT_URL }}
@@ -848,6 +862,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: true }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: ${{ matrix.ROR_TASK }}
         env:
           ROR_S3_ENDPOINT_URL: ${{ vars.ROR_S3_ENDPOINT_URL }}
@@ -895,6 +911,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: Install PGP signing key
         env:
           PGP_SECRET_KEY_B64: ${{ secrets.PGP_SECRET_KEY_B64 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -783,8 +783,8 @@ jobs:
     timeout-minutes: 600
     strategy:
       fail-fast: false
-      # At most 2 legs at a time: two runners, ~4 GB each, and the box is shared with other repos.
-      # GitHub queues the rest — this bound is really set by how many self-hosted runners are registered.
+      # One below the number of self-hosted runners, so a release never takes every slot: the ES
+      # pre-build that two repos wait on must always find one. See ci/self-hosted-runner.md.
       max-parallel: 2
       matrix:
         ROR_TASK: [ upload_pre_es9xx, upload_pre_es8xx, upload_pre_es7xx, upload_pre_es6xx ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,6 +551,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: publish_e2e_matrix
         id: matrix
         env:
@@ -580,6 +582,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: order_e2e_kbn_images
         id: order
         env:
@@ -608,7 +612,6 @@ jobs:
       needs.e2e_matrix.result == 'success' &&
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
-    # Not a container: job, so ci/free-host-disk.sh below can see the preinstalled toolchains.
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB)
     timeout-minutes: 120
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,6 +725,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
       - name: ${{ matrix.ROR_TASK }}
         env:
           ROR_TASK: ${{ matrix.ROR_TASK }}
@@ -783,8 +785,6 @@ jobs:
     timeout-minutes: 600
     strategy:
       fail-fast: false
-      # One below the number of self-hosted runners, so a release never takes every slot: the ES
-      # pre-build that two repos wait on must always find one. See ci/self-hosted-runner.md.
       max-parallel: 2
       matrix:
         ROR_TASK: [ upload_pre_es9xx, upload_pre_es8xx, upload_pre_es7xx, upload_pre_es6xx ]
@@ -842,7 +842,6 @@ jobs:
     timeout-minutes: 600
     strategy:
       fail-fast: false
-      # Same bound as upload_pre_ror — see the note there.
       max-parallel: 2
       matrix:
         ROR_TASK: [ release_es9xx, release_es8xx, release_es7xx, release_es6xx ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,7 +641,7 @@ jobs:
       needs.e2e_build_es_images.result == 'success' &&
       needs.setup.outputs.e2e_modules != '[]' &&
       (github.event_name != 'workflow_dispatch' || needs.setup.outputs.action == 'run_e2e_tests')
-    # Not a container: job, so ci/free-host-disk.sh below can see the preinstalled toolchains.
+    # No container: the disk-reclaim step below must see the host's preinstalled toolchains.
     runs-on: ubuntu-latest   # free for public repos (4cpu/16GB)
     timeout-minutes: 120
     name: e2e_${{ matrix.module }}

--- a/.github/workflows/mirror-es-libs.yml
+++ b/.github/workflows/mirror-es-libs.yml
@@ -34,8 +34,6 @@ jobs:
     env:
       GRADLE_USER_HOME: ${{ github.workspace }}/.gradle-home
       GRADLE_OPTS: '-Dorg.gradle.java.installations.auto-download=true'
-      AGENT_ISSELFHOSTED: '1'
-      ROR_SHARED_DOCKER_HOST: '1'   # shared box: ci/free-host-disk.sh prunes conservatively
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { persist-credentials: false }

--- a/.github/workflows/publish-pre-builds.yml
+++ b/.github/workflows/publish-pre-builds.yml
@@ -48,11 +48,6 @@ jobs:
     env:
       GRADLE_USER_HOME: ${{ github.workspace }}/.gradle-home
       GRADLE_OPTS: '-Dorg.gradle.java.installations.auto-download=true'
-      AGENT_ISSELFHOSTED: '1'
-      # This job talks to the box's docker daemon directly, and that daemon also serves the
-      # readonlyrest_kbn runners. No host-wide `docker system prune -a`, no removing containers that
-      # are not ours. See ci/run-pipeline.sh and ci/publish-ror-plugins.sh.
-      ROR_SHARED_DOCKER_HOST: '1'
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 0, persist-credentials: false }

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -27,6 +27,10 @@ The release path (`upload_pre_ror`, `release_ror`, `publish_mvn`) and the standa
 `mirror-es-libs.yml` and `publish-pre-builds.yml` workflows run on the **self-hosted** box —
 they push images and run for hours. `build-toolchains-image.yml` stays on `ubicloud-standard-4`.
 
+**Every job calls `ci/free-host-disk.sh` right after checkout**, including a new one. The script
+detects the runner and decides whether to reclaim disk; a job never decides that for it. On a
+Windows job there is no equivalent step.
+
 Every Linux job calls `ci/run-pipeline.sh` with a `ROR_TASK` — the scripts in this
 directory contain the build logic; the workflow only orchestrates.
 

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -5,6 +5,10 @@
 # lib is sourced rather than run (`source ci/ci-lib.sh && reap_ci_job_containers` resolved it to ".").
 CI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
+# True on a box whose Docker daemon and system directories other runners share. The runner
+# provisioning writes the marker (ci/self-hosted-runner.md); no job sets it.
+is_shared_docker_host() { [ -e /etc/ror-shared-docker-host ]; }
+
 # Reads one key from gradle.properties, which holds the build's own values. The file sits beside this
 # one, so the caller's working directory does not matter.
 #

--- a/ci/ci-lib.sh
+++ b/ci/ci-lib.sh
@@ -5,9 +5,8 @@
 # lib is sourced rather than run (`source ci/ci-lib.sh && reap_ci_job_containers` resolved it to ".").
 CI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-# True on a box whose Docker daemon and system directories other runners share. The runner
-# provisioning writes the marker (ci/self-hosted-runner.md); no job sets it.
-is_shared_docker_host() { [ -e /etc/ror-shared-docker-host ]; }
+# shellcheck source=ci/runner-detect.sh
+source "$CI_DIR/runner-detect.sh"
 
 # Reads one key from gradle.properties, which holds the build's own values. The file sits beside this
 # one, so the caller's working directory does not matter.

--- a/ci/free-host-disk.sh
+++ b/ci/free-host-disk.sh
@@ -1,36 +1,28 @@
 #!/usr/bin/env bash
-# Make room for ES image builds and ES data dirs. What there is to reclaim depends on the runner:
+# Make room for ES image builds and ES data dirs. The script detects where it runs; no job tells it.
 #
-#   shared self-hosted   the system directories belong to the box, so never touch them. Docker
-#                        garbage from earlier runs is ours to reclaim — but only the parts no
-#                        other repo's runner can be using: dangling layers and build cache, never
-#                        `-a`, never a container we did not start. Selected by ROR_SHARED_DOCKER_HOST=1.
-#   ephemeral hosted VM  reclaim both levers below, but only when the disk is actually tight.
-#                        The VM dies after the job anyway. Selected by RUNNER_ENVIRONMENT=github-hosted.
-#   anything else        reclaim nothing. A developer shell, `act`, or an unlabelled self-hosted
-#                        job must never lose its docker images to this script.
+#   shared self-hosted box   /etc/ror-shared-docker-host exists (written when the runner is
+#                            provisioned, see ci/self-hosted-runner.md). The system directories and
+#                            the Docker daemon belong to every runner on the box, so reclaim only
+#                            dangling layers and build cache.
+#   GitHub-hosted VM         RUNNER_ENVIRONMENT=github-hosted, set by the runner itself. The VM dies
+#                            with the job, so delete the preinstalled toolchains and prune the whole
+#                            daemon, but only when the disk is tight.
+#   anything else            reclaim nothing.
 #
-# On an ephemeral runner two shapes of job call this, and they need different levers:
+# Inside a `container:` job the host toolchains are not on this filesystem, but the bind-mounted
+# /var/run/docker.sock controls the host daemon, so a throwaway container with the host root mounted
+# deletes them. The github-hosted guard covers that path too: it removes system directories.
 #
-#   * bare runner (e2e_tests): the preinstalled toolchains are visible, so deleting them is what
-#     reclaims space. GitHub's ubuntu image ships ~25 GB of dotnet, android, ghc, swift and
-#     hostedtoolcache that no ROR job uses.
-#   * container: job (it_linux): the steps run inside the toolchains image, where those host
-#     directories do not exist. What IS reachable is the runner's Docker daemon, over the
-#     bind-mounted /var/run/docker.sock — and that daemon's storage lives on the host's /, the
-#     same filesystem the ES images and the ES data dirs fill up. Images in use by the running job
-#     container (the toolchains image itself) are never removed by a prune.
-#
-# Nothing here fails the job. A reclaim is an optimisation; if the disk is genuinely full the build
-# says so with a better message than this script could.
+# Nothing here fails the job. A reclaim is an optimisation; a full disk fails the build with a better
+# message than this script could write.
 set -euo pipefail
 
 # Below this many GB free, the levers are worth their wall time. Above it they are not: a reclaim
 # costs minutes, so do not run one for space no job is short of.
 ROR_DISK_RECLAIM_THRESHOLD_GB="${ROR_DISK_RECLAIM_THRESHOLD_GB:-40}"
 
-# The shared box comes first: it is self-hosted too, so the guard below would otherwise catch it.
-if [ "${ROR_SHARED_DOCKER_HOST:-0}" = "1" ]; then
+if [ -e /etc/ror-shared-docker-host ]; then
   echo ">>> [host] shared self-hosted box: reclaiming only our own docker leftovers"
   df -h / || true
   docker image prune -f || true
@@ -40,12 +32,9 @@ if [ "${ROR_SHARED_DOCKER_HOST:-0}" = "1" ]; then
   exit 0
 fi
 
-# Fail closed: reclaim only when the runner proves it is an ephemeral GitHub-hosted VM.
-# RUNNER_ENVIRONMENT is set by the Actions runner itself and is "github-hosted" only on GitHub's
-# own VMs. This script deletes system directories and prunes a whole Docker daemon, so "unknown"
-# has to mean "skip". Do not set AGENT_ISSELFHOSTED workflow-wide: it turns this script off in
-# every job that inherits it.
-if [ "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ] || [ "${AGENT_ISSELFHOSTED:-0}" = "1" ]; then
+# Fail closed: everything below deletes system directories or prunes a whole daemon, so "unknown"
+# means "skip".
+if [ "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ]; then
   echo ">>> not a GitHub-hosted runner (RUNNER_ENVIRONMENT='${RUNNER_ENVIRONMENT:-unset}') - skipping disk reclaim"
   exit 0
 fi
@@ -66,19 +55,23 @@ if [ "$avail_gb" -ge "$ROR_DISK_RECLAIM_THRESHOLD_GB" ]; then
   exit 0
 fi
 
-# --- lever 1: preinstalled toolchains (bare-runner jobs) ---------------------------------------
+# GitHub's ubuntu image ships ~25 GB of toolchains no ROR job uses.
+TOOLCHAIN_DIRS='/usr/share/dotnet /usr/local/.ghcup /usr/share/swift /usr/local/share/powershell /usr/local/julia* /opt/microsoft /opt/az /usr/share/chromium /usr/local/lib/android /opt/ghc /usr/local/share/boost /opt/hostedtoolcache'
+
+# --- lever 1: preinstalled toolchains ---------------------------------------------------------
 if [ -d /usr/share/dotnet ] || [ -d /usr/local/lib/android ] || [ -d /opt/hostedtoolcache ]; then
-  echo ">>> [host] freeing preinstalled toolchains to fit ES image builds"
-  sudo rm -rf \
-    /usr/share/dotnet /usr/local/.ghcup /usr/share/swift \
-    /usr/local/share/powershell /usr/local/julia* \
-    /opt/microsoft /opt/az /usr/share/chromium \
-    /usr/local/lib/android /opt/ghc /usr/local/share/boost /opt/hostedtoolcache 2>/dev/null || true
+  echo ">>> [host] freeing preinstalled toolchains"
+  # shellcheck disable=SC2086
+  sudo rm -rf $TOOLCHAIN_DIRS 2>/dev/null || true
+elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  # A container: job. The host root is reachable through the daemon the socket controls.
+  echo ">>> [host] container job: freeing the host's preinstalled toolchains through the docker daemon"
+  docker run --rm -v /:/host alpine sh -c "cd /host && rm -rf $(printf '%s ' $TOOLCHAIN_DIRS | sed 's|/|./|; s| /| ./|g')" 2>/dev/null || true
 else
-  echo ">>> [host] no preinstalled toolchain dirs visible from here (container: job) - skipping"
+  echo ">>> [host] no toolchain dirs here and no docker daemon - skipping lever 1"
 fi
 
-# --- lever 2: the runner's Docker daemon (reachable from both shapes) ---------------------------
+# --- lever 2: the runner's Docker daemon ------------------------------------------------------
 # Volumes are deliberately NOT pruned: testcontainers may already hold one by the time a later
 # call runs, and the space is in the images and the build cache anyway.
 if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then

--- a/ci/free-host-disk.sh
+++ b/ci/free-host-disk.sh
@@ -17,12 +17,14 @@
 # Nothing here fails the job. A reclaim is an optimisation; a full disk fails the build with a better
 # message than this script could write.
 set -euo pipefail
+# shellcheck source=ci/runner-detect.sh
+source "$(dirname "${BASH_SOURCE[0]}")/runner-detect.sh"
 
 # Below this many GB free, the levers are worth their wall time. Above it they are not: a reclaim
 # costs minutes, so do not run one for space no job is short of.
 ROR_DISK_RECLAIM_THRESHOLD_GB="${ROR_DISK_RECLAIM_THRESHOLD_GB:-40}"
 
-if [ -e /etc/ror-shared-docker-host ]; then
+if is_shared_docker_host; then
   echo ">>> [host] shared self-hosted box: reclaiming only our own docker leftovers"
   df -h / || true
   docker image prune -f || true

--- a/ci/free-host-disk.sh
+++ b/ci/free-host-disk.sh
@@ -1,21 +1,15 @@
 #!/usr/bin/env bash
-# Make room for ES image builds and ES data dirs. The script detects where it runs; no job tells it.
+# Make room for ES image builds and ES data dirs. Every job calls it; the script decides what to do:
 #
-#   shared self-hosted box   /etc/ror-shared-docker-host exists (written when the runner is
-#                            provisioned, see ci/self-hosted-runner.md). The system directories and
-#                            the Docker daemon belong to every runner on the box, so reclaim only
-#                            dangling layers and build cache.
-#   GitHub-hosted VM         RUNNER_ENVIRONMENT=github-hosted, set by the runner itself. The VM dies
-#                            with the job, so delete the preinstalled toolchains and prune the whole
-#                            daemon, but only when the disk is tight.
-#   anything else            reclaim nothing.
+#   shared self-hosted box   reclaim dangling layers and build cache only. The daemon and the
+#                            system directories belong to every runner on the box.
+#   GitHub-hosted VM         delete the preinstalled toolchains and prune the whole daemon, when the
+#                            disk is tight. The VM dies with the job.
+#   anything else            nothing.
 #
 # Inside a `container:` job the host toolchains are not on this filesystem, but the bind-mounted
-# /var/run/docker.sock controls the host daemon, so a throwaway container with the host root mounted
-# deletes them. The github-hosted guard covers that path too: it removes system directories.
-#
-# Nothing here fails the job. A reclaim is an optimisation; a full disk fails the build with a better
-# message than this script could write.
+# /var/run/docker.sock controls the host daemon, so a throwaway container with the host root
+# mounted deletes them. Nothing here fails the job.
 set -euo pipefail
 # shellcheck source=ci/runner-detect.sh
 source "$(dirname "${BASH_SOURCE[0]}")/runner-detect.sh"

--- a/ci/publish-ror-plugins.sh
+++ b/ci/publish-ror-plugins.sh
@@ -4,11 +4,9 @@
 # Sourced by ci/run-pipeline.sh.
 
 cleanup_docker_and_build() {
-  # ROR_SHARED_DOCKER_HOST=1 means the docker daemon is not ours alone: on the self-hosted box it
-  # also serves the readonlyrest_kbn runners, which hold running ELK stacks and images they built.
-  # The full sweep below would delete every one of them and fail their jobs, so reclaim only what
-  # this build itself left behind — dangling layers and build cache. Nothing else on the daemon.
-  if [ "${ROR_SHARED_DOCKER_HOST:-0}" = "1" ]; then
+  # On the shared box the daemon also serves the readonlyrest_kbn runners, which hold running ELK
+  # stacks. The full sweep below would delete them, so reclaim only what this build left behind.
+  if is_shared_docker_host; then
     echo ">>> shared docker host: pruning only dangling images and build cache"
     docker image prune -f || true
     docker builder prune -f --keep-storage "${BUILDX_KEEP_STORAGE:-5GB}" || true

--- a/ci/run-pipeline.sh
+++ b/ci/run-pipeline.sh
@@ -273,7 +273,7 @@ if [[ $ROR_TASK == "publish_pre_builds_docker_images" ]]; then
       # Each ES version pulls its own ~1.5 GB base image, so reclaim between versions. On a shared
       # self-hosted daemon `-a` would also delete the images other repos' runners are using — see
       # cleanup_docker_and_build in ci/publish-ror-plugins.sh.
-      if [ "${ROR_SHARED_DOCKER_HOST:-0}" = "1" ]; then
+      if is_shared_docker_host; then
         docker image prune -f || true
         docker builder prune -f --keep-storage "${BUILDX_KEEP_STORAGE:-5GB}" || true
       else

--- a/ci/runner-detect.sh
+++ b/ci/runner-detect.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Facts about the machine a job runs on. Functions only; safe to source from any script.
+
+# True on a box whose Docker daemon and system directories other runners share. The runner
+# provisioning writes the marker (ci/self-hosted-runner.md); no job sets it.
+is_shared_docker_host() { [ -e /etc/ror-shared-docker-host ]; }

--- a/ci/self-hosted-runner.md
+++ b/ci/self-hosted-runner.md
@@ -114,6 +114,15 @@ gh api repos/sscarduzio/elasticsearch-readonlyrest-plugin/actions/runners \
 - The `runner` user must be in the `docker` group; the release jobs build and push images.
 - Disk is the binding constraint, roughly 1.5 GB of base image per ES version. The 40 GB root disk
   in the profile is enough for two runners only because `ci/free-host-disk.sh` prunes between legs.
-- Shared host, so the release scripts must not sweep the whole Docker daemon. `ROR_SHARED_DOCKER_HOST=1`
-  is set on these jobs and downgrades `docker system prune -af --volumes` to dangling layers and
-  build cache only. Without it, a retry would kill the Kibana runners' in-flight ELK stacks.
+- Shared host, so the CI scripts must not sweep the whole Docker daemon. They detect the box by the
+  marker file `/etc/ror-shared-docker-host` and downgrade every prune to dangling layers and build
+  cache. Write the marker when you provision the runner:
+
+  ```bash
+  incus exec --project github-ci gh-ror-es-$N -- sh -c \
+    'echo "Runners for more than one repo share this box." > /etc/ror-shared-docker-host'
+  ```
+
+  Without it, a retry of a release leg would kill the Kibana runners' in-flight ELK stacks.
+- Three runners, and `release_ror` / `upload_pre_ror` keep `max-parallel: 2`. A release then never
+  takes every slot, so the pre-build that two repos wait on always finds one.


### PR DESCRIPTION
## What

1. The e2e legs run on `ubuntu-latest` again, and `max-parallel: 99` is gone.
2. `ci/free-host-disk.sh` detects the runner instead of being told. No job declares runner facts any more.

## Why

**1.** #1368 moved every test leg to GitHub-hosted runners. #1376 merged two hours later, rewrote the e2e stage, and carried the old `runs-on: ubicloud-standard-4` back on the new test-leg job. Not a git conflict — new lines. Measured on `master` on 8 September: 21 legs, 487 minutes on Ubicloud, about $36 a month. The repo is public, so `ubuntu-latest` costs nothing.

**2.** From @coutoPL's review: a wrong `runs-on` value must not switch the disk reclaim off in silence, and a script that depends on the runner must detect the runner.

| Runner | Detected by | Reclaim |
|---|---|---|
| shared self-hosted box | `/etc/ror-shared-docker-host`, written at provisioning | dangling layers and build cache only |
| GitHub-hosted VM | `RUNNER_ENVIRONMENT=github-hosted`, set by the runner | toolchains and the whole daemon, when the disk is tight |
| anything else | — | nothing |

Inside a `container:` job the host toolchains are not on the job's filesystem, but the bind-mounted docker socket controls the host daemon, so a throwaway container with the host root mounted deletes them, behind the same guard.

`ROR_SHARED_DOCKER_HOST` and `AGENT_ISSELFHOSTED` are removed from every workflow. `ci-lib.sh` gains `is_shared_docker_host`; `run-pipeline.sh` and `publish-ror-plugins.sh` use it.

## Runners

The pool has three ES runners now: `gh-ror-es-3` was added today with the job-started hook, and all three carry the marker. `release_ror` and `upload_pre_ror` keep `max-parallel: 2`, so a release never takes every slot and the pre-build two repos wait on always finds one. Today a release held both old slots for 2½ hours and a pre-build queued 44 minutes for 6 minutes of work.

## Verified

- `grep -rE 'ROR_SHARED_DOCKER_HOST|AGENT_ISSELFHOSTED' .github ci` returns nothing.
- Decision table with `docker`/`df`/`sudo` shimmed: unknown → skip; hosted, wide disk → skip; hosted, tight, container → docker-socket path; unreadable `df` → skip.
- Shared-box path run for real on `gh-ror-es-3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
