### PR TITLE
Notify the e2e tests repo when a release publishes the plugin images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,3 +959,22 @@ jobs:
       - name: Remove the PGP signing key
         if: always()
         run: rm -f .travis/secret.pgp
+
+  # ── NOTIFY_E2E_TESTS (after a successful release) ─────────────────────────
+  # The bootstrap sweep in the e2e tests repo boots every released ELK version against the
+  # `<elk>-ror-latest` images. release_ror is what moves those tags, so the sweep starts from this
+  # event instead of a nightly cron that asks the same question 30 times between two releases.
+  # No `if:`, on purpose: the default gate is "every release_ror leg succeeded", which is exactly
+  # when the tags moved. A skipped or failed release_ror skips this job too.
+  notify_e2e_tests:
+    needs: [ release_ror ]
+    runs-on: ubuntu-latest   # one HTTP call; no gradle, no docker, so it costs no self-hosted minute
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with: { fetch-depth: 1, persist-credentials: false }
+      - name: Free host disk
+        run: ci/free-host-disk.sh
+      - name: Notify the e2e tests repo
+        env:
+          ROR_GH_TOKEN: ${{ secrets.ROR_GH_TOKEN }}
+        run: ci/notify-e2e-tests.sh

--- a/ci/CI.md
+++ b/ci/CI.md
@@ -52,6 +52,7 @@ directory contain the build logic; the workflow only orchestrates.
 | `e2e_tests` | Cypress e2e suite, one job per ES version | pushes + PRs (not drafts) |
 | `build_ror` | builds all plugin zips + bytecode-reuse guard | PRs |
 | `determine_ci_type` → `upload_pre_ror` / `release_ror` / `publish_mvn` | release pipeline | develop/master pushes + manual `release_without_testing` |
+| `notify_e2e_tests` | tells the e2e tests repo that the released images are published | every `release_ror` leg green |
 
 Manual actions (`workflow_dispatch` → `actionToPerform`): `run_all_tests_on_linux`,
 `run_all_tests_on_windows`, `run_e2e_tests`, `release_without_testing`.
@@ -194,6 +195,22 @@ S3, not GitHub artifacts: those count against the metered Actions-storage quota.
 Needs `ROR_ENT_ACTIVATION_TOKEN` (the suite refuses to start without it) and `ROR_GH_TOKEN` (to
 dispatch the ROR KBN build and read its status).
 
+### Telling the e2e repo about a release
+
+The e2e repo also runs a bootstrap sweep: it boots every released ELK version against the released
+`<elk>-ror-latest` images and checks that the stack starts. Those tags are its only input, and only
+a release moves them, so the sweep waits for an event instead of a cron.
+
+`notify_e2e_tests` sends that event: `POST /repos/beshu-tech/readonlyrest-e2e-tests/dispatches` with
+`event_type: ror-plugins-released`, from `ci/notify-e2e-tests.sh`. The payload carries the plugin
+version and the run that sent it, for the reader of the sweep's log. The receiver reads nothing from
+it, so a new key breaks nothing.
+
+`ROR_GH_TOKEN` needs write access to the e2e repo for this call. GitHub answers 404, not 403, to a
+token without it. The script treats every failure as a warning and exits 0: the release is published
+by then, and a red run would say it is not. The log line names the manual command that starts the
+sweep.
+
 ## S3 stores
 
 ROR uploads to S3-compatible stores through one path: `ci/s3-uploader.sh` (curl + SigV4) under
@@ -233,7 +250,7 @@ build cannot compile against jars that are not in the store yet.
 | `DOCKER_HUB_USER` / `DOCKER_HUB_RW_TOKEN` | the push account. It pushes the ROR and toolchains images, and authenticates the pulls of the same job. A job maps it into `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD`, which is the one pair `configure-docker.sh` reads |
 | `DOCKER_HUB_USER` / `DOCKER_HUB_RO_TOKEN` | the read-only token; it cannot push — it is refused push scope. `unit_tests_linux` and `it_linux` map it into `DOCKER_REGISTRY_USER` / `DOCKER_REGISTRY_PASSWORD`, which authenticates the pulls their steps make. No `container:` pull uses it, because the runner makes that pull before step 1. Without it, a pull request from a fork continues with anonymous pulls, and every other event stops |
 | `ROR_ENT_ACTIVATION_TOKEN` | ROR PRO/Enterprise key the e2e stack boots with. **The secret is renamed; the env var handed to the container stays `ROR_ACTIVATION_KEY`, which is the customer-facing name** |
-| `ROR_GH_TOKEN` | cross-repo GitHub PAT: dispatches the ROR KBN image build, reads run status, pushes docs |
+| `ROR_GH_TOKEN` | cross-repo GitHub PAT: dispatches the ROR KBN image build, reads run status, sends the release event to the e2e tests repo, pushes docs |
 | `NVD_API_KEY`, `OSS_INDEX_USERNAME`, `OSS_INDEX_PASSWORD` | `cve_check` feeds |
 | `MAVEN_REPO_USER`, `MAVEN_REPO_PASSWORD`, `MAVEN_STAGING_PROFILE_ID`, `GPG_KEY_ID`, `GPG_PASSPHRASE` | Maven Central publishing |
 | `PGP_SECRET_KEY_B64` | base64 of `secret.pgp`; the publish step decodes it to `.travis/secret.pgp`. Create with `base64 -w0 secret.pgp \| gh secret set PGP_SECRET_KEY_B64` |

--- a/ci/notify-e2e-tests.sh
+++ b/ci/notify-e2e-tests.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Tells the e2e tests repo that a release published new ROR ES plugin images.
+#
+# The bootstrap sweep there boots every released ELK version against the `<elk>-ror-latest` tags.
+# Those tags move only when a release pushes them, about twice a month, so the sweep waits for this
+# event instead of a nightly cron.
+#
+# The event name and the repo below are the whole contract. The receiver reads the payload only to
+# show where the event came from, so a new key here breaks nothing there.
+#
+# No `set -e`, and no command here may end the script on a failure: see notify_skipped() below.
+set -uo pipefail
+
+# shellcheck source=ci/ci-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/ci-lib.sh"
+
+E2E_TESTS_REPO="beshu-tech/readonlyrest-e2e-tests"
+EVENT_TYPE="ror-plugins-released"
+
+# The release is already published when this runs: the zips are on S3, the images are on Docker Hub
+# and the git tags are pushed. A failed notification takes none of that back, so it must never turn
+# the run red — it would say the release failed, and someone would try to repeat it. Every path out
+# of this script therefore ends here or at the success message, and both exit 0.
+notify_skipped() {
+  echo "WARN: the e2e tests repo was not notified: $1"
+  echo "      The release itself is unaffected. Start the sweep by hand with:"
+  echo "      gh workflow run all-e2e-tests.yml -R $E2E_TESTS_REPO"
+  exit 0
+}
+
+[ -n "${ROR_GH_TOKEN:-}" ] || notify_skipped "ROR_GH_TOKEN is empty"
+
+ROR_VERSION=$(gradle_property pluginVersion) || notify_skipped "gradle.properties has no pluginVersion"
+
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}"
+
+PAYLOAD=$(jq -n \
+  --arg event_type "$EVENT_TYPE" \
+  --arg plugin "elasticsearch" \
+  --arg version "$ROR_VERSION" \
+  --arg repository "${GITHUB_REPOSITORY:-}" \
+  --arg ref "${GITHUB_REF:-}" \
+  --arg sha "${GITHUB_SHA:-}" \
+  --arg run_url "$RUN_URL" \
+  '{event_type: $event_type, client_payload: {plugin: $plugin, version: $version, repository: $repository, ref: $ref, sha: $sha, run_url: $run_url}}'
+) || notify_skipped "could not build the request body"
+
+echo ">>> Notifying $E2E_TESTS_REPO: $EVENT_TYPE (ROR $ROR_VERSION)"
+
+BODY_FILE=$(mktemp) || notify_skipped "could not create a temp file for the response"
+trap 'rm -f "$BODY_FILE"' EXIT
+
+# --retry covers a connection that never answers. GitHub answers 204 and nothing else on success.
+HTTP_CODE=$(curl --silent --show-error \
+  --retry 3 --retry-delay 5 --max-time 60 \
+  --output "$BODY_FILE" --write-out '%{http_code}' \
+  --request POST \
+  --header "Accept: application/vnd.github+json" \
+  --header "Authorization: Bearer $ROR_GH_TOKEN" \
+  --header "X-GitHub-Api-Version: 2022-11-28" \
+  --data "$PAYLOAD" \
+  "https://api.github.com/repos/$E2E_TESTS_REPO/dispatches")
+
+if [ "$HTTP_CODE" != "204" ]; then
+  # 404 is what GitHub answers for a repo the token cannot write, so name that case: the API hides
+  # a permission problem behind "not found".
+  notify_skipped "POST /repos/$E2E_TESTS_REPO/dispatches answered $HTTP_CODE ($(tr -s '[:space:]' ' ' < "$BODY_FILE" | head -c 300)).
+      A 404 means ROR_GH_TOKEN cannot write to that repo, not that the repo is absent."
+fi
+
+echo ">>> Notified $E2E_TESTS_REPO"


### PR DESCRIPTION
The bootstrap sweep in `beshu-tech/readonlyrest-e2e-tests` boots 34 released ELK versions against
the released `<elk>-ror-latest` plugin images. PR #129 there moved the sweep off its nightly cron
and onto a `repository_dispatch` of type `ror-plugins-released`. Nothing sends that event. This PR
sends the ES half of it.

## What it does

A new job, `notify_e2e_tests`, runs `ci/notify-e2e-tests.sh`, which sends
`POST /repos/beshu-tech/readonlyrest-e2e-tests/dispatches` with
`{"event_type":"ror-plugins-released","client_payload":{...}}`. The payload carries the plugin
version, the repo, the ref, the sha and the URL of the run that sent it. The receiving workflow
reads no key of it, so it is there for the person who reads the sweep's log.

## Why this job

`release_ror` is the only job that pushes `<elk>-ror-latest`: the tag comes from
`pushRorDockerImage`, which `release_ror_docker_image()` calls, and that call happens only in
`publish_one_version` with `mode = release`. A pre-build or a PR build never reaches it.

`notify_e2e_tests` declares `needs: [release_ror]` and no `if:`. The default gate is then "every
`release_ror` leg succeeded", which is exactly when the tags moved. A run that is not a release
skips `release_ror`, so this job is skipped too. "Re-run failed jobs" after a fixed leg re-runs this
job as well.

It runs on `ubuntu-latest`: one HTTP call needs no gradle, no docker and no self-hosted minute.

## The notification cannot fail the release

When this job starts, the zips are on S3, the images are on Docker Hub and the git tags are pushed.
A red run would say the release failed, and someone would repeat it. So the script has no `set -e`,
and every failure path prints a warning, names the manual command that starts the sweep, and exits
0. The warning also says that a 404 means the token cannot write to the e2e repo, because the
GitHub API hides that case behind "not found".

## The secret

`ROR_GH_TOKEN`, the cross-repo PAT this repo already uses to dispatch the ROR KBN pre-build and to
clone the e2e repo. No new secret.

**One thing for you to confirm:** the token needs write access to
`beshu-tech/readonlyrest-e2e-tests` for the dispatch endpoint. I can see it reads that repo (the
e2e clone in `ci/e2e-tests-lib.sh`) and writes to the ROR KBN repo, but I cannot read the token, so
I cannot prove it writes to the e2e repo. If it does not, the first release after this merge prints
the warning above and stays green, and the token needs the scope.

## Out of scope

The ROR KBN release pipeline must send the same event for the Kibana `-ror-latest` images. That is a
PR in `readonlyrest_kbn`.

## Branch

`docs/dev/branching.md` sends a pipeline change to `master`. This repo has no `master` ref today
(`git ls-remote --heads` lists `develop` and the feature branches only), so this targets `develop`,
the default branch. Merge it back to `master` in the usual way if that branch comes back.

## Verified

- `.github/workflows/ci.yml` parses with a duplicate-key-rejecting YAML loader; 18 jobs, the new one
  among them.
- `actionlint` reports the same 11 pre-existing alias findings as on `develop`, and none in the new
  job.
- `bash -n ci/notify-e2e-tests.sh`, plus a run with no token and a run with a bad token: both print
  the warning and exit 0. The bad-token run proves the request shape reaches the API (401 Bad
  credentials, not 422).
- Not verified: a real dispatch. Sending one would start 34 legs in the e2e repo, so the first real
  release is the first real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic notifications to the end-to-end test repository after successful plugin releases.
  * Release notifications include version and workflow metadata to support downstream test runs.
  * Notification failures provide warnings and manual follow-up instructions without failing the release.

* **Documentation**
  * Documented the release notification workflow, payload, permissions, and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->