### PR TITLE
Merge master back: put the credential check on the default branch, where cron can run it

### DIFF
--- a/.github/workflows/verify-publish-credentials.yml
+++ b/.github/workflows/verify-publish-credentials.yml
@@ -1,0 +1,47 @@
+name: Verify publish credentials
+
+# Proves that the Maven Central credentials still work. The publish job runs only for a release,
+# and it skips when the version is already published, so a credential that stops working stays
+# invisible until a release needs it. This asks the staging API on a clock instead. It publishes
+# nothing.
+
+on:
+  schedule:
+    # 06:00 UTC. Early enough that a broken credential is known before the working day.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  verify_sonatype_credentials:
+    name: Verify the Sonatype credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
+      - name: Ask the staging API whether it accepts the credentials
+        env:
+          MAVEN_REPO_USER: ${{ secrets.MAVEN_REPO_USER }}
+          MAVEN_REPO_PASSWORD: ${{ secrets.MAVEN_REPO_PASSWORD }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
+        run: |
+          source ci/verify-sonatype-credentials.sh
+          verify_credentials
+      - name: Report the failure where someone will see it
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          source ci/verify-sonatype-credentials.sh
+          report_credentials_failure

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -62,7 +62,9 @@ manual; see [The `container:` image](#the-container-image)), `mirror-es-libs.yml
 into the libs store — see [S3 stores](#s3-stores)), `disk-probe.yml` (manually reports runner and
 Docker disk usage), `pr-conventions.yml` (PR title/changelog checks), `actionstrings_gen.yml`
 (regenerates the ES action-string lists in the docs repo), `publish-pre-builds.yml` (on-demand
-ROR+ES dev images).
+ROR+ES dev images), `verify-publish-credentials.yml` (daily cron and manual — proves the Maven
+Central credentials still work, because `publish_mvn` only runs on a release and skips silently
+when the version is already published).
 
 Two orchestration rules worth knowing before editing conditions:
 

--- a/ci/verify-sonatype-credentials.sh
+++ b/ci/verify-sonatype-credentials.sh
@@ -1,0 +1,92 @@
+# shellcheck shell=bash
+# Sourced by .github/workflows/verify-publish-credentials.yml — do not execute directly.
+#
+# The two halves of the daily credential check. They belong together: the second one only says
+# where the first one failed.
+#
+#   verify_credentials         — ask the staging API whether it still accepts our identity
+#   report_credentials_failure — put a failed check where someone reads it
+
+API="https://ossrh-staging-api.central.sonatype.com/service/local"
+
+fail() {
+  echo ">>> ERROR: $1"
+  echo ">>> Fix it before the next release. The publish job cannot recover from this by retrying:"
+  echo ">>>   a 401 here is a rejected identity, not a busy server."
+  exit 1
+}
+
+# Asks the Sonatype staging API for our profiles. A 200 means it accepts the credentials.
+#
+# It also checks that MAVEN_STAGING_PROFILE_ID is a profile the account owns, because the publish
+# task sends that id straight to the call that creates the staging repository. A stale id fails
+# there, and the failure looks the same as a bad password.
+#
+# Nothing here prints a credential or the response body.
+verify_credentials() {
+  [ -n "${MAVEN_REPO_USER:-}" ] || fail "MAVEN_REPO_USER is empty."
+  [ -n "${MAVEN_REPO_PASSWORD:-}" ] || fail "MAVEN_REPO_PASSWORD is empty."
+
+  local body status
+  body="$(mktemp)"
+  # shellcheck disable=SC2064 # expand now: $body is local and gone when the trap runs
+  trap "rm -f '$body'" EXIT
+
+  status="$(curl -sS -o "$body" -w '%{http_code}' \
+    -H 'Accept: application/json' \
+    -u "$MAVEN_REPO_USER:$MAVEN_REPO_PASSWORD" \
+    "$API/staging/profiles")" || fail "Cannot reach $API/staging/profiles."
+
+  case "$status" in
+    200) echo ">>> Sonatype credentials accepted." ;;
+    401|403)
+      fail "The staging API rejected the credentials with HTTP $status.
+>>>   The API wants a Central Portal user token (central.sonatype.com -> Account -> Generate
+>>>   User Token), not the legacy OSSRH login. Set MAVEN_REPO_USER and MAVEN_REPO_PASSWORD in
+>>>   the Doppler project ror_ci (config prd). A direct edit in GitHub is overwritten by the sync."
+      ;;
+    *) fail "Unexpected HTTP $status from $API/staging/profiles." ;;
+  esac
+
+  if [ -n "${MAVEN_STAGING_PROFILE_ID:-}" ]; then
+    if grep -q "$MAVEN_STAGING_PROFILE_ID" "$body"; then
+      echo ">>> MAVEN_STAGING_PROFILE_ID belongs to this account."
+    else
+      fail "MAVEN_STAGING_PROFILE_ID is not a profile this account owns.
+>>>   build.gradle sends it to the create-staging-repository call, which then fails.
+>>>   Take the id from the staging API instead of the old OSSRH console, and set it in Doppler."
+    fi
+  else
+    echo ">>> MAVEN_STAGING_PROFILE_ID is empty; the publish plugin will look the profile up."
+  fi
+}
+
+# Makes a failed credential check visible without a new secret.
+#
+# One issue, reused. A daily job that opens a new issue every morning trains everyone to ignore it,
+# so this comments on the open one instead and opens a fresh issue only when none is open.
+report_credentials_failure() {
+  local title existing body
+  title="Publish credentials are not working"
+  # No label: the repo has no CI label, and a failure handler must not fail on a missing one.
+
+  existing="$(gh issue list --state open --search "\"$title\" in:title" --json number,title \
+    --jq "[.[] | select(.title == \"$title\")] | .[0].number // empty")"
+
+  body="The scheduled credential check failed.
+
+Run: ${RUN_URL:-unknown}
+
+\`publish_mvn\` cannot publish while this is red, and it fails quietly: when the version in
+\`gradle.properties\` is already published the job skips and reports success, so a release is the
+first thing that finds out. The job log says which credential the staging API rejected and where to
+set it."
+
+  if [ -n "$existing" ]; then
+    echo ">>> Issue #$existing is already open; adding a comment."
+    gh issue comment "$existing" --body "$body"
+  else
+    echo ">>> Opening an issue."
+    gh issue create --title "$title" --body "$body"
+  fi
+}


### PR DESCRIPTION
## The check I just merged cannot run

#1381 added `verify-publish-credentials.yml` on a daily cron. It is on `master`, and it will never fire there.

GitHub runs `schedule:` triggers **only from the repository's default branch**, and this repo's default branch is `develop`:

```
$ gh api repos/sscarduzio/elasticsearch-readonlyrest-plugin -q .default_branch
develop

$ gh api ".../contents/.github/workflows/verify-publish-credentials.yml?ref=develop"
404 Not Found

$ gh workflow run verify-publish-credentials.yml --ref master
HTTP 404: workflow verify-publish-credentials.yml not found on the default branch
```

The same rule blocks `workflow_dispatch`: the Actions UI and API only offer workflows that exist on the default branch, so the check cannot even be started by hand.

That is precisely the failure #1381 exists to remove — a check that looks present and stays silent. My mistake in choosing the base: I targeted `master` because the job started life inside `ci.yml` on master pushes, and did not revisit that when it became a scheduled workflow.

## This PR

The standard merge back. `master` is one commit ahead of `develop` — the #1381 squash — and carries nothing else that `develop` lacks.

Once this lands, the cron is live at 06:00 UTC and `workflow_dispatch` appears, so the credentials rotated on 4 September finally get exercised. That answer is still outstanding: `publish_mvn` has not made a real publish since 1.70.3, and all three real attempts died on a 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated daily verification of Maven Central publishing credentials.
  - Added the ability to run credential verification manually when needed.
  - Verification now checks access and reports failures through the project’s issue tracker.

- **Documentation**
  - Updated CI documentation to explain credential verification and publishing workflow behavior, including when publishing is skipped for already-published versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->